### PR TITLE
fix(passkey): unbreak registration — route mount + localhost gate

### DIFF
--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -398,8 +398,10 @@ func main() {
 	}
 	logger.Info("gear system initialized")
 
-	// Initialize WebAuthn for passkey support
-	if cfg.WebAuthnRPID != "" && cfg.WebAuthnRPID != "localhost" {
+	// Initialize WebAuthn for passkey support. `localhost` is a valid RPID
+	// per the WebAuthn spec and is whitelisted as a secure origin by every
+	// browser specifically for dev — don't gate it out.
+	if cfg.WebAuthnRPID != "" {
 		webAuthnCfg := &auth.WebAuthnConfig{
 			RPDisplayName: cfg.WebAuthnRPDisplayName,
 			RPID:          cfg.WebAuthnRPID,
@@ -416,7 +418,7 @@ func main() {
 				"origins", cfg.WebAuthnRPOrigins)
 		}
 	} else {
-		logger.Info("WebAuthn disabled (requires BASE_URL with non-localhost domain)")
+		logger.Info("WebAuthn disabled (BASE_URL did not yield a hostname)")
 	}
 
 	// Setup router

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -416,6 +416,17 @@ func main() {
 			logger.Info("WebAuthn initialized",
 				"rp_id", cfg.WebAuthnRPID,
 				"origins", cfg.WebAuthnRPOrigins)
+			// If RPID is "localhost" but BASE_URL was never explicitly set,
+			// the operator probably forgot to configure it. Passkey UI will
+			// render but registration will fail at the authenticator with an
+			// opaque origin-mismatch error — warn loudly so the misconfig is
+			// findable in the journal.
+			if cfg.WebAuthnRPID == "localhost" && os.Getenv("BASE_URL") == "" {
+				logger.Warn("WebAuthn RPID is 'localhost' because BASE_URL is unset — " +
+					"passkey UI will appear, but registration from any non-localhost " +
+					"hostname will fail with an origin-mismatch error. Set BASE_URL " +
+					"(or WEBAUTHN_RP_ID/WEBAUTHN_RP_ORIGINS) in production.")
+			}
 		}
 	} else {
 		logger.Info("WebAuthn disabled (BASE_URL did not yield a hostname)")

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -522,6 +522,12 @@ func main() {
 		// (per-user → system → fallback). See feature/dashboard-gear F1.
 		r.Get("/", h.RootRedirect)
 
+		// Passkey registration (authenticated). Mounted at the same /api/passkey
+		// prefix as the public login routes above for URL symmetry; auth is
+		// supplied by this protected group's middleware, not the path.
+		r.Get("/api/passkey/register/begin", h.PasskeyRegisterBegin)
+		r.Post("/api/passkey/register/finish", h.PasskeyRegisterFinish)
+
 		// Settings routes
 		r.Route("/settings", func(r chi.Router) {
 			// Settings menu page (accessible by all authenticated users)
@@ -537,9 +543,7 @@ func main() {
 			r.Get("/change-password", h.ChangePasswordPage)
 			r.Post("/change-password", h.ChangePasswordPost)
 
-			// Passkey management
-			r.Get("/api/passkey/register/begin", h.PasskeyRegisterBegin)
-			r.Post("/api/passkey/register/finish", h.PasskeyRegisterFinish)
+			// Passkey deletion (still under /settings as a profile sub-action)
 			r.Post("/profile/passkey/delete", h.PasskeyDelete)
 
 			// User management routes (require admin or approve_users permission)

--- a/gearbox/internal/framework/handler/passkeys.go
+++ b/gearbox/internal/framework/handler/passkeys.go
@@ -89,8 +89,11 @@ func (h *Handler) PasskeyRegisterBegin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return options to client
+	// Return options to client. The challenge is single-use and bound to
+	// the session ID we just stored — never let an intermediary cache it.
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	json.NewEncoder(w).Encode(PasskeyRegisterBeginResponse{ //#nosec G104
 		Options:   options,
 		SessionID: sessionID,


### PR DESCRIPTION
Closes #44.

## Summary

Two bugs were blocking passkey registration. The 404 was the visible one; the 500 was hiding behind it.

- **Routing (#44):** The two register endpoints were mounted inside `r.Route("/settings", ...)`, so their effective paths were `/settings/api/passkey/register/{begin,finish}`. Every caller (`passkey-registration.js`, the inline JS in `user_pages.templ`) hits `/api/passkey/register/begin` — symmetric with the public `/api/passkey/login/*` routes — and got a 404. Moved the routes up one level into the parent protected group, peer with `/logout` and `/`. They still pick up `RequireAuth`, `RequirePasswordChange`, `InjectIntegrationStatus`, and the 60s timeout from that group — auth is enforced by the group, not the URL prefix. `PasskeyDelete` stays under `/settings/profile/...` because it's a profile-page action, not an API endpoint.
- **WebAuthn init gate:** `cmd/server/main.go` had `if cfg.WebAuthnRPID != "" && cfg.WebAuthnRPID != "localhost"` guarding `auth.NewWebAuthnManager(...)`. Any dev install (`BASE_URL=http://localhost:3000`) got a nil manager, and the handler short-circuited every request with `500 "WebAuthn not configured"`. `localhost` is a valid RPID per the WebAuthn spec (Level 2 §4 / §13.4.8) and is whitelisted as a secure origin by every major browser specifically so dev installs don't need a TLS cert. The `go-webauthn/webauthn` library accepts it without complaint. Removed the localhost-specific exclusion.

Verified end-to-end against the running dev server: `POST /api/passkey/register/begin` now returns 200 with a valid `CredentialCreation` payload (`rp.id=localhost`, fresh challenge, user record), and the browser-driven round-trip (begin → authenticator tap → finish) completes successfully.

## Test plan

- [x] Curl the begin endpoint with a real session cookie — was 404, then 500, now 200 with valid JSON.
- [x] Full browser flow on `localhost:3000`: Settings → Profile → "Add a passkey" → authenticator prompt → passkey appears in the list. Confirmed working.
- [x] `make build` + `make templ-generate` clean.
- [x] Security review (focused on this branch's diff) — no findings. Middleware stack is unchanged for the moved routes (`/settings` chi sub-route adds no middleware of its own); WebAuthn library validates origins against the configured `RPOrigins`, so the localhost gate removal can't be cross-leveraged in a production install.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)