### PR TITLE
fix(security): P1-4 — validate CSP_EXTRA_SOURCES / CSP_REPORT_URI env values

### DIFF
--- a/gearbox/internal/framework/middleware/security_headers.go
+++ b/gearbox/internal/framework/middleware/security_headers.go
@@ -2,9 +2,71 @@ package middleware
 
 import (
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"strings"
 )
+
+// validCSPDirective matches a single CSP directive line in the shape the
+// directives slice expects: a directive name followed by one or more source
+// expressions, with no semicolons (which would close the directive and let
+// the env-var splice arbitrary new directives into the CSP header).
+//
+// CSP directive names are letters, digits, and hyphens. Source expressions
+// can be 'self' / 'none' / 'unsafe-inline' / nonce-... / sha256-... / scheme
+// URLs / wildcards / data: / blob: — i.e. printable ASCII without ; or ,
+// or newline. We keep the validator deliberately conservative: only
+// alphanumerics, a small punctuation set, and quoted keywords.
+//
+// 2026-05 audit P1-4.
+var validCSPDirective = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]+(\s+[a-zA-Z0-9'_:/.\-*]+)+$`)
+
+// sanitizeCSPExtraSource accepts a single entry from the
+// CSP_EXTRA_SOURCES comma-separated env var and returns the trimmed
+// value plus an OK flag. Rejects values containing characters that
+// would let an attacker close the current directive and inject a new
+// one (`;`), inject CRLF into the header (`\r`, `\n`), or that don't
+// look like a valid `directive source [source...]` line.
+func sanitizeCSPExtraSource(s string) (string, bool) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return "", false
+	}
+	if strings.ContainsAny(trimmed, ";\r\n\t") {
+		return "", false
+	}
+	if !validCSPDirective.MatchString(trimmed) {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// sanitizeCSPReportURI validates the CSP_REPORT_URI env var. Accepts an
+// http(s):// URL; rejects relative paths (would silently fall through to
+// the dashboard's own origin), schemed URIs other than http(s) (no
+// `javascript:` or `data:`), and anything with embedded whitespace or
+// newlines (CRLF injection into the response header).
+func sanitizeCSPReportURI(s string) (string, bool) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return "", false
+	}
+	if strings.ContainsAny(trimmed, " \t\r\n;") {
+		return "", false
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil || u == nil {
+		return "", false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", false
+	}
+	if u.Host == "" {
+		return "", false
+	}
+	return trimmed, true
+}
 
 // SecurityHeaders adds security-related HTTP headers to responses.
 // Implements defense-in-depth security controls including:
@@ -84,22 +146,25 @@ func buildCSP() string {
 		}
 	}
 
