### PR TITLE
fix(security): P2-8 AES-256-GCM encryption-at-rest for on-disk secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -73,8 +73,13 @@ regexes = [
 # Allowlist - commits to ignore
 # 2fdb5ba: functional_test.go had an example API key value in a doc comment
 # (test-only, not a real credential — replaced with <YOUR_API_KEY> placeholder in a later commit)
+# 96bd383: aead_test.go added three 64-hex-char fixtures (plainSecret /
+# apiKey) to exercise the encryption-at-rest round-trip. A later commit
+# added inline //gitleaks:allow comments, but the gitleaks-action scans
+# the full PR diff range so the historical commit still trips the rule.
 commits = [
     "2fdb5ba0d2e8da23a6409527cdbf6696d90eb537",
+    "96bd38365b022aa8b9d78886dfd3eb16e644eecf",
 ]
 
 # Stopwords - tokens that if found will stop gitleaks

--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -92,6 +92,16 @@ func main() {
 		Level: logLevel,
 	}))
 
+	// Warn once at startup if secret-file encryption is not configured.
+	if ok, err := crypto.EncryptionConfigured(); err != nil {
+		fmt.Fprintf(os.Stderr, "Encryption key configuration error: %v\n", err)
+		os.Exit(1)
+	} else if !ok {
+		logger.Warn("Secret files are stored in plaintext. " +
+			"Set GEARBOX_AGENT_ENCRYPTION_KEY (64 hex chars, see 'openssl rand -hex 32') " +
+			"to enable AES-256-GCM encryption-at-rest.")
+	}
+
 	// Handle API key commands
 	if *showAPIKey {
 		key, err := crypto.ReadAPIKey(cfg.APIKeyPath)
@@ -109,7 +119,7 @@ func main() {
 			logger.Error("Failed to generate API key", "error", err)
 			os.Exit(1)
 		}
-		if err := os.WriteFile(cfg.APIKeyPath, []byte(key), crypto.APIKeyFilePerms); err != nil {
+		if err := crypto.WriteAPIKey(cfg.APIKeyPath, key); err != nil {
 			logger.Error("Failed to write API key", "error", err)
 			os.Exit(1)
 		}

--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -92,14 +92,12 @@ func main() {
 		Level: logLevel,
 	}))
 
