### PR TITLE
fix(security): P1-5 + P1-6 + P1-7 — agent network/auth hardening

### DIFF
--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -384,11 +384,13 @@ func main() {
 	}
 
 	// Register plugin routes with the server
-	// Apply rate limiting and API key auth middleware
+	// Apply rate limiting and API key auth middleware (with per-IP auth-failure
+	// backoff layered on top — see 2026-05 audit P1-7).
 	rateLimiter := middleware.DefaultRateLimiter(logger)
+	authBackoff := middleware.DefaultBackoffTracker(logger)
 	pluginRouter := server.Router().Group(func(r chi.Router) {
 		r.Use(middleware.RateLimitMiddleware(rateLimiter))
-		r.Use(middleware.APIKeyAuth(server.APIKey(), logger))
+		r.Use(middleware.APIKeyAuth(server.APIKey(), logger, authBackoff))
 	})
 	gearManager.RegisterRoutes(pluginRouter)
 

--- a/gearbox-agent/internal/api/server.go
+++ b/gearbox-agent/internal/api/server.go
@@ -77,6 +77,11 @@ func NewServer(cfg ServerConfig) *Server {
 	// Create rate limiter (50 req/sec with burst of 100)
 	rateLimiter := frameworkmiddleware.DefaultRateLimiter(cfg.Logger)
 
+	// Per-IP auth-failure backoff layered on top of rate limiting — defends
+	// against distributed API-key brute force where each IP individually
+	// stays below the 50 req/sec rate-limit threshold. See 2026-05 audit P1-7.
+	authBackoff := frameworkmiddleware.DefaultBackoffTracker(cfg.Logger)
+
 	// Health endpoint (no auth required, no rate limit)
 	r.Get("/health", handlers.Health)
 
@@ -111,7 +116,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// Protected API routes (require API key auth)
 	r.Group(func(r chi.Router) {
 		r.Use(frameworkmiddleware.RateLimitMiddleware(rateLimiter))
-		r.Use(frameworkmiddleware.APIKeyAuth(cfg.APIKey, cfg.Logger))
+		r.Use(frameworkmiddleware.APIKeyAuth(cfg.APIKey, cfg.Logger, authBackoff))
 
 		// Core endpoints (not handled by plugins)
 		r.Get("/api/v1/metadata", handlers.Metadata)

--- a/gearbox-agent/internal/api/websocket.go
+++ b/gearbox-agent/internal/api/websocket.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,57 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/sarg3nt/gearbox-agent/internal/framework/events"
 )
+
+// canonicalOrigin parses an Origin-header value (or an entry from
+// AGENT_ALLOWED_ORIGINS) and returns a comparable canonical form:
+// "<scheme>://<lowercased-host>[:<port>]". Default ports (80 for http,
+// 443 for https) are stripped so the caller can write "https://example.com"
+// in the allowlist regardless of whether browsers send the explicit :443.
+// Returns false if the input doesn't parse as a scheme://host URL.
+//
+// Without this, the previous byte-equal comparison treated
+// "https://Example.Com" and "https://example.com" as different origins,
+// or "https://example.com:443" and "https://example.com" as different.
+// See 2026-05 security audit, P1-5.
+func canonicalOrigin(s string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(s))
+	if err != nil || u == nil {
+		return "", false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme == "" || u.Host == "" {
+		return "", false
+	}
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	// Strip default ports so the allowlist needn't second-guess what a
+	// browser will or won't send.
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port == "" {
+		return scheme + "://" + host, true
+	}
+	return scheme + "://" + host + ":" + port, true
+}
+
+// canonicalHost normalizes an http.Request.Host value (host[:port] with no
+// scheme) for comparison against canonicalOrigin output. The scheme is
+// derived from r.TLS at the call site, since the Host header itself carries
+// no scheme. Same default-port stripping rules as canonicalOrigin.
+func canonicalHost(scheme, hostPort string) string {
+	scheme = strings.ToLower(scheme)
+	host := strings.ToLower(hostPort)
+	if i := strings.Index(host, ":"); i >= 0 {
+		port := host[i+1:]
+		host = host[:i]
+		if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+			return scheme + "://" + host
+		}
+		return scheme + "://" + host + ":" + port
+	}
+	return scheme + "://" + host
+}
 
 const (
 	// Time allowed to write a message to the peer.
@@ -26,45 +78,67 @@ const (
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	// SECURITY FIX: Validate WebSocket origin to prevent Cross-Site WebSocket Hijacking (CSWSH)
-	// Environment variable AGENT_ALLOWED_ORIGINS can specify allowed origins (comma-separated)
-	// If not set, defaults to same-origin only
-	CheckOrigin: func(r *http.Request) bool {
-		origin := r.Header.Get("Origin")
+	// Validate WebSocket origin to prevent Cross-Site WebSocket Hijacking.
+	// AGENT_ALLOWED_ORIGINS is a comma-separated list of allowed origins.
+	// If unset, the default is same-origin only.
+	//
+	// Origins and hosts are compared in canonical form (lowercased host,
+	// default ports stripped) so an allowlist entry of "https://example.com"
+	// matches an Origin header of "https://Example.Com:443". See P1-5 in
+	// the 2026-05 security audit.
+	CheckOrigin: checkOrigin,
+}
 
-		// If no Origin header, allow (same-origin requests from curl/Go clients)
-		if origin == "" {
-			return true
-		}
+// checkOrigin is the gorilla/websocket Upgrader.CheckOrigin function for the
+// agent. Factored out so it can be unit tested without standing up a real
+// WebSocket connection.
+func checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
 
-		// Check environment variable for allowed origins
-		allowedOriginsEnv := os.Getenv("AGENT_ALLOWED_ORIGINS")
-		if allowedOriginsEnv != "" {
-			allowedOrigins := strings.Split(allowedOriginsEnv, ",")
-			for _, allowed := range allowedOrigins {
-				allowed = strings.TrimSpace(allowed)
-				if allowed == "*" {
-					// Wildcard - allow all origins (not recommended for production)
-					return true
-				}
-				if origin == allowed {
-					return true
-				}
+	// No Origin header (curl, Go clients, etc.) — accept, since CSWSH only
+	// applies in a browser context where the header is mandatory.
+	if origin == "" {
+		return true
+	}
+
+	canonOrigin, ok := canonicalOrigin(origin)
+	if !ok {
+		return false
+	}
+
+	allowedOriginsEnv := os.Getenv("AGENT_ALLOWED_ORIGINS")
+	if allowedOriginsEnv != "" {
+		for _, allowed := range strings.Split(allowedOriginsEnv, ",") {
+			allowed = strings.TrimSpace(allowed)
+			if allowed == "" {
+				continue
 			}
-			// Origin not in allowed list
-			return false
+			if allowed == "*" {
+				// Wildcard — allow all origins (not recommended for production)
+				return true
+			}
+			if canon, ok := canonicalOrigin(allowed); ok && canon == canonOrigin {
+				return true
+			}
 		}
+		return false
+	}
 
-		// Default: same-origin only
-		// Compare origin with the request host
-		originHost := strings.TrimPrefix(origin, "https://")
-		originHost = strings.TrimPrefix(originHost, "http://")
-		originHost = strings.Split(originHost, "/")[0] // Remove path if present
-
-		requestHost := r.Host
-
-		return originHost == requestHost
-	},
+	// Default: same-origin only. Derive scheme from TLS state since the Host
+	// header carries none.
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	// Allow X-Forwarded-Proto when set by a trusted reverse proxy. We don't
+	// honor X-Forwarded-Host because the canonical-host comparison treats
+	// r.Host as authoritative for the agent's own listener.
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		if proto == "http" || proto == "https" {
+			scheme = proto
+		}
+	}
+	return canonOrigin == canonicalHost(scheme, r.Host)
 }
 
 // WSHandler handles WebSocket connections for real-time events.

--- a/gearbox-agent/internal/api/websocket_test.go
+++ b/gearbox-agent/internal/api/websocket_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -209,5 +210,122 @@ func TestWSHandler_SubscriberCount(t *testing.T) {
 
 	if eventBus.SubscriberCount() != 0 {
 		t.Errorf("SubscriberCount after disconnect = %d, want 0", eventBus.SubscriberCount())
+	}
+}
+
+// 2026-05 audit P1-5: WebSocket origin validation must be case-insensitive
+// on the host portion (DNS standard) and aware of default-port equivalence
+// (an Origin of "https://example.com:443" must match an allowlist entry of
+// "https://example.com"). The pre-2026-05 implementation byte-compared
+// strings after a naive trim, so case mismatches and port differences
+// produced unexpected accept/reject decisions.
+func TestCanonicalOrigin(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"https://example.com", "https://example.com", true},
+		{"https://Example.Com", "https://example.com", true},
+		{"https://example.com:443", "https://example.com", true},
+		{"http://example.com:80", "http://example.com", true},
+		{"http://example.com:8080", "http://example.com:8080", true},
+		{"https://example.com:8443", "https://example.com:8443", true},
+		{"  https://example.com  ", "https://example.com", true},
+
+		// Rejected: anything that isn't a complete scheme://host URL.
+		{"", "", false},
+		{"example.com", "", false},
+		{"https://", "", false},
+		{"//example.com", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := canonicalOrigin(tt.in)
+		if ok != tt.ok {
+			t.Errorf("canonicalOrigin(%q) ok=%v, want %v", tt.in, ok, tt.ok)
+			continue
+		}
+		if ok && got != tt.want {
+			t.Errorf("canonicalOrigin(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCheckOrigin_SameOriginDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		origin     string
+		host       string
+		tls        bool
+		fwdProto   string
+		wantAccept bool
+	}{
+		{"no-origin-allowed", "", "agent.example.com:8405", true, "", true},
+		{"matching-https", "https://agent.example.com:8405", "agent.example.com:8405", true, "", true},
+		{"matching-https-case-insensitive", "https://Agent.Example.Com:8405", "agent.example.com:8405", true, "", true},
+		{"matching-https-default-port", "https://agent.example.com:443", "agent.example.com", true, "", true},
+		{"matching-https-no-port", "https://agent.example.com", "agent.example.com:443", true, "", true},
+		{"matching-http", "http://agent.example.com:8080", "agent.example.com:8080", false, "", true},
+
+		{"mismatched-host", "https://attacker.example.com", "agent.example.com:8405", true, "", false},
+		{"mismatched-port", "https://agent.example.com:8406", "agent.example.com:8405", true, "", false},
+		{"scheme-mismatch", "http://agent.example.com:8405", "agent.example.com:8405", true, "", false},
+		{"malformed-origin", "not-a-url", "agent.example.com:8405", true, "", false},
+		{"protocol-relative", "//agent.example.com", "agent.example.com:8405", true, "", false},
+
+		{"xfwd-proto-https", "https://agent.example.com", "agent.example.com", false, "https", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// httptest.NewRequest auto-populates r.TLS when given an https://
+			// URL, so build with http:// then optionally stub r.TLS to mirror
+			// what an actual TLS-terminated server.go listener would set.
+			r := httptest.NewRequest("GET", "http://agent.example.com/events", nil)
+			r.TLS = nil
+			r.Host = tt.host
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			if tt.fwdProto != "" {
+				r.Header.Set("X-Forwarded-Proto", tt.fwdProto)
+			}
+			if tt.tls {
+				r.TLS = &tls.ConnectionState{}
+			}
+			if got := checkOrigin(r); got != tt.wantAccept {
+				t.Errorf("checkOrigin(origin=%q host=%q tls=%v xfp=%q) = %v, want %v",
+					tt.origin, tt.host, tt.tls, tt.fwdProto, got, tt.wantAccept)
+			}
+		})
+	}
+}
+
+func TestCheckOrigin_AllowedOriginsEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		envValue   string
+		origin     string
+		wantAccept bool
+	}{
+		{"exact-match", "https://dashboard.example.com", "https://dashboard.example.com", true},
+		{"case-insensitive-match", "https://dashboard.example.com", "https://Dashboard.Example.Com", true},
+		{"default-port-equivalence", "https://dashboard.example.com", "https://dashboard.example.com:443", true},
+		{"port-mismatch-rejected", "https://dashboard.example.com", "https://dashboard.example.com:8443", false},
+		{"second-in-list", "https://a.example.com, https://b.example.com", "https://b.example.com", true},
+		{"not-in-list-rejected", "https://a.example.com", "https://attacker.example.com", false},
+		{"wildcard-allows-all", "*", "https://attacker.example.com", true},
+		{"empty-entries-skipped", ", ,https://dashboard.example.com,,", "https://dashboard.example.com", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENT_ALLOWED_ORIGINS", tt.envValue)
+			r := httptest.NewRequest("GET", "http://agent.example.com/events", nil)
+			r.TLS = &tls.ConnectionState{}
+			r.Header.Set("Origin", tt.origin)
+			if got := checkOrigin(r); got != tt.wantAccept {
+				t.Errorf("checkOrigin(env=%q origin=%q) = %v, want %v",
+					tt.envValue, tt.origin, got, tt.wantAccept)
+			}
+		})
 	}
 }

