### PR TITLE
fix(security): close P0 findings from 2026-05 audit

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,7 +147,7 @@ Gearbox includes the following security features:
 
 ### Authentication & Authorization
 
-- **Bcrypt Password Hashing**: Industry-standard password hashing (cost 10)
+- **Bcrypt Password Hashing**: Industry-standard password hashing (cost 12; OWASP 2026 baseline)
 - **Session Management**: Secure, HTTP-only session cookies
 - **Password Requirements**: Minimum 50 bits entropy, blocks common passwords
 - **Multi-factor Support**: WebAuthn/Passkey support for strong authentication
@@ -171,7 +171,13 @@ Gearbox includes the following security features:
 ### Data Protection
 
 - **Secret Redaction**: Automatic redaction in debug logs
-- **Credential Encryption**: API keys encrypted at rest (AES-256-GCM)
+- **Filesystem-Protected Secrets**: API keys, webhook secrets, and admin
+  credentials are stored as files owned by the agent user with mode `0600`
+  (owner read/write only). Encryption-at-rest is **not** currently
+  implemented; if the filesystem is compromised by an attacker with the
+  agent's UID or root, secrets are exposed. Deployments that need
+  encryption-at-rest should run the agent on a filesystem with FDE
+  (LUKS, FileVault, etc.) or use an external KMS-backed secret store.
 - **Secure Password Storage**: Admin credentials written to file with 0600 permissions
 - **Session Secrets**: 256-bit minimum session secret requirement
 
@@ -195,9 +201,10 @@ Subscribe to the repository to receive notifications of security updates.
 
 ## Security Audit History
 
-| Date       | Auditor        | Scope          | Findings | Status    |
-|------------|----------------|----------------|----------|-----------|
-| 2026-01-31 | Internal Scan  | Full codebase  | 10 total | ✅ Resolved |
+| Date       | Auditor               | Scope                                       | Findings                        | Status         |
+|------------|-----------------------|---------------------------------------------|---------------------------------|----------------|
+| 2026-01-31 | Internal Scan         | Full codebase                               | 10 total                        | ✅ Resolved     |
+| 2026-05-10 | Internal Deep Audit   | Auth, agent API, HAProxy pipeline, SQL/XSS, agent subprocess | 4 P0, 8 P1, 10 P2, 8 P3 | 🔄 In progress |
 
 ## Contact
 

