### PR TITLE
feat(updates): surface held packages distinctly with hold/unhold actions

### DIFF
--- a/gearbox-agent/internal/gears/updates/pm_apt.go
+++ b/gearbox-agent/internal/gears/updates/pm_apt.go
@@ -85,7 +85,45 @@ func (a *aptPackageManager) ListUpgradable() ([]Package, error) {
 	}
 	packages := a.parseAptListOutput(string(output))
 	a.fetchPackageSizes(packages)
+	a.markHeldPackages(packages)
 	return packages, nil
+}
+
+// markHeldPackages sets pkg.IsHeld=true for any package whose name appears in
+// `apt-mark showhold`. Held packages can still show up in `apt list --upgradable`
+// when a newer version exists in the repos; apt simply refuses to upgrade them.
+// Marking them lets the dashboard render a "held" badge and route the row to a
+// separate "Held" view instead of the active updates list.
+//
+// Errors from apt-mark are non-fatal: we just leave IsHeld=false rather than
+// failing the whole upgradable listing, since the held lookup is purely an
+// enrichment step.
+func (a *aptPackageManager) markHeldPackages(packages []Package) {
+	if len(packages) == 0 {
+		return
+	}
+	held, err := a.ListHeldPackages()
+	if err != nil {
+		return
+	}
+	applyHeldMarks(packages, held)
+}
+
+// applyHeldMarks is the pure-logic core of markHeldPackages, broken out so it
+// can be unit-tested without execing apt-mark.
+func applyHeldMarks(packages []Package, held []string) {
+	if len(held) == 0 {
+		return
+	}
+	heldSet := make(map[string]struct{}, len(held))
+	for _, name := range held {
+		heldSet[name] = struct{}{}
+	}
+	for i := range packages {
+		if _, ok := heldSet[packages[i].Name]; ok {
+			packages[i].IsHeld = true
+		}
+	}
 }
 
 func (a *aptPackageManager) TriggerUpdateCheck() error {

--- a/gearbox-agent/internal/gears/updates/updates.go
+++ b/gearbox-agent/internal/gears/updates/updates.go
@@ -38,7 +38,8 @@ type Package struct {
 	AvailableVersion string `json:"available_version"`
 	Architecture     string `json:"architecture"`
 	IsSecurityUpdate bool   `json:"is_security_update"`
-	Priority         string `json:"priority"` // low, medium, high, critical
+	IsHeld           bool   `json:"is_held,omitempty"` // Package is held (pinned via apt-mark/dpkg) — apt will not upgrade it even though a newer version is available
+	Priority         string `json:"priority"`          // low, medium, high, critical
 	Repository       string `json:"repository"`
 	Size             int64  `json:"size_bytes"`    // Download size in bytes
 	ChangelogURL     string `json:"changelog_url"` // URL to package changelog (Launchpad)

--- a/gearbox-agent/internal/gears/updates/updates.go
+++ b/gearbox-agent/internal/gears/updates/updates.go
@@ -38,7 +38,10 @@ type Package struct {
 	AvailableVersion string `json:"available_version"`
 	Architecture     string `json:"architecture"`
 	IsSecurityUpdate bool   `json:"is_security_update"`
-	IsHeld           bool   `json:"is_held,omitempty"` // Package is held (pinned via apt-mark/dpkg) — apt will not upgrade it even though a newer version is available
+	// Always serialize is_held — the dashboard filters on `is_held === false`,
+	// so `omitempty` (dropping the field for false values) would cause those
+	// rows to be filtered out by strict-equality checks on the client.
+	IsHeld           bool   `json:"is_held"` // Package is held (pinned via apt-mark/dpkg) — apt will not upgrade it even though a newer version is available
 	Priority         string `json:"priority"`          // low, medium, high, critical
 	Repository       string `json:"repository"`
 	Size             int64  `json:"size_bytes"`    // Download size in bytes
@@ -58,7 +61,7 @@ type InstalledPackage struct {
 	UpdateAvailable  bool      `json:"update_available,omitempty"`
 	AvailableVersion string    `json:"available_version,omitempty"`
 	IsSecurityUpdate bool      `json:"is_security_update,omitempty"`
-	IsHeld           bool      `json:"is_held,omitempty"` // Package is held (pinned) by dpkg/apt-mark
+	IsHeld           bool      `json:"is_held"` // Package is held (pinned) by dpkg/apt-mark — always serialized (see note on Package above)
 	PackageURL       string    `json:"package_url,omitempty"` // Link to package info page
 }
 

--- a/gearbox-agent/internal/gears/updates/updates_test.go
+++ b/gearbox-agent/internal/gears/updates/updates_test.go
@@ -480,3 +480,49 @@ func TestAptSnapshot_Fields(t *testing.T) {
 		t.Error("CreatedAt mismatch")
 	}
 }
+
+// TestApplyHeldMarks verifies that the held-marker correctly flips IsHeld on
+// packages whose names appear in the held list, leaves others alone, and is a
+// no-op when there are no held packages or no packages.
+func TestApplyHeldMarks(t *testing.T) {
+	t.Run("marks held packages and leaves others alone", func(t *testing.T) {
+		pkgs := []Package{
+			{Name: "openssl"},
+			{Name: "linux-image-generic"},
+			{Name: "nginx"},
+		}
+		applyHeldMarks(pkgs, []string{"openssl", "nginx"})
+
+		if !pkgs[0].IsHeld {
+			t.Errorf("openssl should be held")
+		}
+		if pkgs[1].IsHeld {
+			t.Errorf("linux-image-generic should not be held")
+		}
+		if !pkgs[2].IsHeld {
+			t.Errorf("nginx should be held")
+		}
+	})
+
+	t.Run("empty held list is a no-op", func(t *testing.T) {
+		pkgs := []Package{{Name: "openssl"}}
+		applyHeldMarks(pkgs, nil)
+		if pkgs[0].IsHeld {
+			t.Errorf("no packages should be marked when held list is empty")
+		}
+	})
+
+	t.Run("empty packages list is safe", func(t *testing.T) {
+		// Must not panic.
+		applyHeldMarks(nil, []string{"openssl"})
+		applyHeldMarks([]Package{}, []string{"openssl"})
+	})
+
+	t.Run("held name with no matching package is ignored", func(t *testing.T) {
+		pkgs := []Package{{Name: "nginx"}}
+		applyHeldMarks(pkgs, []string{"ghost-package", "nginx"})
+		if !pkgs[0].IsHeld {
+			t.Errorf("nginx should be held")
+		}
+	})
+}

--- a/gearbox/internal/framework/agent/models.go
+++ b/gearbox/internal/framework/agent/models.go
@@ -666,6 +666,7 @@ type Package struct {
 	AvailableVersion string `json:"available_version"`
 	Architecture     string `json:"architecture"`
 	IsSecurityUpdate bool   `json:"is_security_update"`
+	IsHeld           bool   `json:"is_held,omitempty"` // Held packages (apt-mark/dpkg pinned) won't be upgraded even when a newer version is available.
 	Priority         string `json:"priority"`
 	Repository       string `json:"repository"`
 	Size             int64  `json:"size_bytes"`

--- a/gearbox/internal/framework/agent/models.go
+++ b/gearbox/internal/framework/agent/models.go
@@ -666,7 +666,7 @@ type Package struct {
 	AvailableVersion string `json:"available_version"`
 	Architecture     string `json:"architecture"`
 	IsSecurityUpdate bool   `json:"is_security_update"`
-	IsHeld           bool   `json:"is_held,omitempty"` // Held packages (apt-mark/dpkg pinned) won't be upgraded even when a newer version is available.
+	IsHeld           bool   `json:"is_held"` // Held packages (apt-mark/dpkg pinned) won't be upgraded even when a newer version is available. Always serialized so the dashboard's strict-equality filter (`is_held === false`) sees the explicit value.
 	Priority         string `json:"priority"`
 	Repository       string `json:"repository"`
 	Size             int64  `json:"size_bytes"`
@@ -832,7 +832,7 @@ type InstalledPackage struct {
 	UpdateAvailable  bool   `json:"update_available,omitempty"`
 	AvailableVersion string `json:"available_version,omitempty"`
 	IsSecurityUpdate bool   `json:"is_security_update,omitempty"`
-	IsHeld           bool   `json:"is_held,omitempty"`
+	IsHeld           bool   `json:"is_held"` // Always serialized — see note on Package.IsHeld above.
 	PackageURL       string `json:"package_url,omitempty"`
 }
 

--- a/gearbox/internal/framework/templates/pages/os_updates.templ
+++ b/gearbox/internal/framework/templates/pages/os_updates.templ
@@ -223,6 +223,7 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 									class="h-[38px] px-3 py-1.5 text-sm border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								>
 									<option value="updates">Updates</option>
+									<option value="held">Held</option>
 									<option value="all">All Packages</option>
 								</select>
 								if data.CanAction {

--- a/gearbox/static/js/os-updates/os-updates-page.js
+++ b/gearbox/static/js/os-updates/os-updates-page.js
@@ -2055,6 +2055,9 @@ let allPackagesLoaded = false;
 
 // Normalize upgradable Package objects (from /api/os-updates/packages) to the
 // shape expected by the grid (which was designed around InstalledPackage).
+// is_held flows from the agent; held packages can still appear in
+// `apt list --upgradable` when a newer version exists but apt-mark/dpkg has
+// pinned them. The UI surfaces them via a "held" badge and a dedicated tab.
 function normalizeUpgradablePackages(packages) {
 	return packages.map(p => ({
 		name: p.name,
@@ -2064,7 +2067,7 @@ function normalizeUpgradablePackages(packages) {
 		description: '',
 		update_available: true,
 		is_security_update: p.is_security_update || false,
-		is_held: false,
+		is_held: p.is_held || false,
 		package_url: p.package_url || '',
 	}));
 }
@@ -2214,13 +2217,21 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 			title: '',
 			field: 'name',
 			headerSort: false,
-			width: 220,
+			width: 260,
 			hozAlign: 'right',
 			formatter: function(cell) {
 				const row = cell.getRow().getData();
-				const holdBtn = row.is_held
-					? '<button class="pkg-unhold-btn px-2.5 py-1 text-xs bg-yellow-100 dark:bg-yellow-900/30 hover:bg-yellow-200 dark:hover:bg-yellow-900/50 text-yellow-700 dark:text-yellow-400 rounded transition-colors mr-1">Unhold</button>'
-					: '';
+				// Show Unhold for held packages, Hold for any upgradable-but-not-held
+				// row. The action mirrors the existing Unhold pattern and posts to
+				// the matching /api/os-updates/packages/hold endpoint.
+				let holdBtn;
+				if (row.is_held) {
+					holdBtn = '<button class="pkg-unhold-btn px-2.5 py-1 text-xs bg-yellow-100 dark:bg-yellow-900/30 hover:bg-yellow-200 dark:hover:bg-yellow-900/50 text-yellow-700 dark:text-yellow-400 rounded transition-colors mr-1">Unhold</button>';
+				} else if (row.update_available) {
+					holdBtn = '<button class="pkg-hold-btn px-2.5 py-1 text-xs bg-yellow-50 dark:bg-yellow-900/20 hover:bg-yellow-100 dark:hover:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400 rounded transition-colors mr-1">Hold</button>';
+				} else {
+					holdBtn = '';
+				}
 				return holdBtn + '<button class="pkg-remove-btn px-2.5 py-1 text-xs bg-red-100 dark:bg-red-900/30 hover:bg-red-200 dark:hover:bg-red-900/50 text-red-700 dark:text-red-400 rounded transition-colors">Remove</button>';
 			},
 			cellClick: function(e, cell) {
@@ -2229,6 +2240,8 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 					removeInstalledPackageTabulator(cell, name);
 				} else if (e.target.classList.contains('pkg-unhold-btn')) {
 					unholdPackage(name, cell);
+				} else if (e.target.classList.contains('pkg-hold-btn')) {
+					holdPackage(name, cell);
 				}
 			}
 		});
@@ -2271,14 +2284,23 @@ function _applyPkgViewFilter(value, allData) {
 	if (!installedPkgTable) return;
 
 	if (value === 'updates') {
-		installedPkgTable.setFilter('update_available', '=', true);
+		// Active updates: upgradable AND not held. "Hold" is an explicit operator
+		// opt-out from upgrade, so held rows do not belong in the updates view.
+		installedPkgTable.setFilter([
+			{ field: 'update_available', type: '=', value: true },
+			{ field: 'is_held', type: '=', value: false },
+		]);
+	} else if (value === 'held') {
+		installedPkgTable.setFilter('is_held', '=', true);
 	} else {
 		installedPkgTable.clearFilter();
 	}
 
-	// Count packages with updates
-	const updateCount = allData.filter(p => p.update_available).length;
-	const securityCount = allData.filter(p => p.is_security_update).length;
+	// Count packages excluding held ones — held packages are intentionally
+	// excluded from the upgrade plan, so "Update All (N)" should reflect only
+	// what would actually be upgraded.
+	const updateCount = allData.filter(p => p.update_available && !p.is_held).length;
+	const securityCount = allData.filter(p => p.is_security_update && !p.is_held).length;
 
 	// Show/hide Update All button
 	const updateAllBtn = document.getElementById('pkg-update-all-btn');
@@ -2362,6 +2384,44 @@ function removeInstalledPackageTabulator(cell, name) {
 
 // ── Package Hold / Unhold ─────────────────────────────────────────────────────
 
+async function holdPackage(name, cell) {
+	showConfirmModal({
+		title: 'Hold Package',
+		message: 'Hold ' + name + '? This prevents apt from upgrading it until the hold is removed.',
+		type: 'warning',
+		confirmText: 'Hold',
+		onConfirm: async () => {
+			try {
+				const resp = await fetch('/api/os-updates/packages/hold?server=' + currentServerID, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ name: name })
+				});
+				if (!resp.ok) {
+					const errMsg = await extractErrorMessage(resp);
+					throw new Error(errMsg);
+				}
+				showToast(name + ' is now held', 'success');
+				// Flip is_held in place so the row re-renders into the held filter.
+				if (cell) {
+					const row = cell.getRow();
+					const data = row.getData();
+					data.is_held = true;
+					row.update(data);
+					// Re-apply the active filter so the row moves between tabs
+					// without requiring a manual switch.
+					const filterSelect = document.getElementById('pkg-view-filter');
+					if (filterSelect) {
+						_applyPkgViewFilter(filterSelect.value, installedPkgTable.getData());
+					}
+				}
+			} catch (err) {
+				showToast('Failed to hold package: ' + err.message, 'error');
+			}
+		}
+	});
+}
+
 async function unholdPackage(name, cell) {
 	showConfirmModal({
 		title: 'Remove Hold',
@@ -2380,12 +2440,17 @@ async function unholdPackage(name, cell) {
 					throw new Error(errMsg);
 				}
 				showToast(name + ' hold removed', 'success');
-				// Update the row data in-place
+				// Update the row data in-place and reapply the active filter so
+				// the row moves out of the "Held" tab when viewing it.
 				if (cell) {
 					const row = cell.getRow();
 					const data = row.getData();
 					data.is_held = false;
 					row.update(data);
+					const filterSelect = document.getElementById('pkg-view-filter');
+					if (filterSelect) {
+						_applyPkgViewFilter(filterSelect.value, installedPkgTable.getData());
+					}
 				}
 			} catch (err) {
 				showToast('Failed to remove hold: ' + err.message, 'error');

--- a/gearbox/static/js/os-updates/os-updates-page.js
+++ b/gearbox/static/js/os-updates/os-updates-page.js
@@ -2564,15 +2564,28 @@ async function confirmAptInstall() {
 			throw new Error(errMsg);
 		}
 		showToast('Package ' + name + ' installed successfully', 'success');
-		// Destroy and reload the Tabulator grid
+		// Destroy and reload the Tabulator grid. loadInstalledPackages only
+		// fetches the upgradable list (fast path) — if the user was on the
+		// "All Packages" view, we need to also lazy-load the full installed
+		// list so the just-installed package actually appears. Without this,
+		// the post-install grid is empty whenever the filter happens to be
+		// "All" (or "Held"), and the user has to switch view + back to
+		// trigger the full-list fetch manually.
 		if (installedPkgTable) {
 			installedPkgTable.destroy();
 			installedPkgTable = null;
 		}
 		allPackagesLoaded = false;
+		const filterSelect = document.getElementById('pkg-view-filter');
+		const postInstallFilter = filterSelect ? filterSelect.value : 'updates';
 		const el = document.getElementById('installed-packages-table');
 		if (el) el.innerHTML = '<div id="installed-packages-loading" class="flex items-center gap-2 p-4 text-sm text-gray-500 dark:text-slate-400"><svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg> Loading installed packages...</div>';
-		setTimeout(loadInstalledPackages, 500);
+		setTimeout(async () => {
+			await loadInstalledPackages();
+			if (postInstallFilter === 'all') {
+				await loadAllInstalledPackages();
+			}
+		}, 500);
 	} catch (err) {
 		showToast('Failed to install package: ' + err.message, 'error');
 	}


### PR DESCRIPTION
## Summary

- Agent now enriches each upgradable package with `is_held` by parsing `apt-mark showhold` alongside `apt list --upgradable`. Failure is non-fatal — the listing falls back to `IsHeld=false` rather than erroring the whole request.
- The pure-logic enrichment is extracted as `applyHeldMarks` so it can be unit-tested without execing. Covered by `TestApplyHeldMarks`.
- Dashboard `agent.Package` gains the matching `IsHeld` / `is_held` field for JSON round-trip.
- New `Held` option in the pkg-view-filter dropdown (between Updates and All Packages). `Updates` is now `update_available=true AND is_held=false` — held rows belong in their own tab, not the active-upgrades plan.
- `Update All (N)` count and the Security button count both exclude held packages so what's shown matches what `apt upgrade` would actually do.
- New per-row `Hold` button mirrors the existing `Unhold` button. Both POST to the matching `/api/os-updates/packages/{hold,unhold}` endpoints (which already existed). After a hold/unhold the row updates in place and the active filter reapplies so the row moves between Updates and Held tabs without a page refresh.

Closes #45

## Test plan

- [ ] CI green on the new `TestApplyHeldMarks` test
- [ ] On a box with at least one held package: open OS Updates → Updates view excludes it, Held view shows only it
- [ ] `Update All (N)` count matches what `apt upgrade --dry-run` would actually do
- [ ] Click `Hold` on an upgradable package → row moves to Held tab, `Update All` count drops
- [ ] Click `Unhold` on a held package → row moves back to Updates tab
- [ ] Agent without `apt-mark` (or one that errors) → packages still list with `is_held=false` (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)