-	// Add extra sources from environment variable if configured
+	// Add extra sources from environment variable if configured.
+	// Each comma-separated entry is required to be a well-formed CSP
+	// directive line; entries that look like injection attempts (embedded
+	// `;`, CRLF, etc.) are silently dropped so a compromised deployment
+	// env can't neutralize the CSP. See 2026-05 security audit P1-4.
 	extraSources := os.Getenv("CSP_EXTRA_SOURCES")
 	if extraSources != "" {
-		sources := strings.Split(extraSources, ",")
-		for _, source := range sources {
-			source = strings.TrimSpace(source)
-			if source != "" {
-				directives = append(directives, source)
+		for _, source := range strings.Split(extraSources, ",") {
+			if clean, ok := sanitizeCSPExtraSource(source); ok {
+				directives = append(directives, clean)
 			}
 		}
 	}
 
-	// Add report-uri if configured
-	reportURI := os.Getenv("CSP_REPORT_URI")
-	if reportURI != "" {
-		directives = append(directives, "report-uri "+reportURI)
+	// Add report-uri if configured. The URI is required to be an absolute
+	// http(s) URL; anything else (including relative paths, `javascript:`,
+	// or values with embedded whitespace) is dropped.
+	if uri, ok := sanitizeCSPReportURI(os.Getenv("CSP_REPORT_URI")); ok {
+		directives = append(directives, "report-uri "+uri)
 	}
 
 	return strings.Join(directives, "; ")

--- a/gearbox/internal/framework/middleware/security_headers_test.go
+++ b/gearbox/internal/framework/middleware/security_headers_test.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// 2026-05 audit P1-4: CSP_EXTRA_SOURCES entries must be validated as
+// well-formed CSP directive lines, with no characters that would let an
+// attacker close the directive and inject a new one.
+func TestSanitizeCSPExtraSource(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		// Accepted: well-formed CSP directive lines.
+		{"script-src-self", "script-src 'self'", "script-src 'self'", true},
+		{"connect-src-multi", "connect-src 'self' wss://example.com", "connect-src 'self' wss://example.com", true},
+		{"img-src-data", "img-src 'self' data:", "img-src 'self' data:", true},
+		{"font-src-cdn", "font-src https://fonts.example.com", "font-src https://fonts.example.com", true},
+		{"trimmed-whitespace", "  script-src 'self'  ", "script-src 'self'", true},
+
+		// Rejected: empty / structural injection / CRLF.
+		{"empty", "", "", false},
+		{"whitespace-only", "   ", "", false},
+		{"directive-injection", "script-src 'self'; default-src *", "", false},
+		{"crlf-injection", "script-src 'self'\r\nX-Header: pwn", "", false},
+		{"lf-only", "script-src 'self'\ndefault-src *", "", false},
+
+		// Rejected: doesn't look like a directive line at all.
+		{"single-token", "evil", "", false},
+		{"leading-quote", "'unsafe-inline'", "", false},
+		{"directive-no-source", "script-src", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := sanitizeCSPExtraSource(tt.in)
+			if ok != tt.ok {
+				t.Errorf("sanitizeCSPExtraSource(%q) ok=%v, want %v", tt.in, ok, tt.ok)
+				return
+			}
+			if ok && got != tt.want {
+				t.Errorf("sanitizeCSPExtraSource(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// CSP_REPORT_URI must parse as an absolute http(s) URL; relative paths,
+// non-http schemes, and CRLF injection must all be rejected.
+func TestSanitizeCSPReportURI(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{"https", "https://csp-report.example.com/r", true},
+		{"http", "http://csp-report.example.com/r", true},
+		{"trimmed", "  https://csp-report.example.com/r  ", true},
+
+		{"empty", "", false},
+		{"relative-path", "/csp-report", false},
+		{"javascript-scheme", "javascript:alert(1)", false},
+		{"data-scheme", "data:text/html,evil", false},
+		{"no-scheme-host-only", "csp-report.example.com", false},
+		{"crlf-injection", "https://example.com\r\nX-Header: pwn", false},
+		{"whitespace-in-middle", "https://example.com /path", false},
+		{"directive-injection", "https://example.com; default-src *", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := sanitizeCSPReportURI(tt.in)
+			if ok != tt.ok {
+				t.Errorf("sanitizeCSPReportURI(%q) ok=%v, want %v", tt.in, ok, tt.ok)
+			}
+		})
+	}
+}
+
+// End-to-end: a malicious CSP_EXTRA_SOURCES env var must not be reflected
+// into the response header.
+func TestSecurityHeaders_RejectsCSPInjection(t *testing.T) {
+	t.Setenv("CSP_EXTRA_SOURCES", "script-src 'self'; default-src *")
+	t.Setenv("CSP_REPORT_URI", "javascript:alert(1)")
+
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("CSP header missing")
+	}
+	if strings.Contains(csp, "default-src *") {
+		t.Errorf("CSP contains attacker-injected 'default-src *': %q", csp)
+	}
+	if strings.Contains(csp, "javascript:") {
+		t.Errorf("CSP contains attacker-injected 'javascript:' report URI: %q", csp)
+	}
+}
+
+// Sanity: a well-formed extra source DOES appear in the header.
+func TestSecurityHeaders_AcceptsValidCSPExtra(t *testing.T) {
+	t.Setenv("CSP_EXTRA_SOURCES", "connect-src 'self' wss://events.example.com")
+	t.Setenv("CSP_REPORT_URI", "https://csp.example.com/report")
+
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "wss://events.example.com") {
+		t.Errorf("CSP missing valid extra source: %q", csp)
+	}
+	if !strings.Contains(csp, "report-uri https://csp.example.com/report") {
+		t.Errorf("CSP missing valid report-uri: %q", csp)
+	}
+}


### PR DESCRIPTION
Single-finding PR from the [2026-05 security audit](https://github.com/sarg3nt/gearbox/pull/40). Dashboard-side, so no overlap with the still-open agent-side PRs (#41, #42).

## The bug

`buildCSP()` in `gearbox/internal/framework/middleware/security_headers.go` spliced both `CSP_EXTRA_SOURCES` and `CSP_REPORT_URI` into the `Content-Security-Policy` response header **without validation**. The CSP directive separator is `;`, so an attacker who controls the deployment env (container escape, compromised CI, accidentally-merged config) could append:

```
CSP_EXTRA_SOURCES="script-src 'self'; default-src *"
```

…and the resulting header would include `default-src *`, neutralizing the entire CSP for every user from that point on. `CSP_REPORT_URI` had the same shape plus a response-splitting vector via embedded CRLF.

## The fix

Two new helpers in the same file:

- **`sanitizeCSPExtraSource(s)`** — requires each comma-separated entry to be a well-formed `<directive> <source>...` line. Alphanumeric directive name, source tokens from a small printable-ASCII allowlist, **no** `;` / `\r` / `\n` / `\t`. Invalid entries silently dropped.
- **`sanitizeCSPReportURI(s)`** — requires the URI to parse as an absolute `http(s)://host/...` URL. Rejects relative paths, schemed URIs other than http/https (no `javascript:`/`data:`), and any value with embedded whitespace or `;`.

Both functions return a separate `ok bool` so the call site silently drops invalid env entries — a typo in one entry doesn't take down the whole middleware path.

## Tests

12 cases against the sanitizers covering both happy paths and textbook injection (`; default-src *`, `\r\nX-Header:`, `javascript:`, relative path) + 2 end-to-end tests via `SecurityHeaders` middleware that verify a malicious env value never appears in the response header AND a valid env value DOES appear.

## What's left from the audit

- **P1-8 (Alpine.js directives)** — modal components use `x-data` / `x-show` / `@click.away` but no Alpine.js is loaded. Modals are silently non-functional, and if Alpine is later added the inline event handlers need `'unsafe-eval'` in the CSP unless the CSP-safe build is used. **This is a UX/architecture decision** (rewrite modals in HTMX + vanilla JS vs. add Alpine 3 + `@alpinejs/csp` + CSP changes) — I'll surface the question separately rather than picking a direction unilaterally.
- **P2 batch (10 items)** — mostly doc accuracy + small hardening: constant-time CSRF compare, hard session TTL, per-email login rate limit, HSTS + Permissions-Policy headers, TLS 1.3 floor. Ready to batch when you say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)