--- a/gearbox-agent/internal/framework/middleware/auth.go
+++ b/gearbox-agent/internal/framework/middleware/auth.go
@@ -9,13 +9,31 @@ import (
 )
 
 // APIKeyAuth creates middleware that validates API key authentication.
-func APIKeyAuth(validKey string, logger *slog.Logger) func(http.Handler) http.Handler {
+//
+// When backoff is non-nil, per-IP auth failures trigger exponential
+// backoff (2026-05 audit P1-7) — a defense layered on top of the
+// global rate limiter for distributed brute-force attempts. Pass nil
+// to disable; callers concerned about brute-force should pass a real
+// tracker constructed via DefaultBackoffTracker.
+func APIKeyAuth(validKey string, logger *slog.Logger, backoff *BackoffTracker) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := clientIPFromRemoteAddr(r.RemoteAddr)
+
+			if backoff != nil && backoff.IsBlocked(ip) {
+				logger.Warn("AUTH DENIED: IP in backoff window", "remote_addr", r.RemoteAddr)
+				w.Header().Set("Retry-After", "60")
+				http.Error(w, "Too Many Authentication Failures", http.StatusTooManyRequests)
+				return
+			}
+
 			// Extract API key from Authorization header
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
 				logger.Warn("AUTH DENIED: Missing Authorization header", "remote_addr", r.RemoteAddr)
+				if backoff != nil {
+					backoff.RecordFailure(ip)
+				}
 				http.Error(w, "Unauthorized: missing Authorization header", http.StatusUnauthorized)
 				return
 			}
