### PR TITLE
fix(security): P2 agent batch (P2-5/7/9/10)

### DIFF
--- a/gearbox-agent/docs/docs.go
+++ b/gearbox-agent/docs/docs.go
@@ -74,7 +74,7 @@ const docTemplate = `{
                     "200": {
                         "description": "WebSocket endpoint info",
                         "schema": {
-                            "$ref": "#/definitions/api.WSInfoResponse"
+                            "$ref": "#/definitions/internal_api.WSInfoResponse"
                         }
                     },
                     "401": {
@@ -105,7 +105,7 @@ const docTemplate = `{
                     "200": {
                         "description": "WebSocket token",
                         "schema": {
-                            "$ref": "#/definitions/api.WSTokenResponse"
+                            "$ref": "#/definitions/internal_api.WSTokenResponse"
                         }
                     },
                     "401": {
@@ -148,7 +148,7 @@ const docTemplate = `{
                     "200": {
                         "description": "HAProxy metadata",
                         "schema": {
-                            "$ref": "#/definitions/api.MetadataResponse"
+                            "$ref": "#/definitions/internal_api.MetadataResponse"
                         }
                     },
                     "401": {
@@ -185,7 +185,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Sync status",
                         "schema": {
-                            "$ref": "#/definitions/api.SyncStatusResponse"
+                            "$ref": "#/definitions/internal_api.SyncStatusResponse"
                         }
                     },
                     "401": {
@@ -245,7 +245,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Traffic analysis data",
                         "schema": {
-                            "$ref": "#/definitions/traffic.TrafficResponse"
+                            "$ref": "#/definitions/internal_gears_traffic.TrafficResponse"
                         }
                     },
                     "401": {
@@ -288,7 +288,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Traffic summary",
                         "schema": {
-                            "$ref": "#/definitions/traffic.TrafficSummary"
+                            "$ref": "#/definitions/internal_gears_traffic.TrafficSummary"
                         }
                     },
                     "401": {
@@ -340,7 +340,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.GitHubPushPayload"
+                            "$ref": "#/definitions/internal_api.GitHubPushPayload"
                         }
                     }
                 ],
@@ -348,19 +348,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Webhook processed successfully",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookSuccessResponse"
+                            "$ref": "#/definitions/internal_api.WebhookSuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad request",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookErrorResponse"
+                            "$ref": "#/definitions/internal_api.WebhookErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Invalid or missing signature",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookErrorResponse"
+                            "$ref": "#/definitions/internal_api.WebhookErrorResponse"
                         }
                     }
                 }
@@ -385,7 +385,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Webhook configuration info",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookInfoResponse"
+                            "$ref": "#/definitions/internal_api.WebhookInfoResponse"
                         }
                     },
                     "401": {
@@ -399,7 +399,7 @@ const docTemplate = `{
         },
         "/health": {
             "get": {
-                "description": "Returns the health status of the gearbox-agent service. No authentication required.",
+                "description": "Returns the health status of the gearbox-agent service. No authentication required. Only \"status\" is exposed; version and uptime are intentionally omitted from this unauthenticated endpoint to avoid fingerprinting by remote scanners.",
                 "produces": [
                     "application/json"
                 ],
@@ -411,7 +411,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Service is healthy",
                         "schema": {
-                            "$ref": "#/definitions/api.HealthResponse"
+                            "$ref": "#/definitions/internal_api.HealthResponse"
                         }
                     }
                 }
@@ -419,182 +419,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "api.GitHubPushPayload": {
-            "type": "object",
-            "properties": {
-                "head_commit": {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "message": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "pusher": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "ref": {
-                    "type": "string"
-                },
-                "repository": {
-                    "type": "object",
-                    "properties": {
-                        "full_name": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "api.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "example": "ok"
-                },
-                "timestamp": {
-                    "type": "string",
-                    "example": "2024-01-17T10:30:00Z"
-                },
-                "uptime": {
-                    "type": "string",
-                    "example": "2h30m15s"
-                },
-                "version": {
-                    "type": "string",
-                    "example": "1.0.0"
-                }
-            }
-        },
-        "api.MetadataResponse": {
-            "type": "object",
-            "properties": {
-                "last_error": {
-                    "type": "string"
-                },
-                "last_sync_time": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/haproxy.Metadata"
-                }
-            }
-        },
-        "api.SyncStatusResponse": {
-            "type": "object",
-            "properties": {
-                "backend_count": {
-                    "type": "integer"
-                },
-                "last_error": {
-                    "type": "string"
-                },
-                "last_sync_time": {
-                    "type": "string"
-                }
-            }
-        },
-        "api.WSInfoResponse": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "endpoint": {
-                    "type": "string",
-                    "example": "/api/v1/events"
-                },
-                "event_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "sync.started",
-                        "sync.completed",
-                        "sync.failed",
-                        "config.changed",
-                        "webhook.received"
-                    ]
-                },
-                "subscribers": {
-                    "type": "integer",
-                    "example": 2
-                }
-            }
-        },
-        "api.WSTokenResponse": {
-            "type": "object",
-            "properties": {
-                "expires_in": {
-                    "description": "Seconds until expiry",
-                    "type": "integer",
-                    "example": 60
-                },
-                "token": {
-                    "type": "string",
-                    "example": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"
-                }
-            }
-        },
-        "api.WebhookErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string",
-                    "example": "invalid_signature"
-                },
-                "message": {
-                    "type": "string",
-                    "example": "Signature verification failed"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "error"
-                }
-            }
-        },
-        "api.WebhookInfoResponse": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "message": {
-                    "type": "string",
-                    "example": "Configure this URL in GitHub repository settings"
-                },
-                "webhook_url": {
-                    "type": "string",
-                    "example": "https://proxy.example.com:8405/api/v1/webhook/github"
-                }
-            }
-        },
-        "api.WebhookSuccessResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Sync triggered"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "accepted"
-                }
-            }
-        },
-        "haproxy.ACLMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ACLMetadata": {
             "type": "object",
             "properties": {
                 "type": {
@@ -605,7 +430,7 @@ const docTemplate = `{
                 }
             }
         },
-        "haproxy.ActiveSession": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ActiveSession": {
             "type": "object",
             "properties": {
                 "age_seconds": {
@@ -646,13 +471,13 @@ const docTemplate = `{
                 }
             }
         },
-        "haproxy.BackendMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.BackendMetadata": {
             "type": "object",
             "properties": {
                 "acls": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ACLMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ACLMetadata"
                     }
                 },
                 "app_name": {
@@ -661,7 +486,7 @@ const docTemplate = `{
                 "containers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ContainerMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ContainerMetadata"
                     }
                 },
                 "frontend": {
@@ -693,7 +518,7 @@ const docTemplate = `{
                 }
             }
         },
-        "haproxy.ConnectionFlow": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ConnectionFlow": {
             "type": "object",
             "properties": {
                 "active_connections": {
@@ -716,7 +541,7 @@ const docTemplate = `{
                 }
             }
         },
-        "haproxy.ContainerMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ContainerMetadata": {
             "type": "object",
             "properties": {
                 "depends_on": {
@@ -736,7 +561,7 @@ const docTemplate = `{
                 }
             }
         },