-	// Warn once at startup if secret-file encryption is not configured.
-	if ok, err := crypto.EncryptionConfigured(); err != nil {
+	// Hard-fail early if GEARBOX_AGENT_ENCRYPTION_KEY is set but malformed,
+	// regardless of which subcommand we're about to run — one-shot CLI
+	// commands like --show-api-key need a usable key too.
+	if _, err := crypto.EncryptionConfigured(); err != nil {
 		fmt.Fprintf(os.Stderr, "Encryption key configuration error: %v\n", err)
 		os.Exit(1)
-	} else if !ok {
-		logger.Warn("Secret files are stored in plaintext. " +
-			"Set GEARBOX_AGENT_ENCRYPTION_KEY (64 hex chars, see 'openssl rand -hex 32') " +
-			"to enable AES-256-GCM encryption-at-rest.")
 	}
 
 	// Handle API key commands
@@ -178,6 +176,15 @@ func main() {
 		"commit", CommitSHA,
 		"built", BuildDate,
 	)
+
+	// Warn once at startup if secret-file encryption is not configured.
+	// Placed after one-shot flag handlers so it doesn't pollute their
+	// stdout output (e.g. --show-api-key piped to a clipboard tool).
+	if ok, _ := crypto.EncryptionConfigured(); !ok {
+		logger.Warn("Secret files are stored in plaintext. " +
+			"Set GEARBOX_AGENT_ENCRYPTION_KEY (64 hex chars, see 'openssl rand -hex 32') " +
+			"to enable AES-256-GCM encryption-at-rest.")
+	}
 
 	// Load or create API key
 	apiKey, isNewKey, err := crypto.LoadOrCreateAPIKey(cfg.APIKeyPath)

--- a/gearbox-agent/internal/framework/crypto/aead.go
+++ b/gearbox-agent/internal/framework/crypto/aead.go
@@ -1,0 +1,132 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// magic is the 4-byte header written at the start of every encrypted secret file.
+// Its presence tells the loader to decrypt rather than treat the file as plaintext.
+var magic = [4]byte{'G', 'B', 'E', '1'}
+
+// ErrKeyRequired is returned when an encrypted file is found but no encryption key
+// has been configured. Key loss means rotation — there is no recovery path.
+var ErrKeyRequired = errors.New(
+	"secret file is encrypted (GBE1) but GEARBOX_AGENT_ENCRYPTION_KEY is not set; " +
+		"set the key to decrypt, or rotate the secret (--rotate-api-key / --generate-webhook-secret)",
+)
+
+// KeyProvider supplies the 32-byte AES-256 key used to protect on-disk secrets.
+// Implementations include [EnvKeyProvider] (reads from an environment variable) and,
+// in future releases, cloud-KMS backends (see GitHub issue #54).
+type KeyProvider interface {
+	// Key returns the 32-byte AES-256 key, or nil if encryption is not configured.
+	// A nil key means secrets are stored as plaintext; a non-nil key means they are
+	// encrypted with AES-256-GCM.
+	Key() ([]byte, error)
+}
+
+// EnvKeyProvider reads the encryption key from an environment variable.
+// The variable must contain exactly 64 lowercase hex characters (32 bytes / 256 bits).
+// Generate a suitable value with: openssl rand -hex 32
+type EnvKeyProvider struct {
+	EnvVar string // environment variable name; default "GEARBOX_AGENT_ENCRYPTION_KEY"
+}
+
+// DefaultKeyProvider is the KeyProvider used by loadOrCreateSecret and readSecret
+// unless overridden in tests.
+var DefaultKeyProvider KeyProvider = &EnvKeyProvider{EnvVar: "GEARBOX_AGENT_ENCRYPTION_KEY"}
+
+// Key implements [KeyProvider]. Returns nil, nil when the variable is unset.
+func (e *EnvKeyProvider) Key() ([]byte, error) {
+	val := os.Getenv(e.EnvVar)
+	if val == "" {
+		return nil, nil
+	}
+	key, err := hex.DecodeString(val)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid hex value: %w", e.EnvVar, err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf(
+			"%s: must be exactly 64 hex characters (32 bytes); got %d bytes — generate with: openssl rand -hex 32",
+			e.EnvVar, len(key),
+		)
+	}
+	return key, nil
+}
+
+// EncryptionConfigured returns true when the default key provider has a key set.
+// Used at startup to emit a warning when encryption is not configured.
+func EncryptionConfigured() (bool, error) {
+	key, err := DefaultKeyProvider.Key()
+	if err != nil {
+		return false, err
+	}
+	return key != nil, nil
+}
+
+// isEncrypted returns true when data begins with the GBE1 magic header.
+func isEncrypted(data []byte) bool {
+	if len(data) < len(magic) {
+		return false
+	}
+	return data[0] == magic[0] && data[1] == magic[1] &&
+		data[2] == magic[2] && data[3] == magic[3]
+}
+
+// encryptSecret encrypts plaintext using AES-256-GCM and returns the
+// magic-prefixed blob: magic(4) + nonce(12) + GCM-ciphertext-with-tag.
+func encryptSecret(plaintext string, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+	sealed := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+
+	out := make([]byte, 0, len(magic)+len(nonce)+len(sealed))
+	out = append(out, magic[:]...)
+	out = append(out, nonce...)
+	out = append(out, sealed...)
+	return out, nil
+}
+
+// decryptSecret decrypts a blob produced by [encryptSecret].
+// data must start with the GBE1 magic header.
+func decryptSecret(data []byte, key []byte) (string, error) {
+	if !isEncrypted(data) {
+		return "", errors.New("decryptSecret: data does not start with GBE1 magic")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+	payload := data[len(magic):]
+	nonceSize := gcm.NonceSize()
+	if len(payload) < nonceSize {
+		return "", errors.New("decryptSecret: ciphertext too short")
+	}
+	plaintext, err := gcm.Open(nil, payload[:nonceSize], payload[nonceSize:], nil)
+	if err != nil {
+		return "", fmt.Errorf("gcm.Open: %w (key may be wrong or file corrupted)", err)
+	}
+	return string(plaintext), nil
+}

--- a/gearbox-agent/internal/framework/crypto/aead.go
+++ b/gearbox-agent/internal/framework/crypto/aead.go
@@ -17,9 +17,14 @@ var magic = [4]byte{'G', 'B', 'E', '1'}
 
 // ErrKeyRequired is returned when an encrypted file is found but no encryption key
 // has been configured. Key loss means rotation — there is no recovery path.
+//
+// Recovery: set GEARBOX_AGENT_ENCRYPTION_KEY to the correct value to decrypt;
+// or delete the file and re-generate (--rotate-api-key for the API key,
+// --generate-webhook-secret for the webhook secret — note the latter does
+// NOT overwrite an existing file, so you must rm it first).
 var ErrKeyRequired = errors.New(
 	"secret file is encrypted (GBE1) but GEARBOX_AGENT_ENCRYPTION_KEY is not set; " +
-		"set the key to decrypt, or rotate the secret (--rotate-api-key / --generate-webhook-secret)",
+		"set the key to decrypt, or delete the file and re-generate the secret",
 )
 
 // KeyProvider supplies the 32-byte AES-256 key used to protect on-disk secrets.
@@ -33,7 +38,8 @@ type KeyProvider interface {
 }
 
 // EnvKeyProvider reads the encryption key from an environment variable.
-// The variable must contain exactly 64 lowercase hex characters (32 bytes / 256 bits).
+// The variable must contain exactly 64 hex characters (32 bytes / 256 bits);
+// both upper- and lower-case hex are accepted.
 // Generate a suitable value with: openssl rand -hex 32
 type EnvKeyProvider struct {
 	EnvVar string // environment variable name; default "GEARBOX_AGENT_ENCRYPTION_KEY"

--- a/gearbox-agent/internal/framework/crypto/aead_test.go
+++ b/gearbox-agent/internal/framework/crypto/aead_test.go
@@ -246,7 +246,7 @@ func TestLoadOrCreateSecret_AutoMigratesPlaintext(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "secret")
 
 	// Write a valid plaintext secret.
-	plainSecret := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	plainSecret := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" //gitleaks:allow — deterministic test fixture
 	if err := os.WriteFile(path, []byte(plainSecret), 0600); err != nil {
 		t.Fatalf("write plaintext: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestReadSecret_Missing(t *testing.T) {
 func TestWriteAPIKey_EncryptsWhenKeySet(t *testing.T) {
 	withProvider(t, &staticKeyProvider{key: validTestKey()})
 	path := filepath.Join(t.TempDir(), "api-key")
-	apiKey := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	apiKey := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" //gitleaks:allow — deterministic test fixture
 
 	if err := WriteAPIKey(path, apiKey); err != nil {
 		t.Fatalf("WriteAPIKey error: %v", err)
@@ -375,7 +375,7 @@ func TestWriteAPIKey_EncryptsWhenKeySet(t *testing.T) {
 func TestWriteAPIKey_PlaintextWhenNoKey(t *testing.T) {
 	withProvider(t, &staticKeyProvider{key: nil})
 	path := filepath.Join(t.TempDir(), "api-key")
-	apiKey := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	apiKey := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" //gitleaks:allow — deterministic test fixture
 
 	if err := WriteAPIKey(path, apiKey); err != nil {
 		t.Fatalf("WriteAPIKey error: %v", err)

--- a/gearbox-agent/internal/framework/crypto/aead_test.go
+++ b/gearbox-agent/internal/framework/crypto/aead_test.go
@@ -1,0 +1,387 @@
+package crypto
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// staticKeyProvider always returns the same key (or nil).
+type staticKeyProvider struct{ key []byte }
+
+func (s *staticKeyProvider) Key() ([]byte, error) { return s.key, nil }
+
+// validTestKey returns a fresh 32-byte key for tests.
+func validTestKey() []byte {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	return key
+}
+
+// withProvider temporarily replaces DefaultKeyProvider and restores it on cleanup.
+func withProvider(t *testing.T, p KeyProvider) {
+	t.Helper()
+	original := DefaultKeyProvider
+	DefaultKeyProvider = p
+	t.Cleanup(func() { DefaultKeyProvider = original })
+}
+
+// ── isEncrypted ──────────────────────────────────────────────────────────────
+
+func TestIsEncrypted_MagicHeader(t *testing.T) {
+	data := append(magic[:], []byte("payload")...)
+	if !isEncrypted(data) {
+		t.Error("isEncrypted should return true for GBE1-prefixed data")
+	}
+}
+
+func TestIsEncrypted_PlaintextData(t *testing.T) {
+	data := []byte("plaintext secret value here")
+	if isEncrypted(data) {
+		t.Error("isEncrypted should return false for plaintext data")
+	}
+}
+
+func TestIsEncrypted_TooShort(t *testing.T) {
+	if isEncrypted([]byte("GBE")) {
+		t.Error("isEncrypted should return false for data shorter than magic")
+	}
+	if isEncrypted(nil) {
+		t.Error("isEncrypted should return false for nil data")
+	}
+}
+
+// ── encrypt / decrypt round-trip ─────────────────────────────────────────────
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	key := validTestKey()
+	plaintext := "super-secret-api-key-value-12345678901234567890"
+
+	ct, err := encryptSecret(plaintext, key)
+	if err != nil {
+		t.Fatalf("encryptSecret error: %v", err)
+	}
+	if !isEncrypted(ct) {
+		t.Error("encryptSecret output does not start with GBE1")
+	}
+
+	got, err := decryptSecret(ct, key)
+	if err != nil {
+		t.Fatalf("decryptSecret error: %v", err)
+	}
+	if got != plaintext {
+		t.Errorf("round-trip mismatch: got %q, want %q", got, plaintext)
+	}
+}
+
+func TestEncryptSecret_ProducesUniqueNonces(t *testing.T) {
+	key := validTestKey()
+	plaintext := "same-plaintext"
+
+	ct1, _ := encryptSecret(plaintext, key)
+	ct2, _ := encryptSecret(plaintext, key)
+	if bytes.Equal(ct1, ct2) {
+		t.Error("two encryptSecret calls with the same input must not produce identical ciphertext")
+	}
+}
+
+func TestDecryptSecret_WrongKey(t *testing.T) {
+	key := validTestKey()
+	ct, _ := encryptSecret("secret", key)
+
+	wrongKey := make([]byte, 32)
+	_, err := decryptSecret(ct, wrongKey)
+	if err == nil {
+		t.Error("decryptSecret with wrong key should return error")
+	}
+}
+
+func TestDecryptSecret_CorruptedCiphertext(t *testing.T) {
+	key := validTestKey()
+	ct, _ := encryptSecret("secret", key)
+
+	// Flip a byte in the ciphertext region (after magic + nonce).
+	ct[len(magic)+12]++
+	_, err := decryptSecret(ct, key)
+	if err == nil {
+		t.Error("decryptSecret with corrupted ciphertext should return error")
+	}
+}
+
+func TestDecryptSecret_MissingMagic(t *testing.T) {
+	_, err := decryptSecret([]byte("not-encrypted"), validTestKey())
+	if err == nil {
+		t.Error("decryptSecret without magic header should return error")
+	}
+}
+
+func TestDecryptSecret_TooShort(t *testing.T) {
+	// GBE1 magic + only 4 bytes (nonce needs 12).
+	data := append(magic[:], 0, 0, 0, 0)
+	_, err := decryptSecret(data, validTestKey())
+	if err == nil {
+		t.Error("decryptSecret with truncated payload should return error")
+	}
+}
+
+// ── EnvKeyProvider ───────────────────────────────────────────────────────────
+
+func TestEnvKeyProvider_ValidKey(t *testing.T) {
+	key := validTestKey()
+	hexKey := make([]byte, 64)
+	for i, b := range key {
+		hexKey[i*2] = "0123456789abcdef"[b>>4]
+		hexKey[i*2+1] = "0123456789abcdef"[b&0xf]
+	}
+	t.Setenv("GEARBOX_AGENT_ENCRYPTION_KEY", string(hexKey))
+
+	p := &EnvKeyProvider{EnvVar: "GEARBOX_AGENT_ENCRYPTION_KEY"}
+	got, err := p.Key()
+	if err != nil {
+		t.Fatalf("Key() error: %v", err)
+	}
+	if !bytes.Equal(got, key) {
+		t.Error("Key() returned wrong bytes")
+	}
+}
+
+func TestEnvKeyProvider_Unset(t *testing.T) {
+	t.Setenv("GEARBOX_AGENT_ENCRYPTION_KEY", "")
+
+	p := &EnvKeyProvider{EnvVar: "GEARBOX_AGENT_ENCRYPTION_KEY"}
+	got, err := p.Key()
+	if err != nil {
+		t.Fatalf("Key() error: %v", err)
+	}
+	if got != nil {
+		t.Error("Key() should return nil when env var is unset")
+	}
+}
+
+func TestEnvKeyProvider_InvalidHex(t *testing.T) {
+	t.Setenv("GEARBOX_AGENT_ENCRYPTION_KEY", "not-valid-hex!!")
+
+	p := &EnvKeyProvider{EnvVar: "GEARBOX_AGENT_ENCRYPTION_KEY"}
+	_, err := p.Key()
+	if err == nil {
+		t.Error("Key() should return error for invalid hex")
+	}
+}
+
+func TestEnvKeyProvider_WrongLength(t *testing.T) {
+	// 16 bytes (128-bit) — too short for AES-256.
+	t.Setenv("GEARBOX_AGENT_ENCRYPTION_KEY", "0102030405060708090a0b0c0d0e0f10")
+
+	p := &EnvKeyProvider{EnvVar: "GEARBOX_AGENT_ENCRYPTION_KEY"}
+	_, err := p.Key()
+	if err == nil {
+		t.Error("Key() should return error for non-32-byte key")
+	}
+}
+
+// ── loadOrCreateSecret ───────────────────────────────────────────────────────
+
+func TestLoadOrCreateSecret_NewEncrypted(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: validTestKey()})
+	path := filepath.Join(t.TempDir(), "secret")
+
+	secret, isNew, err := loadOrCreateSecret(path, "test")
+	if err != nil {
+		t.Fatalf("loadOrCreateSecret error: %v", err)
+	}
+	if !isNew {
+		t.Error("expected isNew=true for first creation")
+	}
+	if len(secret) != SecretLength*2 {
+		t.Errorf("secret length %d, want %d", len(secret), SecretLength*2)
+	}
+
+	// Verify the on-disk file is encrypted.
+	data, _ := os.ReadFile(path)
+	if !isEncrypted(data) {
+		t.Error("file on disk should be encrypted (GBE1 prefix) when key is set")
+	}
+}
+
+func TestLoadOrCreateSecret_NewPlaintext(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: nil})
+	path := filepath.Join(t.TempDir(), "secret")
+
+	_, isNew, err := loadOrCreateSecret(path, "test")
+	if err != nil {
+		t.Fatalf("loadOrCreateSecret error: %v", err)
+	}
+	if !isNew {
+		t.Error("expected isNew=true for first creation")
+	}
+
+	// File should be plaintext when no key.
+	data, _ := os.ReadFile(path)
+	if isEncrypted(data) {
+		t.Error("file should be plaintext when no key is configured")
+	}
+}
+
+func TestLoadOrCreateSecret_ReloadEncrypted(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: validTestKey()})
+	path := filepath.Join(t.TempDir(), "secret")
+
+	original, _, _ := loadOrCreateSecret(path, "test")
+	reloaded, isNew, err := loadOrCreateSecret(path, "test")
+	if err != nil {
+		t.Fatalf("second load error: %v", err)
+	}
+	if isNew {
+		t.Error("expected isNew=false on reload")
+	}
+	if reloaded != original {
+		t.Errorf("reloaded secret %q != original %q", reloaded, original)
+	}
+}
+
+func TestLoadOrCreateSecret_AutoMigratesPlaintext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secret")
+
+	// Write a valid plaintext secret.
+	plainSecret := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	if err := os.WriteFile(path, []byte(plainSecret), 0600); err != nil {
+		t.Fatalf("write plaintext: %v", err)
+	}
+
+	// Now load with encryption enabled — should auto-migrate.
+	withProvider(t, &staticKeyProvider{key: validTestKey()})
+	got, isNew, err := loadOrCreateSecret(path, "test")
+	if err != nil {
+		t.Fatalf("loadOrCreateSecret error: %v", err)
+	}
+	if isNew {
+		t.Error("auto-migration should not set isNew=true")
+	}
+	if got != plainSecret {
+		t.Errorf("got %q, want %q", got, plainSecret)
+	}
+
+	// File must now be encrypted on disk.
+	data, _ := os.ReadFile(path)
+	if !isEncrypted(data) {
+		t.Error("file should be encrypted after auto-migration")
+	}
+}
+
+func TestLoadOrCreateSecret_EncryptedNoKey(t *testing.T) {
+	// Create an encrypted file with a key...
+	path := filepath.Join(t.TempDir(), "secret")
+	withProvider(t, &staticKeyProvider{key: validTestKey()})
+	loadOrCreateSecret(path, "test") //nolint:errcheck
+
+	// ... then try to load it without a key.
+	withProvider(t, &staticKeyProvider{key: nil})
+	_, _, err := loadOrCreateSecret(path, "test")
+	if err == nil {
+		t.Fatal("expected ErrKeyRequired for encrypted file without key")
+	}
+	if err != ErrKeyRequired {
+		t.Errorf("expected ErrKeyRequired, got: %v", err)
+	}
+}
+
+// ── readSecret ───────────────────────────────────────────────────────────────
+
+func TestReadSecret_Plaintext(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: nil})
+	path := filepath.Join(t.TempDir(), "secret")
+	expected := "some-plaintext-value"
+	os.WriteFile(path, []byte(expected), 0600)
+
+	got, err := readSecret(path, "test")
+	if err != nil {
+		t.Fatalf("readSecret error: %v", err)
+	}
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestReadSecret_Encrypted(t *testing.T) {
+	key := validTestKey()
+	plaintext := "the-real-secret-value-0123456789"
+
+	path := filepath.Join(t.TempDir(), "secret")
+	ct, _ := encryptSecret(plaintext, key)
+	os.WriteFile(path, ct, 0600)
+
+	withProvider(t, &staticKeyProvider{key: key})
+	got, err := readSecret(path, "test")
+	if err != nil {
+		t.Fatalf("readSecret error: %v", err)
+	}
+	if got != plaintext {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+}
+
+func TestReadSecret_EncryptedNoKey(t *testing.T) {
+	key := validTestKey()
+	path := filepath.Join(t.TempDir(), "secret")
+	ct, _ := encryptSecret("value", key)
+	os.WriteFile(path, ct, 0600)
+
+	withProvider(t, &staticKeyProvider{key: nil})
+	_, err := readSecret(path, "test")
+	if err == nil {
+		t.Fatal("expected ErrKeyRequired")
+	}
+	if err != ErrKeyRequired {
+		t.Errorf("expected ErrKeyRequired, got: %v", err)
+	}
+}
+
+func TestReadSecret_Missing(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: nil})
+	_, err := readSecret("/nonexistent/path/secret", "test")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// ── WriteAPIKey ───────────────────────────────────────────────────────────────
+
+func TestWriteAPIKey_EncryptsWhenKeySet(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: validTestKey()})
+	path := filepath.Join(t.TempDir(), "api-key")
+	apiKey := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	if err := WriteAPIKey(path, apiKey); err != nil {
+		t.Fatalf("WriteAPIKey error: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !isEncrypted(data) {
+		t.Error("WriteAPIKey should write encrypted file when key is set")
+	}
+
+	// Verify we can read it back.
+	got, err := ReadAPIKey(path)
+	if err != nil {
+		t.Fatalf("ReadAPIKey error: %v", err)
+	}
+	if got != apiKey {
+		t.Errorf("ReadAPIKey returned %q, want %q", got, apiKey)
+	}
+}
+
+func TestWriteAPIKey_PlaintextWhenNoKey(t *testing.T) {
+	withProvider(t, &staticKeyProvider{key: nil})
+	path := filepath.Join(t.TempDir(), "api-key")
+	apiKey := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	if err := WriteAPIKey(path, apiKey); err != nil {
+		t.Fatalf("WriteAPIKey error: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if isEncrypted(data) {
+		t.Error("WriteAPIKey should write plaintext when no key is set")
+	}
+}

--- a/gearbox-agent/internal/framework/crypto/keys.go
+++ b/gearbox-agent/internal/framework/crypto/keys.go
@@ -28,45 +28,103 @@ func generateSecret() (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-// loadOrCreateSecret is a generic helper for loading or creating secrets.
+// writeSecret persists secret to path, encrypting it when the provider has a key.
+func writeSecret(path, secret string, provider KeyProvider) error {
+	key, err := provider.Key()
+	if err != nil {
+		return err
+	}
+
+	var data []byte
+	if key != nil {
+		data, err = encryptSecret(secret, key)
+		if err != nil {
+			return fmt.Errorf("encrypt secret: %w", err)
+		}
+	} else {
+		data = []byte(secret)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	return os.WriteFile(path, data, APIKeyFilePerms)
+}
+
+// loadOrCreateSecret loads a secret from path or generates and saves a new one.
+//
+// Encryption behaviour:
+//   - Encrypted file, key present    → decrypt and return
+//   - Encrypted file, no key         → fatal: return ErrKeyRequired
+//   - Plaintext file, key present    → auto-migrate: re-encrypt in place and return
+//   - Plaintext file, no key         → return as-is (warn at caller level)
+//   - File missing                   → generate new secret, write (encrypted if key present)
 func loadOrCreateSecret(secretPath, secretType string) (string, bool, error) {
-	// Try to read existing secret
+	key, err := DefaultKeyProvider.Key()
+	if err != nil {
+		return "", false, fmt.Errorf("key provider error: %w", err)
+	}
+
 	data, err := os.ReadFile(secretPath)
 	if err == nil {
-		secret := string(data)
-		if len(secret) >= SecretLength*2 { // hex encoded is 2x bytes
-			return secret, false, nil
+		// File exists — handle all four cases above.
+		if isEncrypted(data) {
+			if key == nil {
+				return "", false, ErrKeyRequired
+			}
+			secret, err := decryptSecret(data, key)
+			if err != nil {
+				return "", false, fmt.Errorf("failed to decrypt %s: %w", secretType, err)
+			}
+			if len(secret) < SecretLength*2 {
+				// Decrypted payload is invalid; fall through to regenerate below.
+			} else {
+				return secret, false, nil
+			}
+		} else {
+			// Plaintext file.
+			secret := string(data)
+			if len(secret) >= SecretLength*2 {
+				if key != nil {
+					// Auto-migrate: re-encrypt the existing plaintext secret.
+					if err := writeSecret(secretPath, secret, DefaultKeyProvider); err != nil {
+						return "", false, fmt.Errorf("failed to encrypt %s during migration: %w", secretType, err)
+					}
+				}
+				return secret, false, nil
+			}
+			// Secret file exists but is too short; fall through to regenerate.
 		}
-		// Secret file exists but is invalid, regenerate
 	} else if !os.IsNotExist(err) {
 		return "", false, fmt.Errorf("failed to read %s file: %w", secretType, err)
 	}
 
-	// Generate new secret
+	// Generate a new secret and persist it.
 	secret, err := generateSecret()
 	if err != nil {
 		return "", false, err
 	}
-
-	// Ensure directory exists
-	dir := filepath.Dir(secretPath)
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return "", false, fmt.Errorf("failed to create directory %s: %w", dir, err)
-	}
-
-	// Write secret to file
-	if err := os.WriteFile(secretPath, []byte(secret), APIKeyFilePerms); err != nil {
+	if err := writeSecret(secretPath, secret, DefaultKeyProvider); err != nil {
 		return "", false, fmt.Errorf("failed to write %s file: %w", secretType, err)
 	}
-
 	return secret, true, nil
 }
 
-// readSecret is a generic helper for reading secrets from files.
+// readSecret reads a secret from path, decrypting it when necessary.
 func readSecret(secretPath, secretType string) (string, error) {
 	data, err := os.ReadFile(secretPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read %s: %w", secretType, err)
+	}
+	if isEncrypted(data) {
+		key, err := DefaultKeyProvider.Key()
+		if err != nil {
+			return "", fmt.Errorf("key provider error: %w", err)
+		}
+		if key == nil {
+			return "", ErrKeyRequired
+		}
+		return decryptSecret(data, key)
 	}
 	return string(data), nil
 }
@@ -82,9 +140,15 @@ func LoadOrCreateAPIKey(keyPath string) (string, bool, error) {
 	return loadOrCreateSecret(keyPath, "API key")
 }
 
-// ReadAPIKey reads an API key from the specified file path.
+// ReadAPIKey reads an API key from the specified file path, decrypting if needed.
 func ReadAPIKey(keyPath string) (string, error) {
 	return readSecret(keyPath, "API key")
+}
+
+// WriteAPIKey writes an API key to the specified file path, encrypting if a key
+// provider is configured. Used by the --rotate-api-key flag.
+func WriteAPIKey(keyPath, key string) error {
+	return writeSecret(keyPath, key, DefaultKeyProvider)
 }
 
 // LoadOrCreateWebhookSecret loads an existing webhook secret from the file or creates a new one.
@@ -93,7 +157,7 @@ func LoadOrCreateWebhookSecret(secretPath string) (string, bool, error) {
 	return loadOrCreateSecret(secretPath, "webhook secret")
 }
 
-// ReadWebhookSecret reads a webhook secret from the specified file path.
+// ReadWebhookSecret reads a webhook secret from the specified file path, decrypting if needed.
 func ReadWebhookSecret(secretPath string) (string, error) {
 	return readSecret(secretPath, "webhook secret")
 }


### PR DESCRIPTION
## Summary

- **`aead.go`** (new): `KeyProvider` interface, `EnvKeyProvider` reading a 32-byte hex key from `GEARBOX_AGENT_ENCRYPTION_KEY`, `encryptSecret`/`decryptSecret` using AES-256-GCM with random 12-byte nonces, and `GBE1` magic bytes for auto-detection
- **`keys.go`**: `loadOrCreateSecret` and `readSecret` now auto-detect encrypted files and decrypt transparently; auto-migrate existing plaintext files to AES-GCM on first boot with a key set; hard-fail with `ErrKeyRequired` when an encrypted file is found but no key is configured; new exported `WriteAPIKey()` for the `--rotate-api-key` path
- **`main.go`**: `--rotate-api-key` uses `crypto.WriteAPIKey` (respects encryption); startup warning logged at WARN level when `GEARBOX_AGENT_ENCRYPTION_KEY` is not set
- **`aead_test.go`** (new): 24 tests covering all four load/create branches, encrypt/decrypt round-trips, wrong-key, corrupted ciphertext, `EnvKeyProvider` with valid/invalid/missing key, auto-migration, and `ErrKeyRequired` sentinel

## Behaviour matrix

| File on disk | Key set | Result |
|---|---|---|
| Missing | Yes | Generate → encrypt → write |
| Missing | No | Generate → plaintext → write (+ startup WARN) |
| Encrypted (GBE1) | Yes | Decrypt → return |
| Encrypted (GBE1) | No | **Fatal**: `ErrKeyRequired` |
| Plaintext | Yes | Auto-migrate: re-encrypt in place → return |
| Plaintext | No | Return as-is (startup WARN) |

## Generating a key

```bash
openssl rand -hex 32
# → add to /etc/default/gearbox-agent:
GEARBOX_AGENT_ENCRYPTION_KEY=<64-hex-chars>
```

## Key rotation / recovery

Key loss means the on-disk files cannot be decrypted. Recovery path: rotate the secrets (new API key + new webhook secret) with `--rotate-api-key` / `--generate-webhook-secret`, which re-generates and re-encrypts with the new key. Update GitHub webhook config with the new webhook secret.

## Related

- Security audit finding: P2-8 encryption-at-rest
- Tier 2 KMS providers: issue #54

## Test plan

- [x] `go test ./internal/framework/crypto/...` — 41 tests pass
- [x] `go test ./...` — all packages pass
- [x] `go build ./...` — clean compile