@@ -24,6 +42,9 @@ func APIKeyAuth(validKey string, logger *slog.Logger) func(http.Handler) http.Ha
 			parts := strings.SplitN(authHeader, " ", 2)
 			if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
 				logger.Warn("AUTH DENIED: Invalid Authorization format", "remote_addr", r.RemoteAddr)
+				if backoff != nil {
+					backoff.RecordFailure(ip)
+				}
 				http.Error(w, "Unauthorized: invalid Authorization format (expected 'Bearer <token>')", http.StatusUnauthorized)
 				return
 			}
@@ -32,11 +53,32 @@ func APIKeyAuth(validKey string, logger *slog.Logger) func(http.Handler) http.Ha
 			// Use constant-time comparison to prevent timing attacks
 			if subtle.ConstantTimeCompare([]byte(token), []byte(validKey)) != 1 {
 				logger.Warn("AUTH DENIED: Invalid API key", "remote_addr", r.RemoteAddr)
+				if backoff != nil {
+					backoff.RecordFailure(ip)
+				}
 				http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
 				return
 			}
 
+			if backoff != nil {
+				backoff.Reset(ip)
+			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// clientIPFromRemoteAddr strips the :port from a net/http RemoteAddr value.
+// Handles IPv6 bracketed form ([::1]:1234) and the common IPv4 form.
+func clientIPFromRemoteAddr(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(addr, ":"); idx > 0 {
+		// IPv6 in brackets: keep the host portion as-is.
+		if !strings.Contains(addr[idx:], "]") {
+			return addr[:idx]
+		}
+	}
+	return addr
 }

--- a/gearbox-agent/internal/framework/middleware/backoff.go
+++ b/gearbox-agent/internal/framework/middleware/backoff.go
@@ -1,0 +1,173 @@
+package middleware
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// 2026-05 security audit, P1-7.
+//
+// BackoffTracker imposes exponential backoff on a per-IP basis when API-key
+// auth fails. The agent's existing rate limiter (50 req/sec/IP) makes a
+// brute-force on a 256-bit hex API key mathematically infeasible from one
+// IP, but offers no defense against distributed attempts across many IPs
+// or against an attacker who pairs auth probing with other endpoints to
+// stay under the global limit.
+//
+// On each failed auth, the per-IP failure count is incremented. Once the
+// count exceeds `threshold` within `window`, that IP is blocked for an
+// exponentially growing duration (baseDelay × 2^(extra-failures)),
+// capped at maxDelay. A successful auth resets the IP's record.
+//
+// The tracker bounds its own map (same defense as the rate limiter,
+// P1-6) so a botnet spraying unique IPs can't grow memory unbounded.
+type BackoffTracker struct {
+	mu          sync.Mutex
+	failures    map[string]*failureRecord
+	threshold   int           // Allowed failures within window before blocking starts
+	window      time.Duration // Sliding window for counting failures
+	baseDelay   time.Duration // Initial block duration after threshold reached
+	maxDelay    time.Duration // Cap on exponential growth
+	maxEntries  int           // Bounded map
+	logger      *slog.Logger
+	stopCleanup chan struct{}
+}
+
+type failureRecord struct {
+	count           int
+	firstFailure   time.Time
+	lastFailure    time.Time
+	blockedUntil   time.Time
+}
+
+// NewBackoffTracker creates a BackoffTracker. Reasonable defaults:
+//
+//	threshold = 3 failures
+//	window    = 5 minutes
+//	baseDelay = 10 seconds
+//	maxDelay  = 30 minutes
+func NewBackoffTracker(threshold int, window, baseDelay, maxDelay time.Duration, logger *slog.Logger) *BackoffTracker {
+	bt := &BackoffTracker{
+		failures:    make(map[string]*failureRecord),
+		threshold:   threshold,
+		window:      window,
+		baseDelay:   baseDelay,
+		maxDelay:    maxDelay,
+		maxEntries:  10000, // mirrors maxRateLimitClients in ratelimit.go
+		logger:      logger,
+		stopCleanup: make(chan struct{}),
+	}
+	go bt.cleanupLoop()
+	return bt
+}
+
+// DefaultBackoffTracker returns a tracker with the reasonable defaults above.
+func DefaultBackoffTracker(logger *slog.Logger) *BackoffTracker {
+	return NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Minute, logger)
+}
+
+// Close stops the cleanup goroutine.
+func (b *BackoffTracker) Close() {
+	close(b.stopCleanup)
+}
+
+// IsBlocked reports whether the IP is currently in a backoff window.
+// Call this BEFORE attempting authentication.
+func (b *BackoffTracker) IsBlocked(ip string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	rec, ok := b.failures[ip]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(rec.blockedUntil)
+}
+
+// RecordFailure increments the IP's failure counter and, if past the
+// threshold, computes a new blockedUntil with exponential backoff.
+func (b *BackoffTracker) RecordFailure(ip string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	rec, ok := b.failures[ip]
+	if !ok {
+		// New entry. Check bounded-map cap; evict stale before allocating.
+		if b.maxEntries > 0 && len(b.failures) >= b.maxEntries {
+			b.evictStaleLocked(now)
+			if len(b.failures) >= b.maxEntries {
+				// Map full of fresh failures. We silently drop the record
+				// for THIS IP; rate-limiting (in front of the auth check)
+				// is the other backstop.
+				return
+			}
+		}
+		b.failures[ip] = &failureRecord{
+			count:        1,
+			firstFailure: now,
+			lastFailure:  now,
+		}
+		return
+	}
+
+	// If the previous failure was outside the sliding window, reset the
+	// count rather than continuing exponential growth.
+	if now.Sub(rec.firstFailure) > b.window {
+		rec.count = 0
+		rec.firstFailure = now
+		rec.blockedUntil = time.Time{}
+	}
+	rec.count++
+	rec.lastFailure = now
+
+	if rec.count > b.threshold {
+		extra := rec.count - b.threshold
+		// baseDelay * 2^(extra-1); cap at maxDelay.
+		delay := b.baseDelay << uint(extra-1)
+		if delay <= 0 || delay > b.maxDelay {
+			delay = b.maxDelay
+		}
+		rec.blockedUntil = now.Add(delay)
+		if b.logger != nil {
+			b.logger.Warn("Auth backoff: IP blocked",
+				"ip", ip,
+				"failures", rec.count,
+				"blocked_for", delay.String(),
+			)
+		}
+	}
+}
+
+// Reset clears the IP's record. Call on successful authentication.
+func (b *BackoffTracker) Reset(ip string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.failures, ip)
+}
+
+// evictStaleLocked drops failure records that are older than the window AND
+// not currently blocked. Caller MUST hold b.mu.
+func (b *BackoffTracker) evictStaleLocked(now time.Time) {
+	for ip, rec := range b.failures {
+		if now.Sub(rec.lastFailure) > b.window && now.After(rec.blockedUntil) {
+			delete(b.failures, ip)
+		}
+	}
+}
+
+// cleanupLoop periodically drops expired entries.
+func (b *BackoffTracker) cleanupLoop() {
+	ticker := time.NewTicker(b.window) // run as often as the window itself
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			b.mu.Lock()
+			b.evictStaleLocked(time.Now())
+			b.mu.Unlock()
+		case <-b.stopCleanup:
+			return
+		}
+	}
+}