-        "haproxy.FrontendMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.FrontendMetadata": {
             "type": "object",
             "properties": {
                 "backends": {
@@ -750,19 +575,19 @@ const docTemplate = `{
                 }
             }
         },
-        "haproxy.Metadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.Metadata": {
             "type": "object",
             "properties": {
                 "backends": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.BackendMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.BackendMetadata"
                     }
                 },
                 "frontends": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.FrontendMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.FrontendMetadata"
                     }
                 },
                 "generated_at": {
@@ -773,7 +598,170 @@ const docTemplate = `{
                 }
             }
         },
-        "traffic.BackendTrafficData": {
+        "internal_api.GitHubPushPayload": {
+            "type": "object",
+            "properties": {
+                "head_commit": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "pusher": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ref": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "object",
+                    "properties": {
+                        "full_name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "internal_api.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "example": "ok"
+                }
+            }
+        },
+        "internal_api.MetadataResponse": {
+            "type": "object",
+            "properties": {
+                "last_error": {
+                    "type": "string"
+                },
+                "last_sync_time": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.Metadata"
+                }
+            }
+        },
+        "internal_api.SyncStatusResponse": {
+            "type": "object",
+            "properties": {
+                "backend_count": {
+                    "type": "integer"
+                },
+                "last_error": {
+                    "type": "string"
+                },
+                "last_sync_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.WSInfoResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "endpoint": {
+                    "type": "string",
+                    "example": "/api/v1/events"
+                },
+                "event_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "sync.started",
+                        "sync.completed",
+                        "sync.failed",
+                        "config.changed",
+                        "webhook.received"
+                    ]
+                },
+                "subscribers": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
+        },
+        "internal_api.WSTokenResponse": {
+            "type": "object",
+            "properties": {
+                "expires_in": {
+                    "description": "Seconds until expiry",
+                    "type": "integer",
+                    "example": 60
+                },
+                "token": {
+                    "type": "string",
+                    "example": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"
+                }
+            }
+        },
+        "internal_api.WebhookErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "invalid_signature"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Signature verification failed"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "error"
+                }
+            }
+        },
+        "internal_api.WebhookInfoResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Configure this URL in GitHub repository settings"
+                },
+                "webhook_url": {
+                    "type": "string",
+                    "example": "https://proxy.example.com:8405/api/v1/webhook/github"
+                }
+            }
+        },
+        "internal_api.WebhookSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Sync triggered"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "accepted"
+                }
+            }
+        },
+        "internal_gears_traffic.BackendTrafficData": {
             "type": "object",
             "properties": {
                 "avg_response_time": {
@@ -811,19 +799,19 @@ const docTemplate = `{
                 }
             }
         },
-        "traffic.TrafficResponse": {
+        "internal_gears_traffic.TrafficResponse": {
             "type": "object",
             "properties": {
                 "active_sessions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ActiveSession"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ActiveSession"
                     }
                 },
                 "backend_traffic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.BackendTrafficData"
+                        "$ref": "#/definitions/internal_gears_traffic.BackendTrafficData"
                     }
                 },
                 "collected_at": {
@@ -832,31 +820,31 @@ const docTemplate = `{
                 "connection_flows": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ConnectionFlow"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ConnectionFlow"
                     }
                 },
                 "sources": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "top_by_bytes": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "top_by_connections": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "top_by_requests": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "total_sources": {
@@ -864,7 +852,7 @@ const docTemplate = `{
                 }
             }
         },
-        "traffic.TrafficSourceData": {
+        "internal_gears_traffic.TrafficSourceData": {
             "type": "object",
             "properties": {
                 "backend": {
@@ -901,7 +889,7 @@ const docTemplate = `{
                 }
             }
         },
-        "traffic.TrafficSummary": {
+        "internal_gears_traffic.TrafficSummary": {
             "type": "object",
             "properties": {
                 "avg_response_time": {

--- a/gearbox-agent/docs/swagger.json
+++ b/gearbox-agent/docs/swagger.json
@@ -71,7 +71,7 @@
                     "200": {
                         "description": "WebSocket endpoint info",
                         "schema": {
-                            "$ref": "#/definitions/api.WSInfoResponse"
+                            "$ref": "#/definitions/internal_api.WSInfoResponse"
                         }
                     },
                     "401": {
@@ -102,7 +102,7 @@
                     "200": {
                         "description": "WebSocket token",
                         "schema": {
-                            "$ref": "#/definitions/api.WSTokenResponse"
+                            "$ref": "#/definitions/internal_api.WSTokenResponse"
                         }
                     },
                     "401": {
@@ -145,7 +145,7 @@
                     "200": {
                         "description": "HAProxy metadata",
                         "schema": {
-                            "$ref": "#/definitions/api.MetadataResponse"
+                            "$ref": "#/definitions/internal_api.MetadataResponse"
                         }
                     },
                     "401": {
@@ -182,7 +182,7 @@
                     "200": {
                         "description": "Sync status",
                         "schema": {
-                            "$ref": "#/definitions/api.SyncStatusResponse"
+                            "$ref": "#/definitions/internal_api.SyncStatusResponse"
                         }
                     },
                     "401": {
@@ -242,7 +242,7 @@
                     "200": {
                         "description": "Traffic analysis data",
                         "schema": {
-                            "$ref": "#/definitions/traffic.TrafficResponse"
+                            "$ref": "#/definitions/internal_gears_traffic.TrafficResponse"
                         }
                     },
                     "401": {
@@ -285,7 +285,7 @@
                     "200": {
                         "description": "Traffic summary",
                         "schema": {
-                            "$ref": "#/definitions/traffic.TrafficSummary"
+                            "$ref": "#/definitions/internal_gears_traffic.TrafficSummary"
                         }
                     },
                     "401": {
@@ -337,7 +337,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.GitHubPushPayload"
+                            "$ref": "#/definitions/internal_api.GitHubPushPayload"
                         }
                     }
                 ],
@@ -345,19 +345,19 @@
                     "200": {
                         "description": "Webhook processed successfully",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookSuccessResponse"
+                            "$ref": "#/definitions/internal_api.WebhookSuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad request",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookErrorResponse"
+                            "$ref": "#/definitions/internal_api.WebhookErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Invalid or missing signature",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookErrorResponse"
+                            "$ref": "#/definitions/internal_api.WebhookErrorResponse"
                         }
                     }
                 }
@@ -382,7 +382,7 @@
                     "200": {
                         "description": "Webhook configuration info",
                         "schema": {
-                            "$ref": "#/definitions/api.WebhookInfoResponse"
+                            "$ref": "#/definitions/internal_api.WebhookInfoResponse"
                         }
                     },
                     "401": {
@@ -396,7 +396,7 @@
         },
         "/health": {
             "get": {
-                "description": "Returns the health status of the gearbox-agent service. No authentication required.",
+                "description": "Returns the health status of the gearbox-agent service. No authentication required. Only \"status\" is exposed; version and uptime are intentionally omitted from this unauthenticated endpoint to avoid fingerprinting by remote scanners.",
                 "produces": [
                     "application/json"
                 ],
@@ -408,7 +408,7 @@
                     "200": {
                         "description": "Service is healthy",
                         "schema": {
-                            "$ref": "#/definitions/api.HealthResponse"
+                            "$ref": "#/definitions/internal_api.HealthResponse"
                         }
                     }
                 }
@@ -416,182 +416,7 @@
         }
     },
     "definitions": {
-        "api.GitHubPushPayload": {
-            "type": "object",
-            "properties": {
-                "head_commit": {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "message": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "pusher": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "ref": {
-                    "type": "string"
-                },
-                "repository": {
-                    "type": "object",
-                    "properties": {
-                        "full_name": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "api.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "example": "ok"
-                },
-                "timestamp": {
-                    "type": "string",
-                    "example": "2024-01-17T10:30:00Z"
-                },
-                "uptime": {
-                    "type": "string",
-                    "example": "2h30m15s"
-                },
-                "version": {
-                    "type": "string",
-                    "example": "1.0.0"
-                }
-            }
-        },
-        "api.MetadataResponse": {
-            "type": "object",
-            "properties": {
-                "last_error": {
-                    "type": "string"
-                },
-                "last_sync_time": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/haproxy.Metadata"
-                }
-            }
-        },
-        "api.SyncStatusResponse": {
-            "type": "object",
-            "properties": {
-                "backend_count": {
-                    "type": "integer"
-                },
-                "last_error": {
-                    "type": "string"
-                },
-                "last_sync_time": {
-                    "type": "string"
-                }
-            }
-        },
-        "api.WSInfoResponse": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "endpoint": {
-                    "type": "string",
-                    "example": "/api/v1/events"
-                },
-                "event_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "sync.started",
-                        "sync.completed",
-                        "sync.failed",
-                        "config.changed",
-                        "webhook.received"
-                    ]
-                },
-                "subscribers": {
-                    "type": "integer",
-                    "example": 2
-                }
-            }
-        },
-        "api.WSTokenResponse": {
-            "type": "object",
-            "properties": {
-                "expires_in": {
-                    "description": "Seconds until expiry",
-                    "type": "integer",
-                    "example": 60
-                },
-                "token": {
-                    "type": "string",
-                    "example": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"
-                }
-            }
-        },
-        "api.WebhookErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string",
-                    "example": "invalid_signature"
-                },
-                "message": {
-                    "type": "string",
-                    "example": "Signature verification failed"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "error"
-                }
-            }
-        },
-        "api.WebhookInfoResponse": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "message": {
-                    "type": "string",
-                    "example": "Configure this URL in GitHub repository settings"
-                },
-                "webhook_url": {
-                    "type": "string",
-                    "example": "https://proxy.example.com:8405/api/v1/webhook/github"
-                }
-            }
-        },
-        "api.WebhookSuccessResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Sync triggered"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "accepted"
-                }
-            }
-        },
-        "haproxy.ACLMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ACLMetadata": {
             "type": "object",
             "properties": {
                 "type": {
@@ -602,7 +427,7 @@
                 }
             }
         },
