### PR TITLE
fix(catalog): check fmt.Sscanf error in walk array index parse

### DIFF
--- a/gearbox/internal/gears/home/catalog.go
+++ b/gearbox/internal/gears/home/catalog.go
@@ -274,7 +274,9 @@ func walk(doc any, path string) (any, bool) {
 					return nil, false
 				}
 			}
-			fmt.Sscanf(p, "%d", &idx)
+			if _, err := fmt.Sscanf(p, "%d", &idx); err != nil {
+				return nil, false
+			}
 			if idx < 0 || idx >= len(node) {
 				return nil, false
 			}


### PR DESCRIPTION
## Summary

- `golangci-lint` (errcheck) flags `fmt.Sscanf` return value as unchecked at `gearbox/internal/gears/home/catalog.go:277`. Currently failing on every PR that touches `gearbox/` (including #29).
- Fix: explicitly check the error and return `(nil, false)` on parse failure. Preserves existing behavior for the all-digit case validated by the loop above; makes overflow handling explicit.

## Test plan

- [ ] CI Lint job passes
- [ ] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)