### PR TITLE
feat: optional first-box onboarding with welcome screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,28 @@ await showAlertDialog({
 
 Existing reference usages: [user-pages/admin-user-detail.js](static/js/user-pages/admin-user-detail.js), [user-pages/profile-management.js](static/js/user-pages/profile-management.js), [haproxy_config/editor.js](static/js/haproxy_config/editor.js).
 
+### Toggle switches — never use a bare `<input type="checkbox">` in templates
+
+For every boolean input in a `.templ` file — feature opt-ins, settings, "enable this gear", "show all", per-row enable/disable — use the shared slider component in [internal/framework/ui/toggle.templ](gearbox/internal/framework/ui/toggle.templ):
+
+```templ
+import "github.com/sarg3nt/gearbox/internal/framework/ui"
+
+// Single toggle (no inline label — pair with your own <label for=...>)
+@ui.Toggle("welcome-gear-home", "gears", "home", false, false)
+// args: id, name, value (submitted when checked), checked, disabled
+
+// Toggle + label + description, stacked horizontally
+@ui.ToggleWithLabel("notify-email", "notify_email", "1", "Email notifications", "Send a digest each morning", true, false)
+```
+
+**Rules of thumb:**
+
+- The underlying input is `sr-only` but real — it submits with the form and respects `checked` / `disabled`. No JS required for plain forms.
+- Pass `value` when multiple toggles share a `name` (e.g., a multi-select checkbox group posting as `name="gears"`). Leave empty when a single boolean field submits as the default `"on"`.
+- For AJAX toggles that POST on change (no enclosing form), the per-row `gear-toggle` `<button role="switch">` pattern in [gears.templ](gearbox/internal/framework/templates/pages/gears.templ) is the established alternative — but for **anything inside a `<form>`**, use `@ui.Toggle`.
+- Never inline `peer-checked:after:...` Tailwind salads in a new template — that's a sign you should be calling `@ui.Toggle`. Existing inline copies in `overview.templ` and `admin_user_permissions.templ` are tech debt; migrate them when you're already editing those files.
+
 ## Key Constraints
 
 ### NEVER

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -522,6 +522,12 @@ func main() {
 		// (per-user → system → fallback). See feature/dashboard-gear F1.
 		r.Get("/", h.RootRedirect)
 
+		// First-run onboarding (issue #49). Admin-only. The /welcome page
+		// self-redirects to / once onboarding is complete (any box or
+		// system gear enabled), so it's safe to leave reachable.
+		r.Get("/welcome", h.WelcomePage)
+		r.Post("/onboarding", h.OnboardingPost)
+
 		// Settings routes
 		r.Route("/settings", func(r chi.Router) {
 			// Settings menu page (accessible by all authenticated users)

--- a/gearbox/internal/framework/handler/gears.go
+++ b/gearbox/internal/framework/handler/gears.go
@@ -38,21 +38,23 @@ func (h *Handler) GearsPage(w http.ResponseWriter, r *http.Request) {
 		boxID = servers[0].ID
 	}
 
-	if boxID == "" {
-		http.Error(w, "No servers configured", http.StatusBadRequest)
-		return
-	}
+	// boxID may be empty on a fresh install — the template renders an
+	// "Add a Box" CTA in place of the per-box gear list. System-scoped
+	// gears still render regardless.
 
-	// Ensure default gears exist for this server
-	if err := h.db.EnsureServerGears(boxID); err != nil {
-		h.logger.Error("Failed to ensure server gears", "error", err)
-	}
+	var plugins []database.Gear
+	if boxID != "" {
+		// Ensure default gears exist for this box
+		if err := h.db.EnsureServerGears(boxID); err != nil {
+			h.logger.Error("Failed to ensure server gears", "error", err)
+		}
 
-	plugins, err := h.db.GetGears(boxID)
-	if err != nil {
-		h.logger.Error("Failed to get gears", "error", err)
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
+		plugins, err = h.db.GetGears(boxID)
+		if err != nil {
+			h.logger.Error("Failed to get gears", "error", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Load system-scoped (box-agnostic) gears so they render alongside the

--- a/gearbox/internal/framework/handler/handler.go
+++ b/gearbox/internal/framework/handler/handler.go
@@ -221,16 +221,22 @@ func (h *Handler) InjectIntegrationStatus(next http.Handler) http.Handler {
 		if boxID := h.getDefaultServerID(); boxID != "" {
 			integrations, err := h.db.GetGears(boxID)
 			if err != nil {
-				h.logger.Error("failed to get integrations for sidebar", "error", err)
-			} else {
-				for _, i := range integrations {
-					status[i.Name] = i.Enabled
-					orderedIntegrations = append(orderedIntegrations, auth.SidebarIntegration{
-						Name:      i.Name,
-						Enabled:   i.Enabled,
-						SortOrder: i.SortOrder,
-					})
-				}
+				// Fail-open: a partial gear list could collapse the sidebar
+				// to system-gears-only, hiding box features the user
+				// actually has. Leave the gear-status/order context unset
+				// so OrderedIntegrationLinks falls back to its default
+				// (full) rendering branch.
+				h.logger.Error("failed to get box integrations for sidebar", "error", err)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+			for _, i := range integrations {
+				status[i.Name] = i.Enabled
+				orderedIntegrations = append(orderedIntegrations, auth.SidebarIntegration{
+					Name:      i.Name,
+					Enabled:   i.Enabled,
+					SortOrder: i.SortOrder,
+				})
 			}
 		} else {
 			// No box configured — explicitly mark box-scoped gears off so

--- a/gearbox/internal/framework/handler/handler.go
+++ b/gearbox/internal/framework/handler/handler.go
@@ -186,6 +186,11 @@ func (h *Handler) getDefaultServerID() string {
 
 // InjectIntegrationStatus is middleware that adds integration status and user permissions to the request context.
 // This enables server-side conditional rendering of navigation items based on integration status and permissions.
+//
+// System-scoped gears (Home, etc. — keyed by database.SystemServerID) are
+// always loaded, even when no boxes are registered. Box-scoped gears load
+// from the default box if one exists; otherwise they're explicitly disabled
+// so the sidebar stays clean during first-run.
 func (h *Handler) InjectIntegrationStatus(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -196,69 +201,51 @@ func (h *Handler) InjectIntegrationStatus(next http.Handler) http.Handler {
 			ctx = auth.SetUserPermissions(ctx, perms)
 		}
 
-		boxID := h.getDefaultServerID()
-		if boxID != "" {
-			// Get integrations with their enabled status and sort order
+		status := make(map[string]bool)
+		orderedIntegrations := make([]auth.SidebarIntegration, 0)
+
+		// System gears go first so they render at the head of the nav.
+		systemGears, err := h.db.GetGears(database.SystemServerID)
+		if err != nil {
+			h.logger.Warn("failed to load system gears for sidebar", "error", err)
+		}
+		for _, sg := range systemGears {
+			status[sg.Name] = sg.Enabled
+			orderedIntegrations = append(orderedIntegrations, auth.SidebarIntegration{
+				Name:      sg.Name,
+				Enabled:   sg.Enabled,
+				SortOrder: sg.SortOrder,
+			})
+		}
+
+		if boxID := h.getDefaultServerID(); boxID != "" {
 			integrations, err := h.db.GetGears(boxID)
 			if err != nil {
 				h.logger.Error("failed to get integrations for sidebar", "error", err)
-				// Continue without status - sidebar will show all items (fail open)
-				next.ServeHTTP(w, r.WithContext(ctx))
-				return
+			} else {
+				for _, i := range integrations {
+					status[i.Name] = i.Enabled
+					orderedIntegrations = append(orderedIntegrations, auth.SidebarIntegration{
+						Name:      i.Name,
+						Enabled:   i.Enabled,
+						SortOrder: i.SortOrder,
+					})
+				}
 			}
-
-			// Merge in system-wide (box-agnostic) gears so the sidebar can show them.
-			systemGears, err := h.db.GetGears(database.SystemServerID)
-			if err != nil {
-				h.logger.Warn("failed to load system gears for sidebar", "error", err)
+		} else {
+			// No box configured — explicitly mark box-scoped gears off so
+			// the sidebar doesn't fall back to fail-open and clutter
+			// first-run with disabled items. System gears (Home) are
+			// already injected above and remain visible if enabled.
+			for _, n := range []string{"haproxy", "metrics", "logs", "services", "certificates", "traffic", "alerts", "os_updates"} {
+				if _, present := status[n]; !present {
+					status[n] = false
+				}
 			}
-
-			// Build status map for backward compatibility
-			status := make(map[string]bool)
-			for _, i := range integrations {
-				status[i.Name] = i.Enabled
-			}
-			for _, i := range systemGears {
-				status[i.Name] = i.Enabled
-			}
-
-			// Build ordered list for sidebar (box gears first, then system gears
-			// at the head — Home should sit at the top of navigation when enabled).
-			orderedIntegrations := make([]auth.SidebarIntegration, 0, len(integrations)+len(systemGears))
-			for _, i := range systemGears {
-				orderedIntegrations = append(orderedIntegrations, auth.SidebarIntegration{
-					Name:      i.Name,
-					Enabled:   i.Enabled,
-					SortOrder: i.SortOrder,
-				})
-			}
-			for _, i := range integrations {
-				orderedIntegrations = append(orderedIntegrations, auth.SidebarIntegration{
-					Name:      i.Name,
-					Enabled:   i.Enabled,
-					SortOrder: i.SortOrder,
-				})
-			}
-
-			ctx = auth.SetGearStatus(ctx, status)
-			ctx = auth.SetIntegrationOrder(ctx, orderedIntegrations)
-			next.ServeHTTP(w, r.WithContext(ctx))
-			return
 		}
 
-		// No server configured - explicitly disable all gears in navigation
-		// This provides a clean initial setup experience without gear clutter
-		status := map[string]bool{
-			"metrics":      false,
-			"logs":         false,
-			"services":     false,
-			"certificates": false,
-			"traffic":      false,
-			"alerts":       false,
-			"os_updates":   false,
-		}
 		ctx = auth.SetGearStatus(ctx, status)
-		ctx = auth.SetIntegrationOrder(ctx, []auth.SidebarIntegration{})
+		ctx = auth.SetIntegrationOrder(ctx, orderedIntegrations)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/gearbox/internal/framework/handler/login.go
+++ b/gearbox/internal/framework/handler/login.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 
 	"github.com/sarg3nt/gearbox/internal/framework/database"
-	"github.com/sarg3nt/gearbox/internal/framework/models"
 	"github.com/sarg3nt/gearbox/internal/framework/templates/pages"
 )
 
@@ -150,17 +149,9 @@ func (h *Handler) LoginPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If admin user and no HAProxy servers configured, redirect to server setup
-	if user.Role == models.RoleAdmin {
-		count, err := h.db.CountEnabledBoxes()
-		if err != nil {
-			h.logger.Error("Failed to count HAProxy servers", "error", err)
-		} else if count == 0 {
-			h.logger.Info("admin user logged in but no HAProxy servers configured, redirecting to setup", "email", email)
-			http.Redirect(w, r, "/settings/boxes/new", http.StatusSeeOther)
-			return
-		}
-	}
+	// First-run onboarding is no longer forced at login time. If nothing is
+	// configured, the user's resolved landing path will be "/", which
+	// RootRedirect routes to /welcome. Issue #49.
 
 	// Redirect to return URL if provided, otherwise honor the per-user
 	// default-landing-path with system fallback. The return URL must be a
@@ -176,9 +167,12 @@ func (h *Handler) LoginPost(w http.ResponseWriter, r *http.Request) {
 }
 
 // RootRedirect handles GET /. Redirects authenticated users to their
-// default-landing-path (per-user → system → fallback). The chosen fallback
-// when nothing is configured is /haproxy when at least one box is configured,
-// otherwise /settings/boxes/new for a clean first-run experience.
+// default-landing-path (per-user → system → fallback). When nothing is
+// configured the fallback chain is:
+//
+//  1. Any box enabled            → /haproxy
+//  2. Any system gear enabled    → /home (today the only system gear)
+//  3. Otherwise                  → /welcome (first-run onboarding, issue #49)
 func (h *Handler) RootRedirect(w http.ResponseWriter, r *http.Request) {
 	userID := ""
 	if u, err := h.authManager.GetUser(r); err == nil && u != nil {
@@ -191,12 +185,15 @@ func (h *Handler) RootRedirect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fallback: send to haproxy if any box is configured, else to box setup.
 	if count, err := h.db.CountEnabledBoxes(); err == nil && count > 0 {
 		http.Redirect(w, r, "/haproxy", http.StatusSeeOther)
 		return
 	}
-	http.Redirect(w, r, "/settings/boxes/new", http.StatusSeeOther)
+	if homeGear, err := h.db.GetGear(database.SystemServerID, database.GearHome); err == nil && homeGear != nil && homeGear.Enabled {
+		http.Redirect(w, r, "/home", http.StatusSeeOther)
+		return
+	}
+	http.Redirect(w, r, "/welcome", http.StatusSeeOther)
 }
 
 // Logout handles user logout.

--- a/gearbox/internal/framework/handler/onboarding.go
+++ b/gearbox/internal/framework/handler/onboarding.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/templates/pages"
+)
+
+// WelcomePage renders the first-run onboarding screen. Issue #49.
+//
+// Shown only while nothing has been configured — no enabled boxes and no
+// enabled system gears. Once the admin makes any choice, the welcome screen
+// is no longer the landing fallback and direct visits redirect away.
+func (h *Handler) WelcomePage(w http.ResponseWriter, r *http.Request) {
+	user, err := h.authManager.GetUser(r)
+	if err != nil {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if !user.IsAdmin() {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if h.onboardingComplete() {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+
+	systemGears, err := h.db.GetGears(database.SystemServerID)
+	if err != nil {
+		h.logger.Warn("failed to load system gears for welcome page", "error", err)
+		systemGears = nil
+	}
+	// Only offer gears the admin hasn't already enabled. Onboarding is
+	// one-shot; if a gear is enabled the page wouldn't be rendered at all
+	// (see onboardingComplete above), so this filter is mostly defensive.
+	disabled := make([]database.Gear, 0, len(systemGears))
+	for _, g := range systemGears {
+		if !g.Enabled {
+			disabled = append(disabled, g)
+		}
+	}
+
+	csrfToken, _ := h.authManager.GetCSRFToken(r)
+	errorMessage := r.URL.Query().Get("error")
+
+	component := pages.WelcomePage(user, disabled, csrfToken, errorMessage)
+	if err := component.Render(r.Context(), w); err != nil {
+		h.logger.Error("Failed to render welcome template", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+// OnboardingPost handles the welcome form. Two submit buttons share one form:
+//
+//   - action=add-box  → enable any checked system gears, then redirect to
+//     /settings/boxes/new
+//   - action=skip     → enable any checked system gears, then redirect to /
+//     and let RootRedirect's fallback chain pick the landing page
+//
+// If nothing is checked and the admin clicked "skip", the redirect lands back
+// on /welcome via RootRedirect (no decision made, no-op).
+func (h *Handler) OnboardingPost(w http.ResponseWriter, r *http.Request) {
+	user, err := h.authManager.GetUser(r)
+	if err != nil {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if !user.IsAdmin() {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if err := h.authManager.ValidateCSRFToken(r); err != nil {
+		http.Redirect(w, r, "/welcome?error="+url.QueryEscape("Invalid CSRF token"), http.StatusSeeOther)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, "/welcome?error="+url.QueryEscape("Invalid form submission"), http.StatusSeeOther)
+		return
+	}
+
+	action := r.FormValue("action")
+	checked := r.Form["gears"]
+
+	// Only enable gears that are actually system-scoped — defence in depth
+	// against form tampering.
+	for _, name := range checked {
+		if !database.IsSystemGear(name) {
+			h.logger.Warn("onboarding ignored non-system gear", "name", name, "user", user.ID)
+			continue
+		}
+		if err := h.db.SetGearEnabled(database.SystemServerID, name, true, &user.ID); err != nil {
+			h.logger.Error("failed to enable system gear during onboarding",
+				"name", name, "error", err, "user", user.ID)
+			http.Redirect(w, r, "/welcome?error="+url.QueryEscape("Failed to enable selected tools"), http.StatusSeeOther)
+			return
+		}
+		h.logger.Info("onboarding enabled system gear", "name", name, "user", user.ID)
+	}
+
+	if action == "add-box" {
+		http.Redirect(w, r, "/settings/boxes/new", http.StatusSeeOther)
+		return
+	}
+	// action == "skip" (or unknown) — let RootRedirect's chain decide.
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+// onboardingComplete reports whether the admin has finished onboarding —
+// at least one box is enabled, or at least one system-scoped gear is
+// enabled. Used as the one-shot guard for the welcome screen.
+func (h *Handler) onboardingComplete() bool {
+	if count, err := h.db.CountEnabledBoxes(); err == nil && count > 0 {
+		return true
+	}
+	if anyEnabled, err := h.anySystemGearEnabled(); err == nil && anyEnabled {
+		return true
+	}
+	return false
+}
+
+// anySystemGearEnabled reports whether any box-agnostic gear is enabled on
+// the system row.
+func (h *Handler) anySystemGearEnabled() (bool, error) {
+	gears, err := h.db.GetGears(database.SystemServerID)
+	if err != nil {
+		return false, err
+	}
+	for _, g := range gears {
+		if g.Enabled {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/gearbox/internal/framework/templates/pages/gears.templ
+++ b/gearbox/internal/framework/templates/pages/gears.templ
@@ -74,7 +74,7 @@ templ GearsPage(user *models.User, servers []models.BoxConfig, currentServerID s
 				<div class="mb-6">
 					<div class="flex items-baseline justify-between mb-2">
 						<h3 class="text-base font-semibold text-gray-700 dark:text-gray-200">System</h3>
-						<span class="text-xs text-gray-500 dark:text-gray-400">Applies install-wide, not tied to a server</span>
+						<span class="text-xs text-gray-500 dark:text-gray-400">Applies install-wide, not tied to a box</span>
 					</div>
 					<div id="system-gears-list" class="space-y-4">
 						for _, sg := range systemGears {
@@ -82,20 +82,49 @@ templ GearsPage(user *models.User, servers []models.BoxConfig, currentServerID s
 						}
 					</div>
 				</div>
-				<div class="mb-2">
-					<h3 class="text-base font-semibold text-gray-700 dark:text-gray-200">
-						if currentServerID != "" && len(servers) > 0 {
-							{ serverNameByID(servers, currentServerID) }
-						} else {
-							Server gears
-						}
-					</h3>
-				</div>
 			}
 
+			<div class="mb-2">
+				<h3 class="text-base font-semibold text-gray-700 dark:text-gray-200">
+					if currentServerID != "" && len(servers) > 0 {
+						{ serverNameByID(servers, currentServerID) }
+					} else {
+						Box gears
+					}
+				</h3>
+			</div>
 			<div id="gears-list" class="space-y-4">
-				for _, integration := range integrations {
-					@gearCard(integration, currentServerID)
+				if len(servers) > 0 {
+					for _, integration := range integrations {
+						@gearCard(integration, currentServerID)
+					}
+				} else {
+					<div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6">
+						<div class="flex items-start gap-4">
+							<div class="flex-shrink-0 w-12 h-12 rounded-lg bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center">
+								<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"></path>
+								</svg>
+							</div>
+							<div class="flex-1 min-w-0">
+								<h4 class="text-base font-semibold text-gray-800 dark:text-gray-100">No boxes configured</h4>
+								<p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+									Per-box gears (HAProxy, Metrics, Logs, Services, Certificates, Traffic, Alerts, OS Updates) need a registered box to run against. Add one to enable them.
+								</p>
+								<div class="mt-4">
+									<a
+										href="/settings/boxes/new"
+										class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+									>
+										<svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+										</svg>
+										Add a Box
+									</a>
+								</div>
+							</div>
+						</div>
+					</div>
 				}
 			</div>
 

--- a/gearbox/internal/framework/templates/pages/haproxy_settings.templ
+++ b/gearbox/internal/framework/templates/pages/haproxy_settings.templ
@@ -9,84 +9,14 @@ import (
 	"github.com/sarg3nt/gearbox/internal/framework/templates/layouts"
 )
 
-// HAProxyServersPage renders the list of monitored servers.
-// When no servers exist, it uses a minimal layout without the sidebar (like login page).
+// HAProxyBoxesPage renders the list of monitored boxes. First-run onboarding
+// is owned by the /welcome screen (issue #49); this page always uses the
+// standard sidebar layout and shows an inline empty-state when the list is
+// zero.
 templ HAProxyBoxesPage(user *models.User, servers []*database.BoxDB) {
-	if len(servers) == 0 {
-		@HAProxyBoxesPageNoSidebar(user)
-	} else {
-		@layouts.Base("Boxes", user, "/settings") {
-			@HAProxyBoxesPageContent(user, servers)
-		}
+	@layouts.Base("Boxes", user, "/settings") {
+		@HAProxyBoxesPageContent(user, servers)
 	}
-}
-
-// HAProxyServersPageNoSidebar renders the boxes page without sidebar when no servers configured.
-templ HAProxyBoxesPageNoSidebar(user *models.User) {
-	<!DOCTYPE html>
-	<html lang="en" class="h-full">
-	<head>
-		<meta charset="UTF-8"/>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-		<title>Boxes - Gearbox</title>
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
-		if middleware.UseLocalAssets(ctx) {
-			<script src="/static/js/vendor/tailwind.js"></script>
-		} else {
-			<script src="https://cdn.tailwindcss.com"></script>
-		}
-		<script>
-			tailwind.config = { darkMode: 'class' }
-			// Apply theme immediately
-			function getThemePreference() {
-				const stored = localStorage.getItem('theme');
-				if (stored) return stored;
-				return 'system';
-			}
-			function getEffectiveTheme() {
-				const pref = getThemePreference();
-				if (pref === 'system') {
-					return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-				}
-				return pref;
-			}
-			if (getEffectiveTheme() === 'dark') {
-				document.documentElement.classList.add('dark');
-			}
-		</script>
-	</head>
-	<body class="h-full bg-gray-100 dark:bg-slate-900">
-		<div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
-			<div class="max-w-2xl w-full">
-				<div class="text-center mb-8">
-					<div class="flex justify-center mb-4">
-						<img src="/favicon.svg" alt="Gearbox Logo" class="w-16 h-16"/>
-					</div>
-					<h1 class="text-3xl font-bold text-gray-900 dark:text-white">Gearbox</h1>
-					<p class="mt-2 text-sm text-gray-600 dark:text-gray-400">Real-time monitoring for HAProxy</p>
-				</div>
-				<div class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-8 text-center">
-					<svg class="mx-auto h-16 w-16 text-gray-400 mb-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"></path>
-					</svg>
-					<h2 class="text-2xl font-semibold text-gray-900 dark:text-white mb-3">No boxes configured</h2>
-					<p class="text-gray-600 dark:text-gray-400 mb-6">
-						Get started by adding your first monitored box.
-					</p>
-					<a
-						href="/settings/boxes/new"
-						class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-					>
-						<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-						</svg>
-						Add Box
-					</a>
-				</div>
-			</div>
-		</div>
-	</body>
-	</html>
 }
 
 // HAProxyServersPageContent renders the main content of the boxes page.

--- a/gearbox/internal/framework/templates/pages/welcome.templ
+++ b/gearbox/internal/framework/templates/pages/welcome.templ
@@ -4,6 +4,7 @@ import (
 	"github.com/sarg3nt/gearbox/internal/framework/database"
 	"github.com/sarg3nt/gearbox/internal/framework/middleware"
 	"github.com/sarg3nt/gearbox/internal/framework/models"
+	"github.com/sarg3nt/gearbox/internal/framework/ui"
 )
 
 // WelcomePage is the first-run landing screen shown to an admin when nothing
@@ -99,18 +100,15 @@ templ WelcomePage(user *models.User, systemGears []database.Gear, csrfToken stri
 
 								<div class="space-y-3">
 									for _, g := range systemGears {
-										<label class="flex items-start p-4 rounded-md border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 cursor-pointer">
-											<input
-												type="checkbox"
-												name="gears"
-												value={ g.Name }
-												class="mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:border-gray-600 dark:bg-slate-700"
-											/>
-											<span class="ml-3">
+										<div class="flex items-start p-4 rounded-md border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-slate-700/50">
+											<div class="flex items-center h-5 mt-0.5 flex-shrink-0">
+												@ui.Toggle("welcome-gear-"+g.Name, "gears", g.Name, false, false)
+											</div>
+											<label for={ "welcome-gear-" + g.Name } class="ml-3 cursor-pointer flex-1">
 												<span class="block text-sm font-medium text-gray-900 dark:text-white">{ g.DisplayName }</span>
 												<span class="block text-sm text-gray-500 dark:text-gray-400">{ g.Description }</span>
-											</span>
-										</label>
+											</label>
+										</div>
 									}
 								</div>
 

--- a/gearbox/internal/framework/templates/pages/welcome.templ
+++ b/gearbox/internal/framework/templates/pages/welcome.templ
@@ -1,0 +1,138 @@
+package pages
+
+import (
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/middleware"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
+)
+
+// WelcomePage is the first-run landing screen shown to an admin when nothing
+// has been configured yet — no boxes enabled and no system-scoped gears
+// enabled. It nudges toward adding a box (the primary action) but also lets
+// the admin opt into box-agnostic system tools (Home) without registering
+// a box. Issue #49.
+//
+// The page disappears the moment the admin makes any choice — RootRedirect's
+// fallback chain stops routing here once a box or system gear is enabled.
+templ WelcomePage(user *models.User, systemGears []database.Gear, csrfToken string, errorMessage string) {
+	<!DOCTYPE html>
+	<html lang="en" class="h-full">
+	<head>
+		<meta charset="UTF-8"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+		<title>Welcome - Gearbox</title>
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+		if middleware.UseLocalAssets(ctx) {
+			<script src="/static/js/vendor/tailwind.js"></script>
+		} else {
+			<script src="https://cdn.tailwindcss.com"></script>
+		}
+		<script>
+			tailwind.config = { darkMode: 'class' }
+			function getThemePreference() {
+				const stored = localStorage.getItem('theme');
+				if (stored) return stored;
+				return 'system';
+			}
+			function getEffectiveTheme() {
+				const pref = getThemePreference();
+				if (pref === 'system') {
+					return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				}
+				return pref;
+			}
+			if (getEffectiveTheme() === 'dark') {
+				document.documentElement.classList.add('dark');
+			}
+		</script>
+	</head>
+	<body class="h-full bg-gray-100 dark:bg-slate-900">
+		<div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+			<div class="max-w-2xl w-full">
+				<div class="text-center mb-8">
+					<div class="flex justify-center mb-4">
+						<img src="/favicon.svg" alt="Gearbox Logo" class="w-16 h-16"/>
+					</div>
+					<h1 class="text-3xl font-bold text-gray-900 dark:text-white">Welcome to Gearbox</h1>
+					<p class="mt-2 text-sm text-gray-600 dark:text-gray-400">Let's get you set up.</p>
+				</div>
+				<div class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-8">
+					if errorMessage != "" {
+						<div class="mb-6 rounded-md bg-red-50 dark:bg-red-900/30 p-4 border border-red-200 dark:border-red-800">
+							<p class="text-sm text-red-800 dark:text-red-200">{ errorMessage }</p>
+						</div>
+					}
+					<form method="POST" action="/onboarding">
+						<input type="hidden" name="csrf_token" value={ csrfToken }/>
+
+						<div class="text-center">
+							<h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">Add your first box</h2>
+							<p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+								A box is a server, workstation, or appliance running gearbox-agent.
+								Add one to monitor services, traffic, certificates, and more.
+							</p>
+							<button
+								type="submit"
+								name="action"
+								value="add-box"
+								class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+							>
+								<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+								</svg>
+								Add a Box
+							</button>
+						</div>
+
+						if len(systemGears) > 0 {
+							<div class="flex items-center my-8">
+								<div class="flex-grow border-t border-gray-200 dark:border-gray-700"></div>
+								<span class="flex-shrink mx-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">or</span>
+								<div class="flex-grow border-t border-gray-200 dark:border-gray-700"></div>
+							</div>
+
+							<div>
+								<h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">System tools</h3>
+								<p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+									These work without registering a box. Enable any you'd like to use.
+								</p>
+
+								<div class="space-y-3">
+									for _, g := range systemGears {
+										<label class="flex items-start p-4 rounded-md border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 cursor-pointer">
+											<input
+												type="checkbox"
+												name="gears"
+												value={ g.Name }
+												class="mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:border-gray-600 dark:bg-slate-700"
+											/>
+											<span class="ml-3">
+												<span class="block text-sm font-medium text-gray-900 dark:text-white">{ g.DisplayName }</span>
+												<span class="block text-sm text-gray-500 dark:text-gray-400">{ g.Description }</span>
+											</span>
+										</label>
+									}
+								</div>
+
+								<div class="mt-6 text-center">
+									<button
+										type="submit"
+										name="action"
+										value="skip"
+										class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-slate-700 hover:bg-gray-50 dark:hover:bg-slate-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+									>
+										Save &amp; continue without a box
+									</button>
+								</div>
+							</div>
+						}
+					</form>
+				</div>
+				<p class="mt-6 text-center text-xs text-gray-500 dark:text-gray-400">
+					You can add boxes and toggle system tools at any time from Settings.
+				</p>
+			</div>
+		</div>
+	</body>
+	</html>
+}

--- a/gearbox/internal/framework/ui/toggle.templ
+++ b/gearbox/internal/framework/ui/toggle.templ
@@ -1,16 +1,23 @@
 package ui
 
-// Toggle creates a switch/toggle input component
+// Toggle creates a switch/toggle input component.
+//
 // id: unique identifier for the input
 // name: form field name
+// value: form value submitted when checked (empty string → defaults to "on")
 // checked: initial state
 // disabled: whether the toggle is disabled
-templ Toggle(id string, name string, checked bool, disabled bool) {
+//
+// This is the canonical toggle for the app. Always use it for boolean form
+// inputs in templates instead of a bare <input type="checkbox">. See
+// CLAUDE.md → UI Conventions → Toggle switches.
+templ Toggle(id string, name string, value string, checked bool, disabled bool) {
 	<label class={ "relative inline-flex items-center", templ.KV("cursor-pointer", !disabled), templ.KV("cursor-not-allowed opacity-50", disabled) }>
 		<input
 			type="checkbox"
 			id={ id }
 			name={ name }
+			value={ value }
 			class="sr-only peer"
 			checked?={ checked }
 			disabled?={ disabled }
@@ -20,10 +27,10 @@ templ Toggle(id string, name string, checked bool, disabled bool) {
 }
 
 // ToggleWithLabel creates a toggle with an accompanying label
-templ ToggleWithLabel(id string, name string, label string, description string, checked bool, disabled bool) {
+templ ToggleWithLabel(id string, name string, value string, label string, description string, checked bool, disabled bool) {
 	<div class="flex items-start">
 		<div class="flex items-center h-5">
-			@Toggle(id, name, checked, disabled)
+			@Toggle(id, name, value, checked, disabled)
 		</div>
 		<div class="ml-3">
 			<label for={ id } class={ "text-sm font-medium text-gray-900 dark:text-gray-100", templ.KV("cursor-pointer", !disabled), templ.KV("cursor-not-allowed", disabled) }>

--- a/gearbox/internal/framework/ui/toggle.templ
+++ b/gearbox/internal/framework/ui/toggle.templ
@@ -1,10 +1,24 @@
 package ui
 
+// toggleValue defaults an empty value to "on" so the underlying checkbox
+// submits a non-empty form value when checked. This matches the HTML
+// default for a value-less checkbox and keeps `r.FormValue(name) == "on"`
+// callers working without forcing every site to pass an explicit value.
+func toggleValue(v string) string {
+	if v == "" {
+		return "on"
+	}
+	return v
+}
+
 // Toggle creates a switch/toggle input component.
 //
 // id: unique identifier for the input
 // name: form field name
-// value: form value submitted when checked (empty string → defaults to "on")
+// value: form value submitted when checked. If empty, defaults to "on"
+//        (the HTML default for a checkbox without a value attribute). Pass
+//        a unique non-empty value when multiple toggles share a name
+//        (multi-select checkbox group).
 // checked: initial state
 // disabled: whether the toggle is disabled
 //
@@ -17,7 +31,7 @@ templ Toggle(id string, name string, value string, checked bool, disabled bool) 
 			type="checkbox"
 			id={ id }
 			name={ name }
-			value={ value }
+			value={ toggleValue(value) }
 			class="sr-only peer"
 			checked?={ checked }
 			disabled?={ disabled }

--- a/gearbox/internal/gears/home/icons.go
+++ b/gearbox/internal/gears/home/icons.go
@@ -2,23 +2,33 @@ package home
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/a-h/templ"
 )
 
-// HomeIcon returns the SVG icon component for the Home gear sidebar entry.
-//
-// Path is the canonical Heroicons v1 "home" outline: a roof with both
+// homeIconPath is the canonical Heroicons v1 "home" outline: a roof with both
 // walls reaching it, a small door cut in the bottom-center. The previous
-// path was a malformed variant whose right wall stopped halfway up,
-// leaving a visual gap (issue: "the right wall is missing"). It also
-// drew a stray vertical stroke down the middle.
+// path was a malformed variant whose right wall stopped halfway up, leaving
+// a visual gap (issue: "the right wall is missing"). It also drew a stray
+// vertical stroke down the middle.
+const homeIconPath = `M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6`
+
+// HomeIcon returns the home SVG sized for the sidebar entry (w-5 h-5).
+// For other sizes use HomeIconClass.
 func HomeIcon() templ.Component {
+	return HomeIconClass("w-5 h-5")
+}
+
+// HomeIconClass returns the home SVG with caller-supplied Tailwind classes
+// (e.g. "w-16 h-16") so the same icon can be reused at larger sizes
+// without duplicating the SVG markup.
+func HomeIconClass(class string) templ.Component {
 	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
-		_, err := io.WriteString(w, `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
-		</svg>`)
+		_, err := fmt.Fprintf(w, `<svg class=%q fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">`+
+			`<path stroke-linecap="round" stroke-linejoin="round" d=%q></path>`+
+			`</svg>`, class, homeIconPath)
 		return err
 	})
 }

--- a/gearbox/internal/gears/home/pages.templ
+++ b/gearbox/internal/gears/home/pages.templ
@@ -249,8 +249,8 @@ templ IndexPage(d IndexPageData) {
 		<div class="px-4 sm:px-6 lg:px-8 py-6">
 			if len(d.Tiles) == 0 {
 				<div id="home-empty-state" class="border-2 border-dashed border-gray-300 dark:border-slate-700 rounded-xl py-16 text-center">
-					<div class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500 mb-3">
-						@HomeIcon()
+					<div class="mx-auto text-gray-400 dark:text-gray-500 mb-4 flex justify-center">
+						@HomeIconClass("w-20 h-20")
 					</div>
 					<h2 class="text-lg font-semibold text-gray-700 dark:text-gray-200">Your dashboard is empty</h2>
 					<p class="mt-2 text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">


### PR DESCRIPTION
Closes #49

## Summary

Removes the hard requirement that gearbox admins register a box on first launch. A new `/welcome` screen is the first-run landing page and lets the admin choose to add a box, enable box-agnostic system gears (currently just Home), both, or neither.

**Why:** the Home gear (launcher tiles / bookmarks / widgets) works without any registered box. The forced "Add a Box" redirect made gearbox unusable for users who only wanted Home.

**One-shot by construction:** the welcome screen is the fallback landing path only while *no box is enabled AND no system gear is enabled*. The moment the admin enables either, the chain routes elsewhere. No "onboarding_complete" flag needed.

### Flow changes

- `LoginPost` ([login.go](gearbox/internal/framework/handler/login.go)) no longer redirects admins to `/settings/boxes/new` when boxes==0. The user's resolved landing path takes over.
- `RootRedirect` fallback chain (when landing path resolves to `/`):
    1. Any box enabled → `/haproxy`
    2. Any system gear enabled → `/home`
    3. Otherwise → `/welcome`

### Welcome screen

[welcome.templ](gearbox/internal/framework/templates/pages/welcome.templ) — full-page no-sidebar layout (login chrome) with one form, two submit buttons sharing the system-gears checkbox state:

- **Add a Box** → enable any checked system gears, redirect to `/settings/boxes/new`.
- **Save & continue without box** → enable any checked system gears, redirect to `/`. RootRedirect picks the landing path. If nothing was checked, the admin lands back on `/welcome` (re-prompt).

CSRF-validated in [onboarding.go](gearbox/internal/framework/handler/onboarding.go). Form-tampered gear names are rejected via `database.IsSystemGear`.

### UX polish from manual testing

- **Sidebar Home visibility:** `InjectIntegrationStatus` ([handler.go](gearbox/internal/framework/handler/handler.go)) was short-circuiting on box-count==0 and dropping system gears from the nav order. System gears now load first regardless; box gears append only if a box exists.
- **`/settings/gears` with no boxes:** previously returned plain-text `"No servers configured"` 400. Now renders the Home gear plus a "No boxes configured" CTA card linking to `/settings/boxes/new`. Inline copy uses "box" terminology to match #49.
- **Toggle component:** the welcome screen's Home checkbox uses the shared `@ui.Toggle` slider ([ui/toggle.templ](gearbox/internal/framework/ui/toggle.templ)) instead of a bare `<input type="checkbox">`. Added a `value` parameter so multiple toggles can share a `name` (multi-select group). [CLAUDE.md](CLAUDE.md) documents this as the canonical pattern for boolean form inputs.
- **Home empty-state icon:** scaled from 20px to 80px via new `HomeIconClass(class)` helper. Sidebar `HomeIcon()` wrapper unchanged (still `w-5 h-5`).

### Files touched

- New: `internal/framework/handler/onboarding.go`, `internal/framework/templates/pages/welcome.templ`
- Modified: `cmd/server/main.go` (route registration), `internal/framework/handler/login.go`, `internal/framework/handler/handler.go`, `internal/framework/handler/gears.go`, `internal/framework/templates/pages/gears.templ`, `internal/framework/templates/pages/haproxy_settings.templ` (dropped `HAProxyBoxesPageNoSidebar`), `internal/framework/ui/toggle.templ`, `internal/gears/home/icons.go`, `internal/gears/home/pages.templ`, `CLAUDE.md`

## Test plan

- [x] Fresh DB → admin first login (after the forced password change) lands on `/welcome`, not `/settings/boxes/new`.
- [x] "Add a Box" with no checkboxes → existing box-creation flow; on return, landing path no longer routes to `/welcome`.
- [x] "Save & continue" with Home checked → Home enabled, lands on `/home`. Next login goes straight to `/home`.
- [x] "Save & continue" with nothing checked → redirected back to `/welcome` (no-op re-prompt).
- [x] Home visible in sidebar when Home is the only enabled gear.
- [x] `/settings/gears` with no boxes renders properly (Home card + "No boxes configured" CTA), no 400.
- [x] `ui.Toggle` slider renders correctly on the welcome screen and submits checked values.
- [x] Existing installs (any box already enabled) → no behavior change at root or login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)