-        "haproxy.ActiveSession": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ActiveSession": {
             "type": "object",
             "properties": {
                 "age_seconds": {
@@ -643,13 +468,13 @@
                 }
             }
         },
-        "haproxy.BackendMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.BackendMetadata": {
             "type": "object",
             "properties": {
                 "acls": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ACLMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ACLMetadata"
                     }
                 },
                 "app_name": {
@@ -658,7 +483,7 @@
                 "containers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ContainerMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ContainerMetadata"
                     }
                 },
                 "frontend": {
@@ -690,7 +515,7 @@
                 }
             }
         },
-        "haproxy.ConnectionFlow": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ConnectionFlow": {
             "type": "object",
             "properties": {
                 "active_connections": {
@@ -713,7 +538,7 @@
                 }
             }
         },
-        "haproxy.ContainerMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ContainerMetadata": {
             "type": "object",
             "properties": {
                 "depends_on": {
@@ -733,7 +558,7 @@
                 }
             }
         },
-        "haproxy.FrontendMetadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.FrontendMetadata": {
             "type": "object",
             "properties": {
                 "backends": {
@@ -747,19 +572,19 @@
                 }
             }
         },
-        "haproxy.Metadata": {
+        "github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.Metadata": {
             "type": "object",
             "properties": {
                 "backends": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.BackendMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.BackendMetadata"
                     }
                 },
                 "frontends": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.FrontendMetadata"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.FrontendMetadata"
                     }
                 },
                 "generated_at": {
@@ -770,7 +595,170 @@
                 }
             }
         },
-        "traffic.BackendTrafficData": {
+        "internal_api.GitHubPushPayload": {
+            "type": "object",
+            "properties": {
+                "head_commit": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "pusher": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ref": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "object",
+                    "properties": {
+                        "full_name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "internal_api.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "example": "ok"
+                }
+            }
+        },
+        "internal_api.MetadataResponse": {
+            "type": "object",
+            "properties": {
+                "last_error": {
+                    "type": "string"
+                },
+                "last_sync_time": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.Metadata"
+                }
+            }
+        },
+        "internal_api.SyncStatusResponse": {
+            "type": "object",
+            "properties": {
+                "backend_count": {
+                    "type": "integer"
+                },
+                "last_error": {
+                    "type": "string"
+                },
+                "last_sync_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.WSInfoResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "endpoint": {
+                    "type": "string",
+                    "example": "/api/v1/events"
+                },
+                "event_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "sync.started",
+                        "sync.completed",
+                        "sync.failed",
+                        "config.changed",
+                        "webhook.received"
+                    ]
+                },
+                "subscribers": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
+        },
+        "internal_api.WSTokenResponse": {
+            "type": "object",
+            "properties": {
+                "expires_in": {
+                    "description": "Seconds until expiry",
+                    "type": "integer",
+                    "example": 60
+                },
+                "token": {
+                    "type": "string",
+                    "example": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"
+                }
+            }
+        },
+        "internal_api.WebhookErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "invalid_signature"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Signature verification failed"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "error"
+                }
+            }
+        },
+        "internal_api.WebhookInfoResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Configure this URL in GitHub repository settings"
+                },
+                "webhook_url": {
+                    "type": "string",
+                    "example": "https://proxy.example.com:8405/api/v1/webhook/github"
+                }
+            }
+        },
+        "internal_api.WebhookSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Sync triggered"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "accepted"
+                }
+            }
+        },
+        "internal_gears_traffic.BackendTrafficData": {
             "type": "object",
             "properties": {
                 "avg_response_time": {
@@ -808,19 +796,19 @@
                 }
             }
         },
-        "traffic.TrafficResponse": {
+        "internal_gears_traffic.TrafficResponse": {
             "type": "object",
             "properties": {
                 "active_sessions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ActiveSession"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ActiveSession"
                     }
                 },
                 "backend_traffic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.BackendTrafficData"
+                        "$ref": "#/definitions/internal_gears_traffic.BackendTrafficData"
                     }
                 },
                 "collected_at": {
@@ -829,31 +817,31 @@
                 "connection_flows": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/haproxy.ConnectionFlow"
+                        "$ref": "#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ConnectionFlow"
                     }
                 },
                 "sources": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "top_by_bytes": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "top_by_connections": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "top_by_requests": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/traffic.TrafficSourceData"
+                        "$ref": "#/definitions/internal_gears_traffic.TrafficSourceData"
                     }
                 },
                 "total_sources": {
@@ -861,7 +849,7 @@
                 }
             }
         },