--- a/gearbox-agent/internal/framework/services/compose/parser.go
+++ b/gearbox-agent/internal/framework/services/compose/parser.go
@@ -4,6 +4,7 @@ package compose
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -37,7 +38,44 @@ var (
 	validBalance = regexp.MustCompile(`^(roundrobin|leastconn|source|uri|hdr|first|random)$`)
 	// validSSLVerify matches valid SSL verify options.
 	validSSLVerify = regexp.MustCompile(`^(none|required)$`)
+	// validBackendName matches HAProxy backend names. HAProxy itself accepts a
+	// broader character set, but we restrict to DNS-label-style to prevent
+	// newline / directive injection from a Docker Compose label into the
+	// generated haproxy.cfg (see 2026-05 security audit, P0-1).
+	validBackendName = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.\-]{0,62}$`)
 )
+
+// validateACLIPList validates a comma-separated list of IPs/CIDRs against
+// net.ParseCIDR / net.ParseIP. Returns the original string if all entries parse,
+// or an empty string + false on the first invalid entry. Prevents newline or
+// HAProxy directive injection via the haproxy.acl.ip label (2026-05 audit P0-2).
+//
+// The user-supplied form for this label is a comma-separated mix of single IPs
+// (10.0.0.1) and CIDRs (10.0.0.0/24). Anything that doesn't parse as one of
+// those is rejected — including embedded newlines, whitespace beyond simple
+// trimming, or HAProxy keywords.
+func validateACLIPList(raw string) (string, bool) {
+	if raw == "" {
+		return "", true
+	}
+	for _, part := range strings.Split(raw, ",") {
+		entry := strings.TrimSpace(part)
+		if entry == "" {
+			continue
+		}
+		if strings.ContainsAny(entry, " \t\n\r") {
+			return "", false
+		}
+		if _, _, err := net.ParseCIDR(entry); err == nil {
+			continue
+		}
+		if ip := net.ParseIP(entry); ip != nil {
+			continue
+		}
+		return "", false
+	}
+	return raw, true
+}
 
 // Parser parses Docker Compose files for HAProxy backend configuration.
 type Parser struct {
@@ -246,6 +284,34 @@ func (p *Parser) extractBackendConfig(labels map[string]string, appName, service
 		backendName = fmt.Sprintf("%s_%s_backend", sanitizeName(appName), sanitizeName(serviceName))
 	}
 
+	// Reject any user-supplied backend name that would let an attacker inject
+	// HAProxy directives (newlines, spaces, etc.) into the generated config.
+	// The default form built from sanitizeName always passes this regex; the
+	// check exists to gate values that come from the haproxy.backend.name
+	// label. See 2026-05 security audit, P0-1.
+	if !validBackendName.MatchString(backendName) {
+		p.logger.Warn("Invalid backend name; rejecting backend",
+			"app", appName,
+			"service", serviceName,
+			"backend_name", backendName,
+		)
+		return nil
+	}
+
+	// haproxy.acl.ip flows into the `acl ip_allowed_* src <list>` directive in
+	// the generated config. An unvalidated value can inject additional ACL
+	// rules via embedded newlines (2026-05 audit P0-2). Validate every comma-
+	// separated entry as an IP or CIDR before accepting; reject the whole
+	// backend on a malformed entry rather than silently dropping the ACL.
+	aclIP, aclIPOK := validateACLIPList(labels[LabelPrefix+"acl.ip"])
+	if !aclIPOK {
+		p.logger.Warn("Invalid haproxy.acl.ip value; rejecting backend",
+			"app", appName,
+			"service", serviceName,
+		)
+		return nil
+	}
+
 	// Get and validate configurable values with safe defaults
 	mode := getValidatedOrDefault(labels, LabelPrefix+"backend.mode", "http", validMode)
 	balance := getValidatedOrDefault(labels, LabelPrefix+"backend.balance", "roundrobin", validBalance)
@@ -272,7 +338,7 @@ func (p *Parser) extractBackendConfig(labels map[string]string, appName, service
 		ACLHeader:        labels[LabelPrefix+"acl.header"],
 		Public:           labels[LabelPrefix+"public"] == "true",
 		RateLimit:        rateLimit,
-		ACLIP:            labels[LabelPrefix+"acl.ip"],
+		ACLIP:            aclIP,
 		BackendSSL:       labels[LabelPrefix+"backend.ssl"] == "true",
 		BackendSSLVerify: sslVerify,
 	}

--- a/gearbox-agent/internal/framework/services/compose/parser_test.go
+++ b/gearbox-agent/internal/framework/services/compose/parser_test.go
@@ -628,4 +628,132 @@ func TestValidationPatterns(t *testing.T) {
 	if validBalance.MatchString("invalid") {
 		t.Error("validBalance should not match invalid")
 	}
+
+	// Test validBackendName (2026-05 audit P0-1).
+	validBackendNames := []string{
+		"myapp_backend", "web-app", "a", "backend.1", "x9-y8.z7",
+	}
+	invalidBackendNames := []string{
+		"",
+		"-leading-hyphen",
+		".leading-dot",
+		"name with space",
+		"name\nwith-newline",
+		"name\twith-tab",
+		"name;with-semicolon",
+		"backend\n  lua-load /tmp/x.lua", // The actual P0-1 exploit payload
+	}
+	for _, n := range validBackendNames {
+		if !validBackendName.MatchString(n) {
+			t.Errorf("validBackendName should match %q", n)
+		}
+	}
+	for _, n := range invalidBackendNames {
+		if validBackendName.MatchString(n) {
+			t.Errorf("validBackendName should NOT match %q (would allow HAProxy directive injection)", n)
+		}
+	}
+}
+
+func TestValidateACLIPList(t *testing.T) {
+	// 2026-05 audit P0-2: haproxy.acl.ip must reject anything that isn't a
+	// strict comma-separated IP/CIDR list, to prevent injection of additional
+	// HAProxy directives into the generated config.
+	tests := []struct {
+		name  string
+		input string
+		ok    bool
+	}{
+		{"empty", "", true},
+		{"single-ip", "10.0.0.1", true},
+		{"single-cidr", "10.0.0.0/8", true},
+		{"mixed-list", "10.0.0.0/8, 192.168.1.0/24, 172.16.0.5", true},
+		{"newline-injection", "10.0.0.0/8\n  acl admin src 0.0.0.0/0", false}, // The actual P0-2 exploit
+		{"haproxy-keyword", "10.0.0.0/8, acl_open 0.0.0.0/0", false},
+		{"garbage", "not-an-ip", false},
+		{"out-of-range-octet", "999.999.999.999", false},
+		{"semicolon", "10.0.0.0/8; foo", false},
+		{"tab-injection", "10.0.0.0/8\t10.1.0.0/16", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := validateACLIPList(tt.input)
+			if ok != tt.ok {
+				t.Errorf("validateACLIPList(%q) ok=%v, want %v", tt.input, ok, tt.ok)
+			}
+		})
+	}
+}
+
+func TestParseFile_InjectionViaBackendName(t *testing.T) {
+	// 2026-05 audit P0-1: a malicious haproxy.backend.name with embedded
+	// newlines must be rejected at parse time so it never reaches the
+	// generator's fmt.Sprintf("backend %s", …) call.
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "evil")
+	if err := os.MkdirAll(appDir, 0755); err != nil {
+		t.Fatalf("Failed to create app dir: %v", err)
+	}
+
+	// Note: YAML's literal-block style "|" preserves newlines, which is the
+	// exact shape of the exploit payload as it would appear in a docker-
+	// compose.yml authored by an attacker with push access to the repo.
+	composeContent := "services:\n" +
+		"  web:\n" +
+		"    image: nginx\n" +
+		"    labels:\n" +
+		"      haproxy.enable: \"true\"\n" +
+		"      haproxy.hostname: \"evil.example.com\"\n" +
+		"      haproxy.backend.server: \"10.0.0.1:80\"\n" +
+		"      haproxy.backend.name: |\n" +
+		"        myapp\n" +
+		"          lua-load /tmp/evil.lua\n"
+
+	composePath := filepath.Join(appDir, "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte(composeContent), 0644); err != nil {
+		t.Fatalf("Failed to write compose file: %v", err)
+	}
+
+	parser := NewParser(tmpDir, testLogger())
+	backends, err := parser.ParseFile(composePath)
+	if err != nil {
+		t.Fatalf("ParseFile() error = %v", err)
+	}
+	if len(backends) != 0 {
+		t.Errorf("ParseFile() returned %d backend(s) for an injection payload; want 0 (rejected)", len(backends))
+	}
+}
+
+func TestParseFile_InjectionViaACLIP(t *testing.T) {
+	// 2026-05 audit P0-2.
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "aclip")
+	if err := os.MkdirAll(appDir, 0755); err != nil {
+		t.Fatalf("Failed to create app dir: %v", err)
+	}
+
+	composeContent := "services:\n" +
+		"  web:\n" +
+		"    image: nginx\n" +
+		"    labels:\n" +
+		"      haproxy.enable: \"true\"\n" +
+		"      haproxy.hostname: \"evil.example.com\"\n" +
+		"      haproxy.backend.server: \"10.0.0.1:80\"\n" +
+		"      haproxy.acl.ip: |\n" +
+		"        10.0.0.0/8\n" +
+		"          acl admin src 0.0.0.0/0\n"
+
+	composePath := filepath.Join(appDir, "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte(composeContent), 0644); err != nil {
+		t.Fatalf("Failed to write compose file: %v", err)
+	}
+
+	parser := NewParser(tmpDir, testLogger())
+	backends, err := parser.ParseFile(composePath)
+	if err != nil {
+		t.Fatalf("ParseFile() error = %v", err)
+	}
+	if len(backends) != 0 {
+		t.Errorf("ParseFile() returned %d backend(s) for an injection payload; want 0 (rejected)", len(backends))
+	}
 }

--- a/gearbox/internal/framework/handler/login.go
+++ b/gearbox/internal/framework/handler/login.go
@@ -10,6 +10,37 @@ import (
 	"github.com/sarg3nt/gearbox/internal/framework/templates/pages"
 )
 
+// isSafeReturnURL reports whether a `?return=` (or `?next=`) query value is
+// safe to redirect the browser to after login/logout. Only same-origin
+// relative paths are allowed — anything that could escape to an external host
+// is rejected so the login page can't be used as a phishing redirector.
+//
+// The accepted shape is exactly: starts with `/`, does NOT start with `//`
+// (protocol-relative), does NOT start with `/\` (some browsers normalize this
+// to `//` and follow it as protocol-relative), and does not contain a
+// scheme-like prefix elsewhere. Backslashes anywhere in the value are
+// rejected because some browsers normalize them to forward slashes during
+// URL parsing, opening sneak paths like `/\/evil.example.com`.
+//
+// 2026-05 audit P0-4.
+func isSafeReturnURL(s string) bool {
+	if s == "" {
+		return false
+	}
+	if len(s) < 1 || s[0] != '/' {
+		return false
+	}
+	if len(s) >= 2 && (s[1] == '/' || s[1] == '\\') {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
 // resolvePostLoginPath returns the path the user should land on after login
 // or after visiting "/" without a destination. Cascade:
 //
@@ -124,9 +155,13 @@ func (h *Handler) LoginPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Redirect to return URL if provided, otherwise honor the per-user
-	// default-landing-path with system fallback.
+	// default-landing-path with system fallback. The return URL must be a
+	// same-origin relative path — anything else (an absolute URL, a
+	// protocol-relative URL, a `javascript:` URI) is rejected to prevent
+	// the login page from being used as a phishing redirector
+	// (2026-05 audit P0-4).
 	redirectTarget := h.resolvePostLoginPath(user.ID)
-	if returnURL != "" && returnURL != "/login" && returnURL != "/logout" {
+	if isSafeReturnURL(returnURL) && returnURL != "/login" && returnURL != "/logout" {
 		redirectTarget = returnURL
 	}
 	http.Redirect(w, r, redirectTarget, http.StatusSeeOther)
@@ -178,9 +213,12 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Build redirect URL with logout message
+	// Build redirect URL with logout message. The return URL must pass the
+	// same safety check as the post-login redirect (2026-05 audit P0-4) so
+	// the logout page can't be used to inject an attacker-controlled
+	// `?return=...` into the login page's URL.
 	redirectURL := "/login?message=" + url.QueryEscape("You have been logged out.")
-	if returnURL != "" && returnURL != "/" && returnURL != "/login" && returnURL != "/logout" {
+	if isSafeReturnURL(returnURL) && returnURL != "/" && returnURL != "/login" && returnURL != "/logout" {
 		redirectURL += "&return=" + url.QueryEscape(returnURL)
 	}
 

--- a/gearbox/internal/framework/handler/login_test.go
+++ b/gearbox/internal/framework/handler/login_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import "testing"
+
+// 2026-05 audit P0-4. The login and logout handlers both consult
+// isSafeReturnURL to decide whether a ?return=... query value can be
+// used as a redirect target. These tests pin down the matrix so future
+// edits don't accidentally widen what the helper accepts.
+func TestIsSafeReturnURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// Safe: same-origin relative paths.
+		{"plain-root", "/", true},
+		{"plain-path", "/dashboard", true},
+		{"nested-path", "/settings/profile", true},
+		{"with-query", "/search?q=hello", true},
+		{"with-fragment", "/page#section", true},
+
+		// Unsafe: anything that could escape origin.
+		{"empty", "", false},
+		{"absolute-https", "https://evil.example.com/x", false},
+		{"absolute-http", "http://evil.example.com/x", false},
+		{"protocol-relative", "//evil.example.com/x", false},
+		{"backslash-relative", "/\\evil.example.com", false},
+		{"backslash-prefix", "\\evil.example.com", false},
+		{"javascript-uri", "javascript:alert(1)", false},
+		{"data-uri", "data:text/html,evil", false},
+		{"no-leading-slash", "dashboard", false},
+		{"backslash-anywhere", "/legit\\path", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSafeReturnURL(tt.input); got != tt.want {
+				t.Errorf("isSafeReturnURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes four P0 findings from the deep audit I ran on 2026-05-10. Detailed retrospective (with the full P0/P1/P2/P3 list and the "what looks GOOD" tally) lands as a follow-up PR after this one merges, per the responsible-disclosure pattern documented in `SECURITY.md`.

## What's in this PR

Three commits, one per finding (P0-1 and P0-2 are bundled because they're the same vulnerability class in the same file):

### `09b5737` — fix(security): validate `haproxy.backend.name` + `haproxy.acl.ip` labels  
*(P0-1, P0-2)*

Both labels flowed unvalidated from Docker Compose YAML into HAProxy config via `fmt.Sprintf` in the generator. An author with push access to a scraped repo could embed newlines plus arbitrary HAProxy directives in either label and have them executed by HAProxy at the next reload — which runs with the agent's privileges (root in the documented deployment).

- `haproxy.backend.name` → `"backend %s"`, `"  server %s_srv"`, `"  use_backend %s if is_%s"`. Newline injection lands inside the backend block, so `lua-load` (arbitrary Lua exec at startup if Lua is compiled in) and `errorfile <path>` (arbitrary host-file read at startup) become attacker-controlled.
- `haproxy.acl.ip` → `"  acl ip_allowed_* src %s"`. Same shape; an injected `acl admin src 0.0.0.0/0` silently widens any IP allowlist.

**Fix:**

- `validBackendName` regex (DNS-label style) enforced at parser time. Default-generated names from `sanitizeName` always pass; user-supplied names from the label must match or the backend is rejected entirely.
- `validateACLIPList` helper splits on comma and requires every entry to parse as `net.ParseCIDR` or `net.ParseIP`. Embedded whitespace (newlines, tabs) rejected up front.

Both failure modes reject the whole backend instead of silently dropping the offending field — "no ACL = open access" is a worse failure mode than not routing the service.

**Tests:** 13 new cases in `parser_test.go`, including the actual exploit payloads round-tripped through `ParseFile` with the assertion that zero backends are returned.

### `63d6bca` — docs(security): correct bcrypt cost + remove false encryption-at-rest claim  
*(P0-3)*

`SECURITY.md` had two material inaccuracies:

1. Claimed bcrypt cost 10. The code has been using **cost 12** (OWASP 2026 baseline) since `password.go` was written; the doc just lagged.
2. Claimed `"Credential Encryption: API keys encrypted at rest (AES-256-GCM)"`. That implementation does not exist — `grep -ri "aes\|GCM\|cipher" gearbox-agent/` returns zero hits. Secrets are protected by filesystem permissions (mode 0600) only.

Replaced #2 with an honest description and pointed deployments that need encryption-at-rest at FDE / KMS-backed solutions. Implementing real envelope encryption is tracked as a separate (non-P0) work item; co-locating the decryption key with the ciphertext on the same filesystem buys nothing real.

Also appended this audit to the Security Audit History table.

### `9cab5c7` — fix(security): tighten `?return=...` allowlist on login + logout  
*(P0-4)*

`LoginPost` honored any `?return=` value as long as it wasn't literally `/login` or `/logout`, so phishing `https://gearbox.example.com/login?return=https://attacker.example.com/harvest.html` would land the victim on the attacker's page immediately after a legitimate login. `Logout` had the same shape and could relay the value back to the login page.

New `isSafeReturnURL` helper enforces a same-origin allowlist:

- Must start with `/`
- Must NOT start with `//` (protocol-relative)
- Must NOT start with `/\` (backslash normalization sneak path)
- No backslashes anywhere (some browsers normalize them during parsing)
- No `javascript:` / `data:` / absolute-URL prefixes (excluded by "must start with `/`")

Applied to both `LoginPost` and `Logout`. **Tests:** 15 new cases pinning the matrix including the textbook bypasses.

## Verification

- `go build ./...` clean in both `gearbox/` and `gearbox-agent/`
- New tests added per finding pass; existing test suite still passes
- All third-party imports unchanged (just `net` added to the parser)

## Not in this PR (deliberately)

- **The full audit findings doc** (4 P0 / 8 P1 / 10 P2 / 8 P3 + "what looks good") stays uncommitted until this PR merges. It contains exploit payloads for these P0s plus reproduction context for several P1s; landing it before the fixes would be a public 0-day disclosure.
- **The 8 P1 findings** (systemctl/certbot/fail2ban flag injection, CSP env splicing, WS origin normalization, etc.) — separate follow-up PR; non-trivially exploitable, fix-soon but not fix-now.
- **The "implement real encryption-at-rest" work** referenced in the P0-3 doc fix — tracked as a backlog item, not in scope here.

## Test plan

- [ ] CI green (gosec, Trivy, npm audit, CodeQL, Dependency Review, Scorecard, gitleaks, new claude-code-security-review from #38)
- [ ] Review the three commits independently — they're scoped to be reviewable in isolation
- [ ] Merge, then I'll open the retrospective PR with `docs/security-review/2026-05-findings.md` and start on P1 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)