--- a/gearbox-agent/internal/framework/middleware/backoff_test.go
+++ b/gearbox-agent/internal/framework/middleware/backoff_test.go
@@ -1,0 +1,140 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+// 2026-05 audit P1-7. The tracker should:
+// 1. Not block an IP until it exceeds the threshold within the window.
+// 2. Block for at least baseDelay once the threshold is exceeded.
+// 3. Grow the block window exponentially with continued failures.
+// 4. Reset on successful auth.
+// 5. Forget failures that fall outside the sliding window.
+// 6. Bound its own memory.
+
+func TestBackoffTracker_BelowThreshold(t *testing.T) {
+	bt := NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Minute, nil)
+	defer bt.Close()
+
+	for i := 0; i < 3; i++ {
+		bt.RecordFailure("10.0.0.1")
+		if bt.IsBlocked("10.0.0.1") {
+			t.Fatalf("IsBlocked=true at failure %d; want false (still at threshold)", i+1)
+		}
+	}
+}
+
+func TestBackoffTracker_BlocksPastThreshold(t *testing.T) {
+	bt := NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Minute, nil)
+	defer bt.Close()
+
+	for i := 0; i < 4; i++ {
+		bt.RecordFailure("10.0.0.1")
+	}
+	if !bt.IsBlocked("10.0.0.1") {
+		t.Errorf("IsBlocked=false after 4 failures; want true")
+	}
+}
+
+func TestBackoffTracker_ExponentialGrowth(t *testing.T) {
+	bt := NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Minute, nil)
+	defer bt.Close()
+
+	// 4 failures → baseDelay (10s, 2^0=1).
+	for i := 0; i < 4; i++ {
+		bt.RecordFailure("10.0.0.1")
+	}
+	rec := bt.failures["10.0.0.1"]
+	delay := time.Until(rec.blockedUntil)
+	if delay < 9*time.Second || delay > 11*time.Second {
+		t.Errorf("4th failure: delay=%v, want ~10s", delay)
+	}
+
+	// 5th failure: baseDelay << 1 = 20s.
+	bt.RecordFailure("10.0.0.1")
+	delay = time.Until(bt.failures["10.0.0.1"].blockedUntil)
+	if delay < 19*time.Second || delay > 21*time.Second {
+		t.Errorf("5th failure: delay=%v, want ~20s", delay)
+	}
+
+	// 6th failure: 40s.
+	bt.RecordFailure("10.0.0.1")
+	delay = time.Until(bt.failures["10.0.0.1"].blockedUntil)
+	if delay < 39*time.Second || delay > 41*time.Second {
+		t.Errorf("6th failure: delay=%v, want ~40s", delay)
+	}
+}
+
+func TestBackoffTracker_CapAtMaxDelay(t *testing.T) {
+	// baseDelay 10s, maxDelay 30s. After threshold + many failures the delay
+	// must not exceed 30s.
+	bt := NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Second, nil)
+	defer bt.Close()
+
+	for i := 0; i < 20; i++ {
+		bt.RecordFailure("10.0.0.1")
+	}
+	delay := time.Until(bt.failures["10.0.0.1"].blockedUntil)
+	if delay > 31*time.Second {
+		t.Errorf("delay=%v exceeds maxDelay 30s", delay)
+	}
+}
+
+func TestBackoffTracker_ResetClearsBlock(t *testing.T) {
+	bt := NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Minute, nil)
+	defer bt.Close()
+
+	for i := 0; i < 4; i++ {
+		bt.RecordFailure("10.0.0.1")
+	}
+	if !bt.IsBlocked("10.0.0.1") {
+		t.Fatal("setup: IP should be blocked")
+	}
+	bt.Reset("10.0.0.1")
+	if bt.IsBlocked("10.0.0.1") {
+		t.Errorf("IsBlocked=true after Reset; want false")
+	}
+}
+
+func TestBackoffTracker_BoundedMap(t *testing.T) {
+	bt := NewBackoffTracker(3, 5*time.Minute, 10*time.Second, 30*time.Minute, nil)
+	defer bt.Close()
+	bt.maxEntries = 100
+
+	// Fill the map with 100 distinct IPs (one failure each — not enough to
+	// block any of them, but the records exist).
+	for i := 0; i < 100; i++ {
+		ip := makeIP(i)
+		bt.RecordFailure(ip)
+	}
+	if len(bt.failures) != 100 {
+		t.Fatalf("map size = %d; want 100", len(bt.failures))
+	}
+
+	// The 101st distinct IP must NOT cause map growth. The implementation
+	// drops the record rather than expanding (rate-limiting in front is
+	// the other backstop).
+	bt.RecordFailure("10.99.99.99")
+	if len(bt.failures) > 100 {
+		t.Errorf("map size = %d after overflow; want <=100", len(bt.failures))
+	}
+}
+
+func makeIP(i int) string {
+	return "10.0." + itoaPad(i/256) + "." + itoaPad(i%256)
+}
+
+func itoaPad(n int) string {
+	if n < 10 {
+		return string(rune('0'+n%10)) // for the small numbers we use in tests
+	}
+	// We never actually hit this branch with 100 entries (only 0..99), but
+	// keep it correct in case the test is extended later.
+	s := ""
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	return s
+}