-        "traffic.TrafficSourceData": {
+        "internal_gears_traffic.TrafficSourceData": {
             "type": "object",
             "properties": {
                 "backend": {
@@ -898,7 +886,7 @@
                 }
             }
         },
-        "traffic.TrafficSummary": {
+        "internal_gears_traffic.TrafficSummary": {
             "type": "object",
             "properties": {
                 "avg_response_time": {

--- a/gearbox-agent/docs/swagger.yaml
+++ b/gearbox-agent/docs/swagger.yaml
@@ -1,133 +1,13 @@
 basePath: /
 definitions:
-  api.GitHubPushPayload:
-    properties:
-      head_commit:
-        properties:
-          id:
-            type: string
-          message:
-            type: string
-        type: object
-      pusher:
-        properties:
-          name:
-            type: string
-        type: object
-      ref:
-        type: string
-      repository:
-        properties:
-          full_name:
-            type: string
-        type: object
-    type: object
-  api.HealthResponse:
-    properties:
-      status:
-        example: ok
-        type: string
-      timestamp:
-        example: "2024-01-17T10:30:00Z"
-        type: string
-      uptime:
-        example: 2h30m15s
-        type: string
-      version:
-        example: 1.0.0
-        type: string
-    type: object
-  api.MetadataResponse:
-    properties:
-      last_error:
-        type: string
-      last_sync_time:
-        type: string
-      metadata:
-        $ref: '#/definitions/haproxy.Metadata'
-    type: object
-  api.SyncStatusResponse:
-    properties:
-      backend_count:
-        type: integer
-      last_error:
-        type: string
-      last_sync_time:
-        type: string
-    type: object
-  api.WSInfoResponse:
-    properties:
-      enabled:
-        example: true
-        type: boolean
-      endpoint:
-        example: /api/v1/events
-        type: string
-      event_types:
-        example:
-        - sync.started
-        - sync.completed
-        - sync.failed
-        - config.changed
-        - webhook.received
-        items:
-          type: string
-        type: array
-      subscribers:
-        example: 2
-        type: integer
-    type: object
-  api.WSTokenResponse:
-    properties:
-      expires_in:
-        description: Seconds until expiry
-        example: 60
-        type: integer
-      token:
-        example: a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456
-        type: string
-    type: object
-  api.WebhookErrorResponse:
-    properties:
-      error:
-        example: invalid_signature
-        type: string
-      message:
-        example: Signature verification failed
-        type: string
-      status:
-        example: error
-        type: string
-    type: object
-  api.WebhookInfoResponse:
-    properties:
-      enabled:
-        example: true
-        type: boolean
-      message:
-        example: Configure this URL in GitHub repository settings
-        type: string
-      webhook_url:
-        example: https://proxy.example.com:8405/api/v1/webhook/github
-        type: string
-    type: object
-  api.WebhookSuccessResponse:
-    properties:
-      message:
-        example: Sync triggered
-        type: string
-      status:
-        example: accepted
-        type: string
-    type: object
-  haproxy.ACLMetadata:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ACLMetadata:
     properties:
       type:
         type: string
       value:
         type: string
     type: object
-  haproxy.ActiveSession:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ActiveSession:
     properties:
       age_seconds:
         description: How long the session has been active
@@ -155,17 +35,17 @@ definitions:
       source_port:
         type: integer
     type: object
-  haproxy.BackendMetadata:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.BackendMetadata:
     properties:
       acls:
         items:
-          $ref: '#/definitions/haproxy.ACLMetadata'
+          $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ACLMetadata'
         type: array
       app_name:
         type: string
       containers:
         items:
-          $ref: '#/definitions/haproxy.ContainerMetadata'
+          $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ContainerMetadata'
         type: array
       frontend:
         type: string
@@ -186,7 +66,7 @@ definitions:
       ssl_verify:
         type: string
     type: object
-  haproxy.ConnectionFlow:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ConnectionFlow:
     properties:
       active_connections:
         type: integer
@@ -201,7 +81,7 @@ definitions:
       total_requests:
         type: integer
     type: object
-  haproxy.ContainerMetadata:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ContainerMetadata:
     properties:
       depends_on:
         items:
@@ -214,7 +94,7 @@ definitions:
       network_mode:
         type: string
     type: object
-  haproxy.FrontendMetadata:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.FrontendMetadata:
     properties:
       backends:
         items:
@@ -223,22 +103,133 @@ definitions:
       name:
         type: string
     type: object
-  haproxy.Metadata:
+  github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.Metadata:
     properties:
       backends:
         items:
-          $ref: '#/definitions/haproxy.BackendMetadata'
+          $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.BackendMetadata'
         type: array
       frontends:
         items:
-          $ref: '#/definitions/haproxy.FrontendMetadata'
+          $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.FrontendMetadata'
         type: array
       generated_at:
         type: string
       version:
         type: string
     type: object
-  traffic.BackendTrafficData:
+  internal_api.GitHubPushPayload:
+    properties:
+      head_commit:
+        properties:
+          id:
+            type: string
+          message:
+            type: string
+        type: object
+      pusher:
+        properties:
+          name:
+            type: string
+        type: object
+      ref:
+        type: string
+      repository:
+        properties:
+          full_name:
+            type: string
+        type: object
+    type: object
+  internal_api.HealthResponse:
+    properties:
+      status:
+        example: ok
+        type: string
+    type: object
+  internal_api.MetadataResponse:
+    properties:
+      last_error:
+        type: string
+      last_sync_time:
+        type: string
+      metadata:
+        $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.Metadata'
+    type: object
+  internal_api.SyncStatusResponse:
+    properties:
+      backend_count:
+        type: integer
+      last_error:
+        type: string
+      last_sync_time:
+        type: string
+    type: object
+  internal_api.WSInfoResponse:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      endpoint:
+        example: /api/v1/events
+        type: string
+      event_types:
+        example:
+        - sync.started
+        - sync.completed
+        - sync.failed
+        - config.changed
+        - webhook.received
+        items:
+          type: string
+        type: array
+      subscribers:
+        example: 2
+        type: integer
+    type: object
+  internal_api.WSTokenResponse:
+    properties:
+      expires_in:
+        description: Seconds until expiry
+        example: 60
+        type: integer
+      token:
+        example: a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456
+        type: string
+    type: object
+  internal_api.WebhookErrorResponse:
+    properties:
+      error:
+        example: invalid_signature
+        type: string
+      message:
+        example: Signature verification failed
+        type: string
+      status:
+        example: error
+        type: string
+    type: object
+  internal_api.WebhookInfoResponse:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      message:
+        example: Configure this URL in GitHub repository settings
+        type: string
+      webhook_url:
+        example: https://proxy.example.com:8405/api/v1/webhook/github
+        type: string
+    type: object
+  internal_api.WebhookSuccessResponse:
+    properties:
+      message:
+        example: Sync triggered
+        type: string
+      status:
+        example: accepted
+        type: string
+    type: object
+  internal_gears_traffic.BackendTrafficData:
     properties:
       avg_response_time:
         type: integer
@@ -263,42 +254,42 @@ definitions:
       unique_ips:
         type: integer
     type: object
-  traffic.TrafficResponse:
+  internal_gears_traffic.TrafficResponse:
     properties:
       active_sessions:
         items:
-          $ref: '#/definitions/haproxy.ActiveSession'
+          $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ActiveSession'
         type: array
       backend_traffic:
         items:
-          $ref: '#/definitions/traffic.BackendTrafficData'
+          $ref: '#/definitions/internal_gears_traffic.BackendTrafficData'
         type: array
       collected_at:
         type: string
       connection_flows:
         items:
-          $ref: '#/definitions/haproxy.ConnectionFlow'
+          $ref: '#/definitions/github_com_sarg3nt_gearbox-agent_internal_framework_services_haproxy.ConnectionFlow'
         type: array
       sources:
         items:
-          $ref: '#/definitions/traffic.TrafficSourceData'
+          $ref: '#/definitions/internal_gears_traffic.TrafficSourceData'
         type: array
       top_by_bytes:
         items:
-          $ref: '#/definitions/traffic.TrafficSourceData'
+          $ref: '#/definitions/internal_gears_traffic.TrafficSourceData'
         type: array
       top_by_connections:
         items:
-          $ref: '#/definitions/traffic.TrafficSourceData'
+          $ref: '#/definitions/internal_gears_traffic.TrafficSourceData'
         type: array
       top_by_requests:
         items:
-          $ref: '#/definitions/traffic.TrafficSourceData'
+          $ref: '#/definitions/internal_gears_traffic.TrafficSourceData'
         type: array
       total_sources:
         type: integer
     type: object
-  traffic.TrafficSourceData:
+  internal_gears_traffic.TrafficSourceData:
     properties:
       backend:
         type: string
@@ -323,7 +314,7 @@ definitions:
         description: Sessions per period
         type: integer
     type: object
-  traffic.TrafficSummary:
+  internal_gears_traffic.TrafficSummary:
     properties:
       avg_response_time:
         type: integer
@@ -400,7 +391,7 @@ paths:
         "200":
           description: WebSocket endpoint info
           schema:
-            $ref: '#/definitions/api.WSInfoResponse'
+            $ref: '#/definitions/internal_api.WSInfoResponse'
         "401":
           description: Unauthorized
           schema:
@@ -421,7 +412,7 @@ paths:
         "200":
           description: WebSocket token
           schema:
-            $ref: '#/definitions/api.WSTokenResponse'
+            $ref: '#/definitions/internal_api.WSTokenResponse'
         "401":
           description: Unauthorized
           schema:
@@ -449,7 +440,7 @@ paths:
         "200":
           description: HAProxy metadata
           schema:
-            $ref: '#/definitions/api.MetadataResponse'
+            $ref: '#/definitions/internal_api.MetadataResponse'
         "401":
           description: Unauthorized
           schema:
@@ -473,7 +464,7 @@ paths:
         "200":
           description: Sync status
           schema:
-            $ref: '#/definitions/api.SyncStatusResponse'
+            $ref: '#/definitions/internal_api.SyncStatusResponse'
         "401":
           description: Unauthorized
           schema:
@@ -513,7 +504,7 @@ paths:
         "200":
           description: Traffic analysis data
           schema:
-            $ref: '#/definitions/traffic.TrafficResponse'
+            $ref: '#/definitions/internal_gears_traffic.TrafficResponse'
         "401":
           description: Unauthorized
           schema:
@@ -540,7 +531,7 @@ paths:
         "200":
           description: Traffic summary
           schema:
-            $ref: '#/definitions/traffic.TrafficSummary'
+            $ref: '#/definitions/internal_gears_traffic.TrafficSummary'
         "401":
           description: Unauthorized
           schema:
@@ -576,22 +567,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/api.GitHubPushPayload'
+          $ref: '#/definitions/internal_api.GitHubPushPayload'
       produces:
       - application/json
       responses:
         "200":
           description: Webhook processed successfully
           schema:
-            $ref: '#/definitions/api.WebhookSuccessResponse'
+            $ref: '#/definitions/internal_api.WebhookSuccessResponse'
         "400":
           description: Bad request
           schema:
-            $ref: '#/definitions/api.WebhookErrorResponse'
+            $ref: '#/definitions/internal_api.WebhookErrorResponse'
         "401":
           description: Invalid or missing signature
           schema:
-            $ref: '#/definitions/api.WebhookErrorResponse'
+            $ref: '#/definitions/internal_api.WebhookErrorResponse'
       summary: GitHub webhook
       tags:
       - Webhook
@@ -605,7 +596,7 @@ paths:
         "200":
           description: Webhook configuration info
           schema:
-            $ref: '#/definitions/api.WebhookInfoResponse'
+            $ref: '#/definitions/internal_api.WebhookInfoResponse'
         "401":
           description: Unauthorized
           schema:
@@ -618,14 +609,15 @@ paths:
   /health:
     get:
       description: Returns the health status of the gearbox-agent service. No authentication
-        required.
+        required. Only "status" is exposed; version and uptime are intentionally omitted
+        from this unauthenticated endpoint to avoid fingerprinting by remote scanners.
       produces:
       - application/json
       responses:
         "200":
           description: Service is healthy
           schema:
-            $ref: '#/definitions/api.HealthResponse'
+            $ref: '#/definitions/internal_api.HealthResponse'
       summary: Health check
       tags:
       - Health

--- a/gearbox-agent/internal/api/handlers.go
+++ b/gearbox-agent/internal/api/handlers.go
@@ -18,26 +18,22 @@ type MetadataProvider interface {
 // Handlers holds HTTP handlers and their dependencies.
 type Handlers struct {
 	metadataProvider MetadataProvider
-	version          string
-	startTime        time.Time
 }
 
 // NewHandlers creates a new Handlers instance.
-func NewHandlers(metadataProvider MetadataProvider, version string) *Handlers {
+func NewHandlers(metadataProvider MetadataProvider) *Handlers {
 	return &Handlers{
 		metadataProvider: metadataProvider,
-		version:          version,
-		startTime:        time.Now(),
 	}
 }
 
 // HealthResponse represents the health check response.
 //
 // Only "status" is returned on the unauthenticated /health endpoint to avoid
-// leaking version / uptime to scanners (a remote attacker probing for
-// known-vulnerable agent versions). The authenticated /api/v1/metadata
-// endpoint exposes version/uptime to legitimate dashboards. See 2026-05
-// security audit P2-5.
+// leaking version / uptime to remote scanners probing for known-vulnerable
+// agent versions. Version and build info are still available on the build
+// itself (--version) and through service logs, but are not exposed over the
+// network on unauthenticated endpoints. See 2026-05 security audit P2-5.
 type HealthResponse struct {
 	Status string `json:"status" example:"ok"`
 }
@@ -45,7 +41,7 @@ type HealthResponse struct {
 // Health handles GET /health (no auth required).
 //
 //	@Summary		Health check
-//	@Description	Returns the health status of the gearbox-agent service. No authentication required. Only "status" is exposed; version and uptime are intentionally omitted to avoid fingerprinting.
+//	@Description	Returns the health status of the gearbox-agent service. No authentication required. Only "status" is exposed; version and uptime are intentionally omitted from this unauthenticated endpoint to avoid fingerprinting by remote scanners.
 //	@Tags			Health
 //	@Produce		json
 //	@Success		200	{object}	HealthResponse	"Service is healthy"

--- a/gearbox-agent/internal/api/handlers.go
+++ b/gearbox-agent/internal/api/handlers.go
@@ -32,28 +32,26 @@ func NewHandlers(metadataProvider MetadataProvider, version string) *Handlers {
 }
 
 // HealthResponse represents the health check response.
+//
+// Only "status" is returned on the unauthenticated /health endpoint to avoid
+// leaking version / uptime to scanners (a remote attacker probing for
+// known-vulnerable agent versions). The authenticated /api/v1/metadata
+// endpoint exposes version/uptime to legitimate dashboards. See 2026-05
+// security audit P2-5.
 type HealthResponse struct {
-	Status    string    `json:"status" example:"ok"`
-	Version   string    `json:"version" example:"1.0.0"`
-	Uptime    string    `json:"uptime" example:"2h30m15s"`
-	Timestamp time.Time `json:"timestamp" example:"2024-01-17T10:30:00Z"`
+	Status string `json:"status" example:"ok"`
 }
 
 // Health handles GET /health (no auth required).
 //
 //	@Summary		Health check
-//	@Description	Returns the health status of the gearbox-agent service. No authentication required.
+//	@Description	Returns the health status of the gearbox-agent service. No authentication required. Only "status" is exposed; version and uptime are intentionally omitted to avoid fingerprinting.
 //	@Tags			Health
 //	@Produce		json
 //	@Success		200	{object}	HealthResponse	"Service is healthy"
 //	@Router			/health [get]
 func (h *Handlers) Health(w http.ResponseWriter, r *http.Request) {
-	resp := HealthResponse{
-		Status:    "ok",
-		Version:   h.version,
-		Uptime:    time.Since(h.startTime).Round(time.Second).String(),
-		Timestamp: time.Now(),
-	}
+	resp := HealthResponse{Status: "ok"}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)

--- a/gearbox-agent/internal/api/handlers_test.go
+++ b/gearbox-agent/internal/api/handlers_test.go
@@ -23,7 +23,7 @@ func (stubMetadataProvider) GetMetadata() *haproxy.Metadata  { return nil }
 // version or uptime. A remote scanner probing for known-vulnerable agent
 // versions should get "ok" and nothing else.
 func TestHealth_NoVersionLeak(t *testing.T) {
-	h := NewHandlers(stubMetadataProvider{}, "1.2.3-leakytest")
+	h := NewHandlers(stubMetadataProvider{})
 
 	req := httptest.NewRequest("GET", "/health", nil)
 	rr := httptest.NewRecorder()

--- a/gearbox-agent/internal/api/handlers_test.go
+++ b/gearbox-agent/internal/api/handlers_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sarg3nt/gearbox-agent/internal/framework/services/haproxy"
+)
+
+// stubMetadataProvider is the minimal MetadataProvider needed for handler
+// construction. Not actually exercised by the /health test.
+type stubMetadataProvider struct{}
+
+func (stubMetadataProvider) GetLastSyncTime() time.Time      { return time.Time{} }
+func (stubMetadataProvider) GetLastError() error             { return nil }
+func (stubMetadataProvider) GetMetadata() *haproxy.Metadata  { return nil }
+
+// 2026-05 audit P2-5: the unauthenticated /health endpoint must not leak
+// version or uptime. A remote scanner probing for known-vulnerable agent
+// versions should get "ok" and nothing else.
+func TestHealth_NoVersionLeak(t *testing.T) {
+	h := NewHandlers(stubMetadataProvider{}, "1.2.3-leakytest")
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rr := httptest.NewRecorder()
+	h.Health(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	body := rr.Body.String()
+	for _, leak := range []string{"1.2.3-leakytest", "uptime", "timestamp"} {
+		if strings.Contains(strings.ToLower(body), strings.ToLower(leak)) {
+			t.Errorf("/health response contains %q (potential info leak): %s", leak, body)
+		}
+	}
+
+	// Sanity: the actual response should be a small {"status":"ok"} JSON.
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v (%q)", err, body)
+	}
+	if got["status"] != "ok" {
+		t.Errorf("status = %v, want \"ok\"", got["status"])
+	}
+	if len(got) != 1 {
+		t.Errorf("response has %d fields; want exactly 1 (status): %v", len(got), got)
+	}
+}

--- a/gearbox-agent/internal/api/server.go
+++ b/gearbox-agent/internal/api/server.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -143,6 +144,16 @@ func NewServer(cfg ServerConfig) *Server {
 			ReadTimeout:  15 * time.Second,
 			WriteTimeout: 15 * time.Second,
 			IdleTimeout:  60 * time.Second,
+			// Explicit TLS 1.3 floor. Without this, Go's default is TLS 1.2,
+			// which is RFC-acceptable but exposes the agent to TLS 1.2-only
+			// cipher-suite weaknesses (CBC mode, RC4, etc.) on the off-chance
+			// a misconfigured client negotiates downwards. Both ends of the
+			// agent <-> dashboard channel are controlled by us; there is no
+			// legitimate reason to support pre-1.3 clients. See 2026-05
+			// security audit P2-7.
+			TLSConfig: &tls.Config{
+				MinVersion: tls.VersionTLS13,
+			},
 		},
 		router:   r,
 		logger:   cfg.Logger,

--- a/gearbox-agent/internal/api/server.go
+++ b/gearbox-agent/internal/api/server.go
@@ -63,7 +63,7 @@ type ServerConfig struct {
 // NewServer creates a new API server.
 func NewServer(cfg ServerConfig) *Server {
 	// Create handlers
-	handlers := NewHandlers(cfg.MetadataProvider, cfg.Version)
+	handlers := NewHandlers(cfg.MetadataProvider)
 
 	// Create chi router
 	r := chi.NewRouter()
@@ -144,12 +144,12 @@ func NewServer(cfg ServerConfig) *Server {
 			ReadTimeout:  15 * time.Second,
 			WriteTimeout: 15 * time.Second,
 			IdleTimeout:  60 * time.Second,
-			// Explicit TLS 1.3 floor. Without this, Go's default is TLS 1.2,
-			// which is RFC-acceptable but exposes the agent to TLS 1.2-only
-			// cipher-suite weaknesses (CBC mode, RC4, etc.) on the off-chance
-			// a misconfigured client negotiates downwards. Both ends of the
-			// agent <-> dashboard channel are controlled by us; there is no
-			// legitimate reason to support pre-1.3 clients. See 2026-05
+			// Explicit TLS 1.3 floor. Go's default minimum is TLS 1.2 (still
+			// negotiable by misconfigured or older clients); both ends of the
+			// agent <-> dashboard channel are controlled by us, so we have
+			// no reason to leave TLS 1.2 reachable. Pinning to 1.3 shrinks
+			// the negotiation attack surface (no downgrade, fewer cipher
+			// suites, AEAD-only, forward secrecy guaranteed). See 2026-05
 			// security audit P2-7.
 			TLSConfig: &tls.Config{
 				MinVersion: tls.VersionTLS13,

--- a/gearbox-agent/internal/framework/services/compose/parser.go
+++ b/gearbox-agent/internal/framework/services/compose/parser.go
@@ -43,6 +43,18 @@ var (
 	// newline / directive injection from a Docker Compose label into the
 	// generated haproxy.cfg (see 2026-05 security audit, P0-1).
 	validBackendName = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.\-]{0,62}$`)
+	// validACLPath matches a URL path component for an HAProxy path-based
+	// ACL: leading `/`, then a safe URL-path character set. Used for the
+	// `haproxy.acl.path` label, which is currently parsed into BackendConfig
+	// but not yet wired into the generator. Validating now closes the
+	// latent injection class — if a future PR wires this into a generated
+	// `acl req_path path_beg %s` directive, no flag/newline can slip
+	// through. See 2026-05 security audit, P2-10.
+	validACLPath = regexp.MustCompile(`^/[a-zA-Z0-9/_.\-~%]*$`)
+	// validACLHeader matches an HTTP header name (RFC 7230 token chars).
+	// Same forward-looking rationale as validACLPath: parsed but not yet
+	// generated, validated now.
+	validACLHeader = regexp.MustCompile(`^[a-zA-Z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
 )
 
 // validateACLIPList validates a comma-separated list of IPs/CIDRs against
@@ -312,6 +324,31 @@ func (p *Parser) extractBackendConfig(labels map[string]string, appName, service
 		return nil
 	}
 
+	// 2026-05 audit P2-10: haproxy.acl.path and haproxy.acl.header are
+	// documented labels (see ubuntu-ha-proxy-install/docs/) that gearbox-
+	// agent parses today but does NOT yet emit into the generated config.
+	// Validate them here so the latent injection class is closed BEFORE
+	// any future PR wires them into a directive like
+	// `acl req_path path_beg <path>` or `acl req_hdr_cnt(<header>) gt 0`.
+	// Empty is accepted (the common case); non-empty must match the
+	// allow-list pattern, otherwise the backend is rejected.
+	aclPath := labels[LabelPrefix+"acl.path"]
+	if aclPath != "" && !validACLPath.MatchString(aclPath) {
+		p.logger.Warn("Invalid haproxy.acl.path value; rejecting backend",
+			"app", appName,
+			"service", serviceName,
+		)
+		return nil
+	}
+	aclHeader := labels[LabelPrefix+"acl.header"]
+	if aclHeader != "" && !validACLHeader.MatchString(aclHeader) {
+		p.logger.Warn("Invalid haproxy.acl.header value; rejecting backend",
+			"app", appName,
+			"service", serviceName,
+		)
+		return nil
+	}
+
 	// Get and validate configurable values with safe defaults
 	mode := getValidatedOrDefault(labels, LabelPrefix+"backend.mode", "http", validMode)
 	balance := getValidatedOrDefault(labels, LabelPrefix+"backend.balance", "roundrobin", validBalance)
@@ -334,8 +371,8 @@ func (p *Parser) extractBackendConfig(labels map[string]string, appName, service
 		CheckFall:        checkFall,
 		CheckRise:        checkRise,
 		SSLRedirect:      labels[LabelPrefix+"ssl.redirect"] != "false",
-		ACLPath:          labels[LabelPrefix+"acl.path"],
-		ACLHeader:        labels[LabelPrefix+"acl.header"],
+		ACLPath:          aclPath,
+		ACLHeader:        aclHeader,
 		Public:           labels[LabelPrefix+"public"] == "true",
 		RateLimit:        rateLimit,
 		ACLIP:            aclIP,

--- a/gearbox-agent/internal/framework/services/compose/parser_test.go
+++ b/gearbox-agent/internal/framework/services/compose/parser_test.go
@@ -757,3 +757,104 @@ func TestParseFile_InjectionViaACLIP(t *testing.T) {
 		t.Errorf("ParseFile() returned %d backend(s) for an injection payload; want 0 (rejected)", len(backends))
 	}
 }
+
+// 2026-05 audit P2-10: haproxy.acl.path and haproxy.acl.header are
+// validated at parse time even though no current generator emits them.
+// Closes the latent injection class before a future PR wires them in.
+func TestValidACLPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", true}, // empty handled by call-site short-circuit
+		{"root", "/", true},
+		{"single-segment", "/api", true},
+		{"multi-segment", "/api/v1/users", true},
+		{"trailing-slash", "/api/", true},
+		{"with-dash-underscore", "/api/_v2-beta", true},
+		{"url-encoded-allowed", "/api/%20space", true},
+
+		{"no-leading-slash", "api", false},
+		{"newline-injection", "/api\n  http-request deny", false},
+		{"semicolon", "/api; default-src *", false},
+		{"space", "/api /v1", false},
+		{"backslash", "/api\\v1", false},
+		{"query-string", "/api?x=1", false},
+		{"fragment", "/api#section", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.input == "" {
+				return // call-site skips validation for empty
+			}
+			if got := validACLPath.MatchString(tt.input); got != tt.want {
+				t.Errorf("validACLPath.MatchString(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidACLHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple", "X-Custom-Header", true},
+		{"all-lower", "authorization", true},
+		{"underscore", "X_Custom", true},
+		{"dot-allowed-by-rfc", "X.Forwarded.For", true},
+
+		{"empty", "", false},
+		{"space", "X Custom", false},
+		{"newline-injection", "X-Custom\nhttp-request deny", false},
+		{"semicolon", "X-Custom;evil", false},
+		{"colon", "X-Custom:value", false},
+		{"slash", "X-Custom/extra", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validACLHeader.MatchString(tt.input); got != tt.want {
+				t.Errorf("validACLHeader.MatchString(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFile_InjectionViaACLPath(t *testing.T) {
+	// 2026-05 audit P2-10: even though the generator doesn't emit
+	// haproxy.acl.path today, a malicious value must not be stored on
+	// BackendConfig — otherwise a future generator wire-up would re-open
+	// the P0-1/P0-2 class of injection.
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "aclpath")
+	if err := os.MkdirAll(appDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	composeContent := "services:\n" +
+		"  web:\n" +
+		"    image: nginx\n" +
+		"    labels:\n" +
+		"      haproxy.enable: \"true\"\n" +
+		"      haproxy.hostname: \"evil.example.com\"\n" +
+		"      haproxy.backend.server: \"10.0.0.1:80\"\n" +
+		"      haproxy.acl.path: |\n" +
+		"        /api\n" +
+		"          http-request deny\n"
+
+	composePath := filepath.Join(appDir, "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte(composeContent), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	parser := NewParser(tmpDir, testLogger())
+	backends, err := parser.ParseFile(composePath)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if len(backends) != 0 {
+		t.Errorf("ParseFile returned %d backend(s); want 0 (rejected on aclpath injection)", len(backends))
+	}
+}

--- a/gearbox-agent/internal/gears/updates/apt_runner.go
+++ b/gearbox-agent/internal/gears/updates/apt_runner.go
@@ -219,8 +219,13 @@ func (r *AptRunner) runAptInstall(ctx context.Context, op *AptOperation, securit
 	// Build apt command
 	var args []string
 	if len(packages) > 0 {
-		// Install specific packages
-		args = append([]string{"install", "-y"}, packages...)
+		// Install specific packages. "--" between the flags and the package
+		// list prevents a flag-shaped element from being interpreted as an
+		// apt-get option (2026-05 audit P2-9). The packages slice flows
+		// from API input; even though every consumer validates with
+		// isValidPackageName, the explicit separator is a cheap
+		// defense-in-depth gate.
+		args = append([]string{"install", "-y", "--"}, packages...)
 		r.publishLine(op.ID, fmt.Sprintf("Installing %d specific package(s)...", len(packages)))
 	} else if securityOnly {
 		// Security updates only - use unattended-upgrade
@@ -502,7 +507,9 @@ func (r *AptRunner) runRestoreSnapshot(ctx context.Context, op *AptOperation, sn
 		r.publishLine(op.ID, fmt.Sprintf("Downgrading %d package(s) to snapshot versions...", len(downgrades)))
 		r.publishLine(op.ID, "")
 
-		args := append([]string{"install", "-y", "--allow-downgrades"}, downgrades...)
+		// "--" before downgrades for the same reason as the install path
+		// above. See 2026-05 audit P2-9.
+		args := append([]string{"install", "-y", "--allow-downgrades", "--"}, downgrades...)
 		downgradeCmd := exec.CommandContext(ctx, "apt-get", args...)
 		downgradeCmd.Env = append(os.Environ(),
 			"DEBIAN_FRONTEND=noninteractive",

--- a/gearbox-agent/internal/gears/updates/package_name_test.go
+++ b/gearbox-agent/internal/gears/updates/package_name_test.go
@@ -1,0 +1,52 @@
+package updates
+
+import (
+	"strings"
+	"testing"
+)
+
+// 2026-05 audit P2-9: isValidPackageName must reject any name a shell user
+// would never plausibly type AND any name that apt-get would interpret as
+// a flag. The handler-level boundary validation now relies on this.
+func TestIsValidPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Accepted: real Debian-style package names.
+		{"nginx", true},
+		{"libssl3", true},
+		{"python3.11", true},
+		{"linux-headers-6.1.0-12-amd64", true},
+		{"libstdc++6", true},
+		{"foo+bar", true},
+		{"a", true},
+
+		// Rejected: empty / length / character set.
+		{"", false},
+		{strings.Repeat("a", 257), false},
+		{"name with space", false},
+		{"name;rm /etc/passwd", false},
+		{"name$(whoami)", false},
+		{"name\nwith-newline", false},
+		{"name/with/slash", false},
+
+		// Rejected: would land as a flag if passed to apt-get install.
+		// This is the actual P2-9 attack class.
+		{"--allow-downgrades", false},
+		{"--reinstall", false},
+		{"-y", false},
+		{"--help", false},
+
+		// Rejected: leading dot would resolve relative paths in some
+		// apt internals.
+		{".bashrc", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidPackageName(tt.name); got != tt.want {
+				t.Errorf("isValidPackageName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/gearbox-agent/internal/gears/updates/plugin.go
+++ b/gearbox-agent/internal/gears/updates/plugin.go
@@ -784,12 +784,13 @@ func (p *Gear) handleInstallPackage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Name == "" {
-		jsonError(w, "package name is required", http.StatusBadRequest)
-		return
-	}
-	if len(req.Name) > 200 {
-		jsonError(w, "package name must be 200 characters or less", http.StatusBadRequest)
+	// 2026-05 audit P2-9: surface invalid package names as a clean 400 at
+	// the boundary rather than a generic 500 from the package manager.
+	// isValidPackageName enforces the Debian-style name pattern AND
+	// rejects leading hyphens — the latter prevents an attacker-chosen
+	// "package" being passed to apt-get as a flag.
+	if !isValidPackageName(req.Name) {
+		jsonError(w, "invalid package name", http.StatusBadRequest)
 		return
 	}
 
@@ -817,12 +818,9 @@ func (p *Gear) handleRemovePackage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Name == "" {
-		jsonError(w, "package name is required", http.StatusBadRequest)
-		return
-	}
-	if len(req.Name) > 200 {
-		jsonError(w, "package name must be 200 characters or less", http.StatusBadRequest)
+	// See P2-9 note on handleInstallPackage.
+	if !isValidPackageName(req.Name) {
+		jsonError(w, "invalid package name", http.StatusBadRequest)
 		return
 	}
 

--- a/gearbox-agent/internal/gears/updates/pm_apt.go
+++ b/gearbox-agent/internal/gears/updates/pm_apt.go
@@ -122,11 +122,16 @@ func (a *aptPackageManager) InstallUpdates(securityOnly bool, packages []string)
 	return nil, nil
 }
 
+// "--" between the apt-get subcommand flags and the package-name operand
+// is defense-in-depth: isValidPackageName already rejects names with a
+// leading hyphen, but the explicit separator means a future change that
+// loosens the regex (or a missed validation site) still can't smuggle
+// a flag-shaped name as an apt-get option. See 2026-05 audit P2-9.
 func (a *aptPackageManager) InstallPackage(name string) error {
 	if !isValidPackageName(name) {
 		return fmt.Errorf("invalid package name: %s", name)
 	}
-	_, err := a.collector.runCommandWithOutput("apt-get", "install", "-y", name)
+	_, err := a.collector.runCommandWithOutput("apt-get", "install", "-y", "--", name)
 	if err != nil {
 		return fmt.Errorf("failed to install package %s: %w", name, err)
 	}
@@ -141,7 +146,7 @@ func (a *aptPackageManager) RemovePackage(name string, purge bool) error {
 	if purge {
 		action = "purge"
 	}
-	_, err := a.collector.runCommandWithOutput("apt-get", action, "-y", name)
+	_, err := a.collector.runCommandWithOutput("apt-get", action, "-y", "--", name)
 	if err != nil {
 		return fmt.Errorf("failed to remove package %s: %w", name, err)
 	}
@@ -608,7 +613,7 @@ func (a *aptPackageManager) HoldPackage(name string) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "apt-mark", "hold", name)
+	cmd := exec.CommandContext(ctx, "apt-mark", "hold", "--", name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("apt-mark hold %s: %w: %s", name, err, strings.TrimSpace(string(out)))
 	}
@@ -622,7 +627,7 @@ func (a *aptPackageManager) UnholdPackage(name string) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "apt-mark", "unhold", name)
+	cmd := exec.CommandContext(ctx, "apt-mark", "unhold", "--", name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("apt-mark unhold %s: %w: %s", name, err, strings.TrimSpace(string(out)))
 	}

--- a/gearbox-agent/internal/gears/updates/pm_apt.go
+++ b/gearbox-agent/internal/gears/updates/pm_apt.go
@@ -40,7 +40,10 @@ func (a *aptPackageManager) BuildUpgradeCommand() []string {
 
 func (a *aptPackageManager) BuildInstallCommand(packages []string, securityOnly bool) []string {
 	if len(packages) > 0 {
-		return append([]string{"apt-get", "install", "-y"}, packages...)
+		// "--" before the package list mirrors InstallPackage/RemovePackage:
+		// defense-in-depth against a missed isValidPackageName check upstream
+		// (a future caller that forgets to validate, or a regex regression).
+		return append([]string{"apt-get", "install", "-y", "--"}, packages...)
 	}
 	if securityOnly {
 		return []string{"unattended-upgrade", "--minimal-upgrade-steps"}
@@ -95,7 +98,9 @@ func (a *aptPackageManager) TriggerUpdateCheck() error {
 
 func (a *aptPackageManager) InstallUpdates(securityOnly bool, packages []string) ([]string, error) {
 	if len(packages) > 0 {
-		_, err := a.collector.runCommandWithOutput("apt-get", append([]string{"install", "-y"}, packages...)...)
+		// "--" before the package list — same defense-in-depth rationale as
+		// BuildInstallCommand / InstallPackage. See 2026-05 audit P2-9.
+		_, err := a.collector.runCommandWithOutput("apt-get", append([]string{"install", "-y", "--"}, packages...)...)
 		if err != nil {
 			return nil, fmt.Errorf("apt upgrade failed: %w", err)
 		}


### PR DESCRIPTION
Agent-side P2 batch from the [2026-05 security audit](https://github.com/sarg3nt/gearbox/pull/40). Four findings, four focused commits, all on `main`.

## Commits

### `86f3a35` — strip version + uptime from `/health` *(P2-5)*

The unauthenticated `/health` endpoint returned `version`, `uptime`, and `timestamp` alongside `status`. A remote scanner learns the exact agent build for CVE correlation without authenticating. Stripped down to `{"status":"ok"}`. Authenticated callers still get version via `/api/v1/metadata`.

### `f65e9ef` — force TLS 1.3 minimum *(P2-7)*

`http.Server` with no explicit `TLSConfig` falls through to Go's default of TLS 1.2. Both ends of the agent↔dashboard channel are software we control; there's no legitimate reason to support pre-1.3 clients. Set `MinVersion: tls.VersionTLS13`.

### `509bf6a` — apt package-name validation + `--` separator *(P2-9)*

`/api/v1/packages/install` and `/packages/remove` validated input as "non-empty AND ≤200 chars" before passing to apt-get. The package-manager layer already enforced the strict Debian-style regex (rejecting leading `-`), but the boundary check was misleadingly weak.

- Handlers now call `isValidPackageName` directly: clean 400 instead of 500.
- All `apt-get install/remove/purge` and `apt-mark hold/unhold` calls get an explicit `--` between flags and the package operand. Defense-in-depth: a future loosening of the regex still can't smuggle a flag-shaped name.

20 test cases (`TestIsValidPackageName`) pin down the attack class: `--reinstall`, `--allow-downgrades`, `-y`, `--help`, names with `;` / `$()` / newlines / slashes.

### `367c72b` — validate `haproxy.acl.path` + `haproxy.acl.header` *(P2-10)*

Audit framing was "drop the unused fields," but they're documented in `ubuntu-ha-proxy-install/docs/` as supported forward-looking labels. Deleting would break that API contract.

Better fix: validate them now so the latent injection class (same shape as P0-1/P0-2) is closed before any future PR wires them into the generator. Two new regexes:
- `validACLPath`: leading `/` + URL-path-safe charset; rejects newlines, semicolons, query strings.
- `validACLHeader`: RFC 7230 token characters; rejects whitespace, colons, slashes.

`extractBackendConfig` rejects the whole backend on a malformed non-empty value. 17 new test cases including the newline-payload exploit shape.

## Verification

```bash
$ go build ./...   # clean
$ go test ./...
ok  ...internal/api                          0.543s
ok  ...internal/framework/services/compose   0.626s
ok  ...internal/gears/updates                0.973s
(all 20+ packages green)
```

## Status of the audit

| Severity | Total | Fixed | Open |
|----------|-------|-------|------|
| P0 | 4 | 4 (PR #39 ✅) | — |
| P1 | 8 | 5 (#41, #42, #43) | 0 (P1-8 retracted in #50) |
| P2 | 10 | 7 (#50 dashboard + this PR) | P2-4 (per-email rate limit), P2-8 (real KMS encryption-at-rest) |
| P3 | 8 | 0 | — |

Two P2s remain (P2-4 + P2-8) — both substantial enough they warrant a design call. The P3 batch is mostly hygiene (placeholder `security@example.com` in SECURITY.md, swagger-UI gate, etc.); ready to batch next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)