--- a/gearbox-agent/internal/framework/middleware/ratelimit.go
+++ b/gearbox-agent/internal/framework/middleware/ratelimit.go
@@ -8,6 +8,23 @@ import (
 	"time"
 )
 
+// maxRateLimitClients caps the number of distinct client IPs the rate
+// limiter will track in memory. A distributed attacker hitting the agent
+// from a botnet (or any large pool of unique source IPs) would otherwise
+// be able to grow the map unbounded, since the cleanup goroutine only
+// evicts entries idle for 10 minutes. With the cap in place, attempts to
+// add a new bucket past the cap fall through to a synchronous "premature
+// cleanup" of stale entries; if that doesn't free space, the request is
+// denied as if rate-limited. See 2026-05 security audit, P1-6.
+const maxRateLimitClients = 10000
+
+// staleClientThreshold is how old a bucket's lastUpdate must be before the
+// premature-cleanup path is willing to evict it. Lower than the 10-minute
+// cleanupLoop threshold to give the at-capacity path more room to work,
+// but high enough that a brief burst from many clients doesn't cause real
+// requests to be denied.
+const staleClientThreshold = 2 * time.Minute
+
 // RateLimiter implements a simple token bucket rate limiter per IP.
 type RateLimiter struct {
 	mu          sync.Mutex
@@ -15,6 +32,7 @@ type RateLimiter struct {
 	rate        int           // Requests per second
 	burst       int           // Maximum burst size
 	cleanup     time.Duration // How often to clean up old entries
+	maxClients  int           // Bounded map size; 0 = unbounded (tests only)
 	logger      *slog.Logger
 	trustProxy  bool          // Whether to trust X-Forwarded-For headers
 	stopCleanup chan struct{} // Signal to stop cleanup goroutine
@@ -35,6 +53,7 @@ func NewRateLimiter(rate, burst int, trustProxy bool, logger *slog.Logger) *Rate
 		rate:        rate,
 		burst:       burst,
 		cleanup:     5 * time.Minute,
+		maxClients:  maxRateLimitClients,
 		logger:      logger,
 		trustProxy:  trustProxy,
 		stopCleanup: make(chan struct{}),
@@ -61,9 +80,28 @@ func (rl *RateLimiter) Allow(ip string) bool {
 
 	bucket, exists := rl.clients[ip]
 	if !exists {
-		// New client, start with full burst capacity
+		// New client. Check the bounded-map cap before allocating a bucket
+		// to defend against a distributed attacker pumping unique IPs into
+		// the map faster than the 5-minute cleanup loop evicts them
+		// (2026-05 audit, P1-6).
+		if rl.maxClients > 0 && len(rl.clients) >= rl.maxClients {
+			rl.evictStaleLocked(now)
+			if len(rl.clients) >= rl.maxClients {
+				// Still full after premature cleanup. Deny rather than
+				// allocate. The denied IP gets back in next time someone
+				// else's bucket goes stale.
+				if rl.logger != nil {
+					rl.logger.Warn("Rate limiter map at capacity; denying new client",
+						"ip", ip,
+						"map_size", len(rl.clients),
+					)
+				}
+				return false
+			}
+		}
+		// Start with full burst capacity (-1 for this request).
 		rl.clients[ip] = &clientBucket{
-			tokens:     float64(rl.burst - 1), // -1 for this request
+			tokens:     float64(rl.burst - 1),
 			lastUpdate: now,
 		}
 		return true
@@ -105,6 +143,19 @@ func (rl *RateLimiter) cleanupLoop() {
 			rl.mu.Unlock()
 		case <-rl.stopCleanup:
 			return
+		}
+	}
+}
+
+// evictStaleLocked drops bucket entries older than staleClientThreshold.
+// Caller MUST hold rl.mu. Used by Allow() when the map hits capacity, to
+// make room before allocating a new bucket. The 2-minute threshold is
+// shorter than the cleanupLoop's 10-minute threshold so the at-capacity
+// path can free space without waiting for the periodic sweep.
+func (rl *RateLimiter) evictStaleLocked(now time.Time) {
+	for ip, bucket := range rl.clients {
+		if now.Sub(bucket.lastUpdate) > staleClientThreshold {
+			delete(rl.clients, ip)
 		}
 	}
 }

--- a/gearbox-agent/internal/framework/middleware/ratelimit_test.go
+++ b/gearbox-agent/internal/framework/middleware/ratelimit_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -182,5 +183,57 @@ func TestDefaultRateLimiter(t *testing.T) {
 	}
 	if rl.burst != 100 {
 		t.Errorf("default burst = %d, want 100", rl.burst)
+	}
+}
+
+// 2026-05 audit P1-6: the per-IP map must not grow unbounded.
+func TestRateLimiter_BoundedMap(t *testing.T) {
+	rl := NewRateLimiter(50, 100, false, nil)
+	defer rl.Close()
+	// Shrink the cap to keep the test fast.
+	rl.maxClients = 100
+
+	// Fill the map with 100 distinct IPs. All should be allowed (each gets
+	// its own bucket with full burst).
+	for i := 0; i < 100; i++ {
+		ip := fmt.Sprintf("10.0.%d.%d", i/256, i%256)
+		if !rl.Allow(ip) {
+			t.Fatalf("Allow(%q) = false at i=%d; want true (map not yet at cap)", ip, i)
+		}
+	}
+	if len(rl.clients) != 100 {
+		t.Fatalf("map size = %d after filling; want 100", len(rl.clients))
+	}
+
+	// The 101st distinct IP must be denied because the map is at cap and
+	// no entries are stale (all just created).
+	overflow := "10.1.0.1"
+	if rl.Allow(overflow) {
+		t.Errorf("Allow(%q) = true past cap; want false (map full, no stale entries)", overflow)
+	}
+	if len(rl.clients) != 100 {
+		t.Errorf("map size = %d after overflow attempt; want 100 (no new entry)", len(rl.clients))
+	}
+}
+
+func TestRateLimiter_EvictsStaleWhenAtCap(t *testing.T) {
+	rl := NewRateLimiter(50, 100, false, nil)
+	defer rl.Close()
+	rl.maxClients = 10
+
+	// Fill with 10 IPs, but rewind their lastUpdate so they look stale.
+	for i := 0; i < 10; i++ {
+		ip := fmt.Sprintf("10.0.0.%d", i)
+		rl.Allow(ip)
+		rl.clients[ip].lastUpdate = time.Now().Add(-5 * time.Minute)
+	}
+	if len(rl.clients) != 10 {
+		t.Fatalf("map size = %d; want 10", len(rl.clients))
+	}
+
+	// A new IP should be admitted: the premature-cleanup path will evict
+	// the 10 stale entries before allocating.
+	if !rl.Allow("10.1.0.1") {
+		t.Errorf("Allow(10.1.0.1) = false; want true (cap reached but stale entries evictable)")
 	}
 }


### PR DESCRIPTION
Second batch of P1 fixes from the [2026-05 security audit](https://github.com/sarg3nt/gearbox/pull/40). Three findings, all on the agent-side network/auth path — each commit is reviewable in isolation.

## Commits

### `ef28c4f` — fix(security): normalize WebSocket origin + host comparison  *(P1-5)*

`Upgrader.CheckOrigin` did byte-equal comparison after a naive scheme-strip:

- Case-sensitive: `Origin: https://Example.Com` did not match an allowlist entry of `https://example.com` (hostnames are case-insensitive per DNS).
- Port-naive: `Origin: https://example.com:443` did not match an allowlist of `https://example.com` even though `:443` IS the default port for https.

**Fix:** parse Origin and `r.Host` with `net/url`, lowercase the host, strip the default port for the scheme, compare canonical forms. Also derive the same-origin scheme from `r.TLS` or `X-Forwarded-Proto` instead of guessing (matters when the agent sits behind TLS-terminating HAProxy).

13 test cases pin the parse matrix and the same-origin/allowlist decision paths.

### `20c2972` — fix(security): bound rate-limiter client map (memory-DoS defense)  *(P1-6)*

The token-bucket map allocated one entry per source IP and only the 5-min-tick cleanup goroutine evicted them (idle >10 minutes). A distributed attacker — or any misbehaving NAT pool — could grow the map faster than cleanup evicts.

**Fix:** hard cap of 10,000 entries. When `Allow()` sees a new IP and the map is at cap, run a synchronous `evictStaleLocked` pass dropping entries idle >2 min. If that fails to free space, deny the request as if rate-limited. The cap is well above any realistic legitimate-client count for a single agent.

Tests cover (1) refusal of the (cap+1)th IP with a full map of fresh entries, and (2) admission of a new IP when stale entries are present.

### `a81a9fa` — fix(security): add per-IP auth-failure backoff layered on rate limiting  *(P1-7)*

The existing rate limiter (50/sec/IP) makes single-IP brute force on a 256-bit hex key mathematically infeasible — but offers no defense against distributed brute force (each IP staying under 50/sec) or attempts paired with legitimate-looking traffic to other endpoints.

**New `BackoffTracker`** imposes a per-IP failure ceiling on top of the rate limiter. Defaults:

| Setting | Value |
|---------|-------|
| threshold | 3 failures |
| window | 5 minutes |
| baseDelay | 10 seconds |
| maxDelay | 30 minutes |

After 3 failures within 5 minutes, each additional failure extends the block: 10s → 20s → 40s → 80s → … → capped at 30m. Successful auth resets. Failures outside the window reset the count. Tracker bounds its own map (10k entries, same defense as the rate limiter).

`APIKeyAuth` signature gains an optional `*BackoffTracker` param. Both callers (`internal/api/server.go` and `cmd/gearbox-agent/main.go`) construct a `DefaultBackoffTracker` and pass it. Blocked IPs get a `429 Too Many Authentication Failures` with `Retry-After: 60` rather than 401.

6 test cases cover threshold, exponential growth, max cap, reset on success, and bounded-map.

## Verification

```bash
$ go build ./...   # clean
$ go test ./...
ok  ...internal/api               0.348s
ok  ...internal/framework/middleware  0.436s
(all 20+ packages green)
```

## Notes

- Branched off `main`; no conflict with the open PR #40 (findings retrospective) or PR #41 (P1-1/P1-3 flag injection).
- This leaves **P1-4** (CSP env splicing) and **P1-8** (Alpine.js directives) from the P1 set, both dashboard-side. I'll batch those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)