### PR TITLE
feat(updates): UniFi-style datagrid framework + collapsible sections

### DIFF
--- a/gearbox/internal/framework/handler/os_updates.go
+++ b/gearbox/internal/framework/handler/os_updates.go
@@ -98,11 +98,10 @@ func (h *Handler) OSUpdatesPage(w http.ResponseWriter, r *http.Request) {
 		pythonToolsStatus, _ = client.GetPythonToolsStatus()
 	}
 
-	// Get snapshots
-	snapshots, _ := client.ListSnapshots()
-
-	// Get update history
-	history, _ := client.GetUpdateHistory(20)
+	// Snapshots and update history are now lazy-loaded by the page JS on
+	// first expand of their collapsible sections (see SECTIONS in
+	// os-updates-page.js). Skipping the server-side fetch here saves two
+	// agent round-trips on every page load.
 
 	// Prepare view model
 	data := pages.OSUpdatesPageData{
@@ -115,8 +114,6 @@ func (h *Handler) OSUpdatesPage(w http.ResponseWriter, r *http.Request) {
 		RebootStatus:     rebootStatus,
 		UnattendedConfig: unattendedConfig,
 		PythonToolsStatus: pythonToolsStatus,
-		Snapshots:        snapshots,
-		History:          history,
 		CanConfigure:     h.authManager.HasPermission(r, models.ComponentOSUpdates, models.PermissionConfigure),
 		CanAction:        h.authManager.HasPermission(r, models.ComponentOSUpdates, models.PermissionAction),
 	}

--- a/gearbox/internal/framework/templates/layouts/base.templ
+++ b/gearbox/internal/framework/templates/layouts/base.templ
@@ -292,32 +292,33 @@ templ Base(title string, user *models.User, currentPath ...string) {
 				}
 			}
 
-			/* Dark mode Tabulator */
-			.dark .tabulator {
+			/* Dark mode Tabulator (legacy — for non-datagrid-unifi instances like statusgrid).
+			   New tables should opt into the UniFi skin via createDataGrid(). */
+			.dark .tabulator:not(.datagrid-unifi) {
 				background-color: #1e293b;
 				border-color: #475569;
 			}
-			.dark .tabulator .tabulator-header {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header {
 				background-color: #334155;
 				border-color: #475569;
 				color: #e2e8f0;
 			}
-			.dark .tabulator .tabulator-header .tabulator-col {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-col {
 				background-color: #334155;
 				border-color: #475569;
 			}
-			.dark .tabulator .tabulator-header .tabulator-col .tabulator-col-content {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-col .tabulator-col-content {
 				color: #e2e8f0;
 			}
-			.dark .tabulator .tabulator-header .tabulator-col.tabulator-sortable .tabulator-col-title {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-col.tabulator-sortable .tabulator-col-title {
 				color: #e2e8f0;
 			}
 			/* Header column hover */
-			.dark .tabulator .tabulator-header .tabulator-col:hover {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-col:hover {
 				background-color: #475569 !important;
 			}
-			.dark .tabulator .tabulator-header .tabulator-col:hover .tabulator-col-content,
-			.dark .tabulator .tabulator-header .tabulator-col:hover .tabulator-col-title {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-col:hover .tabulator-col-content,
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-col:hover .tabulator-col-title {
 				color: #ffffff !important;
 			}
 			.tabulator .tabulator-header .tabulator-header-filter input,
@@ -328,55 +329,55 @@ templ Base(title string, user *models.User, currentPath ...string) {
 				height: 24px;
 				font-size: 0.75rem;
 			}
-			.dark .tabulator .tabulator-header .tabulator-header-filter input,
-			.dark .tabulator .tabulator-header .tabulator-header-filter select {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-header-filter input,
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-header .tabulator-header-filter select {
 				background-color: #1e293b;
 				border-color: #475569;
 				color: #e2e8f0;
 			}
-			.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row {
 				background-color: #1e293b !important;
 				border-color: #475569;
 				color: #e2e8f0;
 			}
-			.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row .tabulator-cell {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row .tabulator-cell {
 				background-color: #1e293b !important;
 				border-color: #475569;
 			}
-			.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-even,
-			.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-even .tabulator-cell {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-even,
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-even .tabulator-cell {
 				background-color: #273549 !important;
 			}
-			.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-odd,
-			.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-odd .tabulator-cell {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-odd,
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-odd .tabulator-cell {
 				background-color: #1e293b !important;
 			}
 			/* Hover states - Tabulator uses .tabulator-selectable:hover */
 			@media (hover:hover) and (pointer:fine) {
-				.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover {
+				.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover {
 					background-color: #64748b !important;
 					color: #ffffff !important;
 				}
-				.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover .tabulator-cell {
+				.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover .tabulator-cell {
 					background-color: #64748b !important;
 					color: #ffffff !important;
 				}
-				.dark .tabulator .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover .tabulator-frozen {
+				.dark .tabulator:not(.datagrid-unifi) .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover .tabulator-frozen {
 					background-color: #64748b !important;
 					color: #ffffff !important;
 				}
 			}
-			.dark .tabulator .tabulator-footer {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-footer {
 				background-color: #334155;
 				border-color: #475569;
 				color: #e2e8f0;
 			}
-			.dark .tabulator .tabulator-footer .tabulator-page {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-footer .tabulator-page {
 				background-color: #1e293b;
 				border-color: #475569;
 				color: #e2e8f0;
 			}
-			.dark .tabulator .tabulator-footer .tabulator-page.active {
+			.dark .tabulator:not(.datagrid-unifi) .tabulator-footer .tabulator-page.active {
 				background-color: #3b82f6;
 				color: white;
 			}
@@ -394,6 +395,8 @@ templ Base(title string, user *models.User, currentPath ...string) {
 		<link rel="stylesheet" href="/static/css/components/cards.css"/>
 		<link rel="stylesheet" href="/static/css/components/modals.css"/>
 		<link rel="stylesheet" href="/static/css/components/buttons.css"/>
+		<link rel="stylesheet" href="/static/css/components/datagrid.css"/>
+		<script src="/static/js/common/datagrid.js"></script>
 		<script>
 			// Theme management
 			function getThemePreference() {

--- a/gearbox/internal/framework/templates/pages/os_updates.templ
+++ b/gearbox/internal/framework/templates/pages/os_updates.templ
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,18 @@ import (
 	"github.com/sarg3nt/gearbox/internal/framework/templates/components"
 	"github.com/sarg3nt/gearbox/internal/framework/templates/layouts"
 )
+
+// jsonScriptBody marshals v to JSON and escapes any "</" so it can safely sit
+// inside a <script type="application/json"> tag without prematurely closing
+// the script element. Returns "null" on marshal failure rather than blowing
+// up the page render.
+func jsonScriptBody(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "null"
+	}
+	return strings.ReplaceAll(string(b), "</", `<\/`)
+}
 
 // OSUpdatesPageData contains all data needed for the OS updates page.
 type OSUpdatesPageData struct {
@@ -59,18 +72,12 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 			</div>
 			<div class="flex-1"></div>
 			<div class="flex items-center space-x-3">
-				if data.CanAction {
-					<button
-						id="check-updates-btn"
-						onclick="checkForUpdates()"
-						class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors flex items-center gap-2"
-					>
-						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-						</svg>
-						Check for Updates
-					</button>
-				}
+				<!-- LiveRefreshButton serves dual purpose here: its color reflects
+				     the SSE connection (green = live apt-event stream), and clicking
+				     it triggers checkForUpdates() — which queries apt for new
+				     versions and refreshes the cards + grid in place. SSE itself
+				     does NOT poll for new updates; manual click (or page reload) is
+				     the only way to refresh that state. -->
 				@components.LiveRefreshButton()
 			</div>
 		</div>
@@ -217,6 +224,18 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 										</button>
 									}
 								}
+								<span class="datagrid-search-wrap">
+									<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z"></path>
+									</svg>
+									<input
+										type="search"
+										id="pkg-search"
+										placeholder="Search packages..."
+										class="h-[38px] pr-3 text-sm border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 w-56"
+										autocomplete="off"
+									/>
+								</span>
 								<select
 									id="pkg-view-filter"
 									onchange="onPkgViewFilterChange(this.value)"
@@ -242,8 +261,12 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 						</div>
 					</div>
 					<div class="p-4">
-						<div id="installed-packages-table" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden">
-							<div id="installed-packages-loading" class="p-8 text-center text-gray-500 dark:text-gray-400 flex items-center justify-center gap-2">
+						<!-- Fixed height (474px) matches the gridHeight computed in
+						     os-updates-page.js (ROW_HEIGHT 36 × 12 visible rows + 42px
+						     header). Pre-sizing the container avoids a layout shift
+						     when Tabulator replaces the loading state with the grid. -->
+						<div id="installed-packages-table" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden" style="height: 474px">
+							<div id="installed-packages-loading" class="h-full flex items-center justify-center gap-2 text-sm text-gray-500 dark:text-gray-400">
 								<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
 								Loading packages...
 							</div>
@@ -253,132 +276,54 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 					</div>
 				</div>
 
-				<!-- Snapshots Section -->
-				<div class="bg-white dark:bg-slate-800 rounded-lg shadow">
-					<div class="p-4 border-b border-gray-200 dark:border-slate-700">
-						<div class="flex justify-between items-center">
+				<!-- Snapshots Section: collapsible, lazy-loaded on first expand.
+				     Live updates: whenever an apt operation completes (SSE event)
+				     and this section is open, the grid is refetched. -->
+				<details class="datagrid-card bg-white dark:bg-slate-800 rounded-lg shadow" data-section="snapshots">
+					<summary class="p-4 border-b border-gray-200 dark:border-slate-700 flex justify-between items-center gap-3">
+						<div class="flex items-center gap-3">
+							<svg class="datagrid-chevron w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+							</svg>
 							<div>
 								<h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Package Snapshots</h3>
 								<p class="text-sm text-gray-500 dark:text-gray-400">Restore to a previous package state</p>
 							</div>
-							if data.CanAction {
-								<div class="flex gap-2 items-center">
-									<button
-										id="bulk-delete-snapshots-btn"
-										onclick="bulkDeleteSnapshots()"
-										class="hidden px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
-									>
-										Delete Selected
-									</button>
-									<button
-										onclick="createManualSnapshot()"
-										class="px-3 py-1.5 text-sm bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
-									>
-										Create Snapshot
-									</button>
-								</div>
-							}
 						</div>
+						if data.CanAction {
+							<div class="flex gap-2 items-center">
+								<button
+									id="bulk-delete-snapshots-btn"
+									onclick="bulkDeleteSnapshots()"
+									class="hidden px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
+								>
+									Delete Selected
+								</button>
+								<button
+									onclick="createManualSnapshot()"
+									class="px-3 py-1.5 text-sm bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
+								>
+									Create Snapshot
+								</button>
+							</div>
+						}
+					</summary>
+					<div class="p-4">
+						<div id="snapshots-grid" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden"></div>
 					</div>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm">
-							<thead class="bg-gray-50 dark:bg-slate-700">
-								<tr>
-									if data.CanAction {
-										<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 w-10">
-											<input type="checkbox" id="select-all-snapshots" onchange="toggleSelectAllSnapshots(this.checked)" class="w-4 h-4 rounded border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700"/>
-										</th>
-									}
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Name</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Type</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Description</th>
-									if data.CanAction {
-										<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Actions</th>
-									}
-								</tr>
-							</thead>
-							<tbody id="snapshots-table" class="divide-y divide-gray-200 dark:divide-slate-600">
-								if data.Snapshots == nil || len(data.Snapshots.Snapshots) == 0 {
-									<tr>
-										<td colspan="6" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-											No snapshots available
-										</td>
-									</tr>
-								} else {
-									for i, snapshot := range data.Snapshots.Snapshots {
-										<tr class="hover:bg-gray-50 dark:hover:bg-slate-700" data-snapshot-row={ snapshot.ID }>
-											if data.CanAction {
-												<td class="px-4 py-3">
-													<input
-														type="checkbox"
-														class="snapshot-checkbox w-4 h-4 rounded border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700"
-														data-snapshot-id={ snapshot.ID }
-														onchange="updateBulkDeleteButton()"
-													/>
-												</td>
-											}
-											<td class="px-4 py-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">
-												<span class="snapshot-date" data-timestamp={ snapshot.CreatedAt }>{ snapshot.CreatedAt }</span>
-											</td>
-											<td class="px-4 py-3 text-gray-800 dark:text-gray-200 font-medium">
-												{ snapshot.ID }
-											</td>
-											<td class="px-4 py-3">
-												<div class="flex items-center gap-1.5">
-													if isAutoSnapshot(snapshot.Reason) {
-														<span class="px-2 py-0.5 text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded font-medium">auto</span>
-													} else {
-														<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-slate-600 text-gray-600 dark:text-gray-400 rounded font-medium">manual</span>
-													}
-													if i == 0 {
-														<span class="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded font-medium">Latest</span>
-													}
-												</div>
-											</td>
-											<td class="px-4 py-3 text-gray-600 dark:text-gray-400">
-												{ snapshotDescription(snapshot.Reason) }
-											</td>
-											if data.CanAction {
-												<td class="px-4 py-3">
-													<div class="flex gap-2">
-														<button
-															class="snapshot-preview-btn text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs font-medium"
-															data-snapshot-id={ snapshot.ID }
-														>
-															Preview
-														</button>
-														<button
-															class="snapshot-restore-btn text-yellow-600 dark:text-yellow-400 hover:text-yellow-800 dark:hover:text-yellow-300 text-xs font-medium"
-															data-snapshot-id={ snapshot.ID }
-														>
-															Restore
-														</button>
-														<button
-															class="snapshot-delete-btn text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-xs font-medium"
-															data-snapshot-id={ snapshot.ID }
-														>
-															Delete
-														</button>
-													</div>
-												</td>
-											}
-										</tr>
-									}
-								}
-							</tbody>
-						</table>
-					</div>
-				</div>
+				</details>
 
-				<!-- Python CLI Tools Section -->
-				if data.Config != nil && data.Config.ShowPythonTools {
+				<!-- Python CLI Tools Section.
+				     Only rendered when at least one of pipx/pip is available on the
+				     target system, so empty subsections don't waste screen space. -->
+				if data.Config != nil && data.Config.ShowPythonTools && data.PythonToolsStatus != nil && (data.PythonToolsStatus.Pipx.Available || data.PythonToolsStatus.Pip.Available) {
 					<div class="bg-white dark:bg-slate-800 rounded-lg shadow">
 						<div class="p-4 border-b border-gray-200 dark:border-slate-700">
 							<h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Python CLI Tools</h3>
 							<p class="text-sm text-gray-500 dark:text-gray-400">Manage Python packages and applications</p>
 						</div>
 
+						if data.PythonToolsStatus.Pipx.Available {
 						<!-- pipx subsection -->
 						<div class="p-4 border-b border-gray-200 dark:border-slate-700">
 							<div class="flex justify-between items-center mb-3">
@@ -417,79 +362,15 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 									Clear
 								</button>
 							</div>
-							<div id="pipx-list" class="overflow-x-auto rounded-lg border border-gray-200 dark:border-slate-600">
-								if data.PythonToolsStatus == nil || !data.PythonToolsStatus.Pipx.Available {
-									<div class="p-6 text-center text-gray-500 dark:text-gray-400">
-										pipx is not available on this system
-									</div>
-								} else if len(data.PythonToolsStatus.Pipx.Packages) == 0 {
-									<div class="p-6 text-center text-gray-500 dark:text-gray-400">
-										No pipx packages installed
-									</div>
-								} else {
-									<table class="w-full text-sm">
-										<thead class="bg-gray-50 dark:bg-slate-700 border-b border-gray-200 dark:border-slate-600">
-											<tr>
-												if data.CanAction {
-													<th class="px-3 py-3 w-8">
-														<input type="checkbox" id="pipx-select-all" class="rounded border-gray-300 dark:border-slate-500 text-blue-600 focus:ring-blue-500" onchange="togglePipxSelectAll(this)"/>
-													</th>
-												}
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Package</th>
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Installed</th>
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Latest</th>
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Apps</th>
-												if data.CanAction {
-													<th class="px-4 py-3 w-40"></th>
-												}
-											</tr>
-										</thead>
-										<tbody class="divide-y divide-gray-200 dark:divide-slate-600">
-											for _, pkg := range data.PythonToolsStatus.Pipx.Packages {
-												<tr class="hover:bg-gray-50 dark:hover:bg-slate-700 pipx-row" data-package-name={ pkg.Name }>
-													if data.CanAction {
-														<td class="px-3 py-3">
-															<input type="checkbox" class="pipx-checkbox rounded border-gray-300 dark:border-slate-500 text-blue-600 focus:ring-blue-500" value={ pkg.Name } onchange="onPipxCheckboxChange()"/>
-														</td>
-													}
-													<td class="px-4 py-3 text-gray-800 dark:text-gray-200 font-medium">{ pkg.Name }</td>
-													<td class="px-4 py-3 text-gray-600 dark:text-gray-400 font-mono text-xs">{ pkg.Version }</td>
-													<td class="px-4 py-3 font-mono text-xs pipx-version-cell" data-package={ pkg.Name } data-installed={ pkg.Version }>
-														<svg class="w-3.5 h-3.5 animate-spin text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-													</td>
-													<td class="px-4 py-3 text-gray-500 dark:text-gray-400 text-xs">
-														if len(pkg.Apps) > 0 {
-															{ joinStrings(pkg.Apps, ", ") }
-														} else {
-															<span class="text-gray-400 dark:text-gray-500">—</span>
-														}
-													</td>
-													if data.CanAction {
-														<td class="px-4 py-3">
-															<div class="flex gap-2 justify-end">
-																<button
-																	class="pipx-upgrade-btn px-3 py-1.5 text-sm bg-blue-100 dark:bg-blue-900/30 hover:bg-blue-200 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-400 rounded-lg transition-colors flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed"
-																	data-package-name={ pkg.Name }
-																>
-																	Upgrade
-																</button>
-																<button
-																	class="pipx-uninstall-btn px-3 py-1.5 text-sm bg-red-100 dark:bg-red-900/30 hover:bg-red-200 dark:hover:bg-red-900/50 text-red-700 dark:text-red-400 rounded-lg transition-colors"
-																	data-package-name={ pkg.Name }
-																>
-																	Uninstall
-																</button>
-															</div>
-														</td>
-													}
-												</tr>
-											}
-										</tbody>
-									</table>
-								}
-							</div>
+							<!-- Initial package data embedded as JSON for the datagrid.
+							     PyPI latest-version lookups happen async via
+							     loadPythonVersions() once the grid is built. -->
+							@templ.Raw("<script type=\"application/json\" id=\"pipx-data\">" + jsonScriptBody(data.PythonToolsStatus.Pipx.Packages) + "</script>")
+							<div id="pipx-grid" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden"></div>
 						</div>
+						}
 
+						if data.PythonToolsStatus.Pip.Available {
 						<!-- pip subsection -->
 						<div class="p-4">
 							<div class="flex justify-between items-center mb-3">
@@ -528,162 +409,45 @@ templ OSUpdatesPage(data OSUpdatesPageData) {
 									Clear
 								</button>
 							</div>
-							<div id="pip-list" class="overflow-x-auto rounded-lg border border-gray-200 dark:border-slate-600">
-								if data.PythonToolsStatus == nil || !data.PythonToolsStatus.Pip.Available {
-									<div class="p-6 text-center text-gray-500 dark:text-gray-400">
-										pip is not available on this system
-									</div>
-								} else if len(data.PythonToolsStatus.Pip.Packages) == 0 {
-									<div class="p-6 text-center text-gray-500 dark:text-gray-400">
-										No user-installed pip packages
-									</div>
-								} else {
-									<table class="w-full text-sm">
-										<thead class="bg-gray-50 dark:bg-slate-700 border-b border-gray-200 dark:border-slate-600">
-											<tr>
-												if data.CanAction {
-													<th class="px-3 py-3 w-8">
-														<input type="checkbox" id="pip-select-all" class="rounded border-gray-300 dark:border-slate-500 text-blue-600 focus:ring-blue-500" onchange="togglePipSelectAll(this)"/>
-													</th>
-												}
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Package</th>
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Installed</th>
-												<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Latest</th>
-												if data.CanAction {
-													<th class="px-4 py-3 w-40"></th>
-												}
-											</tr>
-										</thead>
-										<tbody class="divide-y divide-gray-200 dark:divide-slate-600">
-											for _, pkg := range data.PythonToolsStatus.Pip.Packages {
-												<tr class="hover:bg-gray-50 dark:hover:bg-slate-700 pip-row" data-package-name={ pkg.Name }>
-													if data.CanAction {
-														<td class="px-3 py-3">
-															<input type="checkbox" class="pip-checkbox rounded border-gray-300 dark:border-slate-500 text-blue-600 focus:ring-blue-500" value={ pkg.Name } onchange="onPipCheckboxChange()"/>
-														</td>
-													}
-													<td class="px-4 py-3 text-gray-800 dark:text-gray-200 font-medium">{ pkg.Name }</td>
-													<td class="px-4 py-3 text-gray-600 dark:text-gray-400 font-mono text-xs">{ pkg.Version }</td>
-													<td class="px-4 py-3 font-mono text-xs pip-version-cell" data-package={ pkg.Name } data-installed={ pkg.Version }>
-														<svg class="w-3.5 h-3.5 animate-spin text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-													</td>
-													if data.CanAction {
-														<td class="px-4 py-3">
-															<div class="flex gap-2 justify-end">
-																<button
-																	class="pip-upgrade-btn px-3 py-1.5 text-sm bg-blue-100 dark:bg-blue-900/30 hover:bg-blue-200 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-400 rounded-lg transition-colors flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed"
-																	data-package-name={ pkg.Name }
-																>
-																	Upgrade
-																</button>
-																<button
-																	class="pip-uninstall-btn px-3 py-1.5 text-sm bg-red-100 dark:bg-red-900/30 hover:bg-red-200 dark:hover:bg-red-900/50 text-red-700 dark:text-red-400 rounded-lg transition-colors"
-																	data-package-name={ pkg.Name }
-																>
-																	Uninstall
-																</button>
-															</div>
-														</td>
-													}
-												</tr>
-											}
-										</tbody>
-									</table>
-								}
-							</div>
+							@templ.Raw("<script type=\"application/json\" id=\"pip-data\">" + jsonScriptBody(data.PythonToolsStatus.Pip.Packages) + "</script>")
+							<div id="pip-grid" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden"></div>
 						</div>
+						}
 					</div>
 				}
 
-				<!-- Update History -->
-				<div class="bg-white dark:bg-slate-800 rounded-lg shadow">
-					<div class="p-4 border-b border-gray-200 dark:border-slate-700">
-						<h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Update History</h3>
-						<p class="text-sm text-gray-500 dark:text-gray-400">Recent package changes</p>
+				<!-- Update History: collapsible, lazy-loaded on first expand. -->
+				<details class="datagrid-card bg-white dark:bg-slate-800 rounded-lg shadow" data-section="history">
+					<summary class="p-4 border-b border-gray-200 dark:border-slate-700 flex items-center gap-3">
+						<svg class="datagrid-chevron w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+						</svg>
+						<div>
+							<h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Update History</h3>
+							<p class="text-sm text-gray-500 dark:text-gray-400">Recent package changes</p>
+						</div>
+					</summary>
+					<div class="p-4">
+						<div id="history-grid" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden"></div>
 					</div>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm">
-							<thead class="bg-gray-50 dark:bg-slate-700">
-								<tr>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Timestamp</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Action</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Package</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Version Change</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Status</th>
-								</tr>
-							</thead>
-							<tbody id="history-table" class="divide-y divide-gray-200 dark:divide-slate-600">
-								if data.History == nil || len(data.History.History) == 0 {
-									<tr>
-										<td colspan="5" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-											No update history available
-										</td>
-									</tr>
-								} else {
-									for _, entry := range data.History.History {
-										<tr class="hover:bg-gray-50 dark:hover:bg-slate-700">
-											<td class="px-4 py-3 text-gray-600 dark:text-gray-400">{ entry.Timestamp }</td>
-											<td class="px-4 py-3">
-												<span class={ "px-2 py-1 text-xs rounded", getActionColor(entry.Action) }>{ entry.Action }</span>
-											</td>
-											<td class="px-4 py-3 text-gray-800 dark:text-gray-200 font-medium">{ entry.Package }</td>
-											<td class="px-4 py-3 text-gray-600 dark:text-gray-400 font-mono text-xs">
-												if entry.FromVersion != "" && entry.ToVersion != "" {
-													{ entry.FromVersion } → { entry.ToVersion }
-												} else if entry.ToVersion != "" {
-													{ entry.ToVersion }
-												} else {
-													-
-												}
-											</td>
-											<td class="px-4 py-3">
-												if entry.Status == "success" || entry.Status == "install" || entry.Status == "upgrade" {
-													<span class="px-2 py-1 text-xs bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 rounded">Success</span>
-												} else if entry.Status == "remove" || entry.Status == "purge" {
-													<span class="px-2 py-1 text-xs bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 rounded">Removed</span>
-												} else {
-													<span class="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">{ entry.Status }</span>
-												}
-											</td>
-										</tr>
-									}
-								}
-							</tbody>
-						</table>
-					</div>
-				</div>
-					<!-- Update Logs -->
-				<div class="bg-white dark:bg-slate-800 rounded-lg shadow">
-					<div class="p-4 border-b border-gray-200 dark:border-slate-700 flex items-center justify-between">
+				</details>
+				<!-- Update Logs: collapsible, lazy-loaded on first expand.
+				     Replaces the previous "Load Logs" button — opening the section
+				     fetches the logs. -->
+				<details class="datagrid-card bg-white dark:bg-slate-800 rounded-lg shadow" data-section="logs">
+					<summary class="p-4 border-b border-gray-200 dark:border-slate-700 flex items-center gap-3">
+						<svg class="datagrid-chevron w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+						</svg>
 						<div>
 							<h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Update Logs</h3>
 							<p class="text-sm text-gray-500 dark:text-gray-400">Logs from apt operations run through Gearbox</p>
 						</div>
-						<button onclick="loadUpdateLogs()" class="px-3 py-1.5 text-sm bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors">
-							Load Logs
-						</button>
+					</summary>
+					<div class="p-4">
+						<div id="logs-grid" class="rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden"></div>
 					</div>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm">
-							<thead class="bg-gray-50 dark:bg-slate-700">
-								<tr>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Type</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Status</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Details</th>
-									<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Actions</th>
-								</tr>
-							</thead>
-							<tbody id="update-logs-table" class="divide-y divide-gray-200 dark:divide-slate-600">
-								<tr>
-									<td colspan="5" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-										Click "Load Logs" to view apt operation logs
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</div>
+				</details>
 			</div>
 
 			<!-- Update Log Detail Modal -->

--- a/gearbox/static/css/components/datagrid.css
+++ b/gearbox/static/css/components/datagrid.css
@@ -1,0 +1,288 @@
+/* UniFi-style data grid — Tabulator skin.
+ *
+ * Opt-in: applied to a Tabulator instance via the `datagrid-unifi` CSS class
+ * (set automatically by createDataGrid() in static/js/common/datagrid.js).
+ *
+ * Pairs with: flat header, accent on active sort column, hover-only sort
+ * arrows, no zebra stripes, dense rows. Use with a toolbar-mounted search
+ * input — do NOT enable per-column headerFilter.
+ */
+
+/* ---- Container ---- */
+.tabulator.datagrid-unifi {
+	background-color: transparent;
+	border: none;
+	font-size: 0.875rem;
+}
+
+/* ---- Header: flat, no background, no column dividers ---- */
+.tabulator.datagrid-unifi .tabulator-header {
+	background-color: transparent;
+	border-top: none;
+	border-bottom: 1px solid #e2e8f0;
+	color: #64748b;
+	font-weight: 500;
+}
+.dark .tabulator.datagrid-unifi .tabulator-header {
+	border-bottom-color: #334155;
+	color: #94a3b8;
+}
+
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col {
+	background-color: transparent;
+	border-right: none;
+	padding: 0.5rem 0.25rem;
+}
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col .tabulator-col-content {
+	padding: 0.25rem 0.5rem;
+}
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col.tabulator-sortable .tabulator-col-title {
+	color: inherit;
+	font-weight: 500;
+	text-transform: none;
+	letter-spacing: 0;
+}
+
+/* Header hover: brighten text only (no background flash) */
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col:hover {
+	background-color: transparent !important;
+}
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col:hover .tabulator-col-content,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col:hover .tabulator-col-title {
+	color: #1e293b !important;
+}
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col:hover .tabulator-col-content,
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col:hover .tabulator-col-title {
+	color: #f1f5f9 !important;
+}
+
+/* ---- Sort arrows: hidden by default, visible on hover or when active ---- */
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col.tabulator-sortable .tabulator-col-sorter {
+	opacity: 0;
+	transition: opacity 0.15s ease-in-out;
+}
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col.tabulator-sortable:hover .tabulator-col-sorter,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"] .tabulator-col-sorter,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"] .tabulator-col-sorter {
+	opacity: 1;
+}
+
+/* ---- Active sort column: blue accent on title + arrow ---- */
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"] .tabulator-col-title,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"] .tabulator-col-title,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"]:hover .tabulator-col-title,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"]:hover .tabulator-col-title {
+	color: #2563eb !important;
+}
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"] .tabulator-col-title,
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"] .tabulator-col-title,
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"]:hover .tabulator-col-title,
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"]:hover .tabulator-col-title {
+	color: #3b82f6 !important;
+}
+/* Color the sorter arrow to match */
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"] .tabulator-arrow,
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"] .tabulator-arrow {
+	border-bottom-color: #2563eb !important;
+	border-top-color: #2563eb !important;
+}
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="ascending"] .tabulator-arrow,
+.dark .tabulator.datagrid-unifi .tabulator-header .tabulator-col[aria-sort="descending"] .tabulator-arrow {
+	border-bottom-color: #3b82f6 !important;
+	border-top-color: #3b82f6 !important;
+}
+
+/* ---- Body: no zebra stripes ---- */
+.tabulator.datagrid-unifi .tabulator-tableholder {
+	background-color: transparent;
+}
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table {
+	background-color: transparent;
+}
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row,
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-even,
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-odd {
+	background-color: transparent !important;
+}
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row .tabulator-cell,
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-even .tabulator-cell,
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-row-odd .tabulator-cell {
+	background-color: transparent !important;
+	border-right: none;
+}
+
+/* Row separator: single subtle horizontal line */
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row {
+	border-bottom: 1px solid #f1f5f9;
+	color: #1e293b;
+}
+.dark .tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row {
+	border-bottom-color: #1e293b;
+	color: #e2e8f0 !important;
+}
+
+.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row .tabulator-cell {
+	padding: 0.625rem 0.75rem;
+}
+
+/* Subtle row hover.
+ * Only background changes — the row's base color (set above) carries through.
+ * Do NOT set `color` here: legacy Tabulator CSS used `color: inherit !important`
+ * to defeat its own white-text override, but `inherit` cascades up past our
+ * base row-color rule and ends near the page-body color, which is roughly the
+ * hover background. Result: any cell text without its own explicit color class
+ * (e.g. unstyled `<span>`s in the Installed Version / Description columns)
+ * becomes unreadable. With the legacy rules now scoped to :not(.datagrid-unifi),
+ * we can leave color alone and the base #e2e8f0 / #1e293b row color stands.
+ */
+@media (hover: hover) and (pointer: fine) {
+	.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover {
+		background-color: #f8fafc !important;
+	}
+	.tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover .tabulator-cell {
+		background-color: transparent !important;
+	}
+	.dark .tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover {
+		background-color: rgba(148, 163, 184, 0.10) !important;
+	}
+	.dark .tabulator.datagrid-unifi .tabulator-tableholder .tabulator-table .tabulator-row.tabulator-selectable:hover .tabulator-cell {
+		background-color: transparent !important;
+	}
+}
+
+/* ---- Column drag affordance ---- */
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col {
+	cursor: grab;
+}
+.tabulator.datagrid-unifi .tabulator-header .tabulator-col.tabulator-moving {
+	background-color: rgba(59, 130, 246, 0.12) !important;
+	cursor: grabbing;
+}
+
+/* ---- Row selection checkboxes ----
+ * Tabulator emits its own checkbox via the `rowSelection` formatter. We
+ * replace the native browser checkbox with a themed one: subtle hollow box
+ * by default, blue-filled with a white checkmark when checked, blue-filled
+ * with a horizontal dash when indeterminate (header partial-select).
+ */
+.tabulator.datagrid-unifi .tabulator-cell.tabulator-row-handle,
+.tabulator.datagrid-unifi .tabulator-col .tabulator-col-content .tabulator-col-title {
+	user-select: none;
+}
+
+.tabulator.datagrid-unifi input[type="checkbox"] {
+	appearance: none;
+	-webkit-appearance: none;
+	width: 16px;
+	height: 16px;
+	margin: 0;
+	padding: 0;
+	border: 1.5px solid #cbd5e1;
+	border-radius: 3px;
+	background-color: #ffffff;
+	cursor: pointer;
+	vertical-align: middle;
+	position: relative;
+	transition: background-color 0.12s ease, border-color 0.12s ease;
+	flex-shrink: 0;
+}
+.dark .tabulator.datagrid-unifi input[type="checkbox"] {
+	border-color: #475569;
+	background-color: rgba(15, 23, 42, 0.6);
+}
+.tabulator.datagrid-unifi input[type="checkbox"]:hover {
+	border-color: #3b82f6;
+}
+.tabulator.datagrid-unifi input[type="checkbox"]:focus-visible {
+	outline: 2px solid rgba(59, 130, 246, 0.5);
+	outline-offset: 1px;
+}
+.tabulator.datagrid-unifi input[type="checkbox"]:checked,
+.tabulator.datagrid-unifi input[type="checkbox"]:indeterminate {
+	background-color: #3b82f6;
+	border-color: #3b82f6;
+}
+/* Checkmark (drawn via two borders forming an inverted L, rotated 45deg) */
+.tabulator.datagrid-unifi input[type="checkbox"]:checked::after {
+	content: '';
+	position: absolute;
+	left: 4px;
+	top: 1px;
+	width: 4px;
+	height: 8px;
+	border: solid #ffffff;
+	border-width: 0 2px 2px 0;
+	transform: rotate(45deg);
+}
+/* Indeterminate dash */
+.tabulator.datagrid-unifi input[type="checkbox"]:indeterminate::after {
+	content: '';
+	position: absolute;
+	left: 2px;
+	right: 2px;
+	top: 50%;
+	height: 2px;
+	margin-top: -1px;
+	background-color: #ffffff;
+	border-radius: 1px;
+}
+
+.tabulator.datagrid-unifi .tabulator-row.tabulator-selected {
+	background-color: rgba(59, 130, 246, 0.08) !important;
+}
+.dark .tabulator.datagrid-unifi .tabulator-row.tabulator-selected {
+	background-color: rgba(59, 130, 246, 0.14) !important;
+}
+
+/* ---- Collapsible card chrome ----
+ * Used by <details class="datagrid-card"> sections. The native chevron is
+ * hidden in favor of a custom one rendered inside the summary, so we can
+ * place the title + action buttons on the same row and rotate the chevron
+ * with the open state.
+ */
+details.datagrid-card > summary {
+	list-style: none;
+	cursor: pointer;
+	user-select: none;
+}
+details.datagrid-card > summary::-webkit-details-marker {
+	display: none;
+}
+details.datagrid-card > summary .datagrid-chevron {
+	transition: transform 0.2s ease-in-out;
+}
+details.datagrid-card[open] > summary .datagrid-chevron {
+	transform: rotate(90deg);
+}
+
+/* ---- Placeholder ---- */
+.tabulator.datagrid-unifi .tabulator-placeholder {
+	background-color: transparent;
+	color: #64748b;
+}
+.dark .tabulator.datagrid-unifi .tabulator-placeholder {
+	color: #94a3b8;
+}
+
+/* ---- Toolbar search input affordance (paired with createDataGrid) ----
+ * The grid factory wires a global search input. This rule styles any input
+ * marked with `data-datagrid-search` so the icon + padding are consistent
+ * across pages without having to repeat Tailwind classes.
+ */
+.datagrid-search-wrap {
+	position: relative;
+	display: inline-block;
+}
+.datagrid-search-wrap > svg {
+	position: absolute;
+	left: 0.625rem;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 1rem;
+	height: 1rem;
+	color: #94a3b8;
+	pointer-events: none;
+}
+.datagrid-search-wrap > input[type="search"] {
+	padding-left: 2rem;
+}

--- a/gearbox/static/js/common/datagrid.js
+++ b/gearbox/static/js/common/datagrid.js
@@ -1,0 +1,166 @@
+/**
+ * createDataGrid — UniFi-style Tabulator wrapper.
+ *
+ * Wraps `new Tabulator(...)` with the gearbox house style:
+ *   - flat, accent-on-active-sort header (CSS in components/datagrid.css)
+ *   - hover-only sort arrows
+ *   - columns are draggable to reorder
+ *   - per-column header filters are NOT used; instead an external search
+ *     input is wired as a universal filter across every searchable field
+ *
+ * Usage:
+ *
+ *     const grid = createDataGrid('#my-table', {
+ *         columns: [...],                  // standard Tabulator column defs
+ *         data:    [...],
+ *         searchInput:  '#my-search',      // optional <input> selector/element
+ *         searchFields: ['name', 'desc'],  // optional (default: every column with a `field`)
+ *         // ...any other Tabulator options pass through
+ *     });
+ *
+ *     grid.setViewFilters([{field: 'status', type: '=', value: 'active'}]);
+ *     grid.clearViewFilters();
+ *
+ * The returned object is the raw Tabulator instance with two extra methods
+ * (`setViewFilters` / `clearViewFilters`) that compose with the search filter.
+ * Do NOT call `table.setFilter()` directly when using a search input — it
+ * will wipe the search. Use `setViewFilters` instead.
+ */
+(function () {
+	'use strict';
+
+	function createDataGrid(target, opts) {
+		opts = opts || {};
+		const {
+			columns,
+			data,
+			searchInput,
+			searchFields,
+			cssClass: extraCssClass,
+			...rest
+		} = opts;
+
+		const cssClass = (extraCssClass ? extraCssClass + ' ' : '') + 'datagrid-unifi';
+
+		const table = new Tabulator(target, Object.assign({
+			data: data || [],
+			columns: columns,
+			layout: 'fitColumns',
+			sortMode: 'local',
+			filterMode: 'local',
+			movableColumns: true,
+		}, rest, { cssClass: cssClass }));
+
+		// Tabulator's `cssClass` option records the class but does not always
+		// add it to the host element we passed in (depends on whether the
+		// element starts empty or already had Tabulator markup). Add it
+		// directly so our CSS selectors match unconditionally.
+		const hostEl = typeof target === 'string' ? document.querySelector(target) : target;
+		if (hostEl) {
+			cssClass.split(/\s+/).filter(Boolean).forEach(c => hostEl.classList.add(c));
+		}
+
+		// Filter state: view filters (e.g. "Updates / Held / All" dropdown) and
+		// search text. We compose both into a single setFilter call so they
+		// don't clobber each other.
+		const state = {
+			viewFilters: [],
+			searchQuery: '',
+			searchFields: searchFields || (columns || [])
+				.map(c => c.field)
+				.filter(f => typeof f === 'string' && f.length > 0),
+		};
+
+		function matchObjectFilter(f, row) {
+			const v = row[f.field];
+			const target = f.value;
+			switch (f.type) {
+				case '=': return v === target;
+				case '!=': return v !== target;
+				case '<': return v < target;
+				case '>': return v > target;
+				case '<=': return v <= target;
+				case '>=': return v >= target;
+				case 'like': return v != null && String(v).toLowerCase().indexOf(String(target).toLowerCase()) !== -1;
+				case 'in': return Array.isArray(target) && target.indexOf(v) !== -1;
+				default: return v === target;
+			}
+		}
+
+		function applyFilters() {
+			const hasSearch = !!state.searchQuery;
+			const viewCount = state.viewFilters.length;
+
+			if (!hasSearch && viewCount === 0) {
+				table.clearFilter(true);
+				return;
+			}
+
+			if (!hasSearch) {
+				// View filters only: use native object filter array — Tabulator
+				// handles AND composition.
+				table.setFilter(state.viewFilters);
+				return;
+			}
+
+			// Search is active. Tabulator's setFilter silently ignores function
+			// elements inside an array (verified empirically in 6.3.0), so we
+			// can't mix native object filters with our search function. Build
+			// one composite function that AND-composes view filters + search.
+			const q = state.searchQuery;
+			const fields = state.searchFields;
+			const viewFilters = state.viewFilters;
+			table.setFilter(function (row) {
+				for (let i = 0; i < viewFilters.length; i++) {
+					if (!matchObjectFilter(viewFilters[i], row)) return false;
+				}
+				for (let i = 0; i < fields.length; i++) {
+					const v = row[fields[i]];
+					if (v != null && String(v).toLowerCase().indexOf(q) !== -1) {
+						return true;
+					}
+				}
+				return false;
+			});
+		}
+
+		table.setViewFilters = function (filters) {
+			if (filters == null) {
+				state.viewFilters = [];
+			} else if (Array.isArray(filters)) {
+				state.viewFilters = filters;
+			} else {
+				state.viewFilters = [filters];
+			}
+			applyFilters();
+		};
+
+		table.clearViewFilters = function () {
+			state.viewFilters = [];
+			applyFilters();
+		};
+
+		// Wire the search input (if provided).
+		if (searchInput) {
+			const input = typeof searchInput === 'string'
+				? document.querySelector(searchInput)
+				: searchInput;
+			if (input) {
+				const onInput = function () {
+					state.searchQuery = (input.value || '').trim().toLowerCase();
+					applyFilters();
+				};
+				input.addEventListener('input', onInput);
+				// Pre-fill state from any value already in the box (e.g. browser
+				// restored the input from history).
+				if (input.value) {
+					onInput();
+				}
+			}
+		}
+
+		return table;
+	}
+
+	window.createDataGrid = createDataGrid;
+})();

--- a/gearbox/static/js/os-updates/os-updates-page.js
+++ b/gearbox/static/js/os-updates/os-updates-page.js
@@ -165,8 +165,10 @@ document.addEventListener('DOMContentLoaded', function() {
 	// Delay slightly to ensure currentServerID is set
 	setTimeout(initSSE, 100);
 
-	// Lazily load Python package version info (slow PyPI check, done async)
-	if (document.querySelector('.pipx-version-cell, .pip-version-cell')) {
+	// Initialize pipx/pip grids from their embedded JSON, then kick off the
+	// async PyPI version check that fills in the "Latest" column.
+	if (document.getElementById('pipx-grid') || document.getElementById('pip-grid')) {
+		initPythonToolsGrids();
 		setTimeout(loadPythonVersions, 200);
 	}
 
@@ -328,11 +330,18 @@ function initSSE() {
 	};
 }
 
-// Manual refresh triggered by the LiveRefreshButton
-function manualRefresh() {
+// Manual refresh triggered by the LiveRefreshButton.
+// On this page the refresh icon is the only "check for updates" affordance —
+// run a real apt update check rather than a full page reload, so the user
+// stays on the current scroll position and search/sort state survives.
+async function manualRefresh() {
 	const icon = document.getElementById('refresh-icon');
 	if (icon) icon.classList.add('animate-spin');
-	window.location.reload();
+	try {
+		await checkForUpdates();
+	} finally {
+		if (icon) icon.classList.remove('animate-spin');
+	}
 }
 
 function switchServer(serverID) {
@@ -373,6 +382,15 @@ async function checkForUpdates() {
 			}
 		}
 		await refreshInstalledPackagesGrid();
+		// Also refresh any open collapsible sections so the refresh icon
+		// behaves predictably — same data update path as an SSE apt.completed.
+		// Closed sections are skipped (their grid hasn't been initialized
+		// yet and they'll fetch fresh on next expand anyway).
+		if (typeof isSectionOpen === 'function') {
+			if (isSectionOpen('snapshots')) refreshSnapshotsGrid();
+			if (isSectionOpen('history'))   refreshHistoryGrid();
+			if (isSectionOpen('logs'))      refreshLogsGrid();
+		}
 
 		if (btn) {
 			btn.disabled = false;
@@ -683,13 +701,11 @@ function deleteSnapshot(snapshotID) {
 					throw new Error(errMsg);
 				}
 				showToast('Snapshot deleted', 'success');
-				// Remove the snapshot row from the DOM immediately
-				const snapshotRow = document.querySelector('[data-snapshot-row="' + snapshotID + '"]');
-				if (snapshotRow) {
-					snapshotRow.remove();
+				// Refetch the snapshots grid from the server. Tabulator owns row
+				// state — direct DOM manipulation is no longer reliable here.
+				if (SECTIONS.snapshots) {
+					await SECTIONS.snapshots.refresh();
 					updateBulkDeleteButton();
-				} else {
-					setTimeout(() => window.location.reload(), 1000);
 				}
 			} catch (err) {
 				showToast('Failed to delete snapshot: ' + err.message, 'error');
@@ -702,36 +718,29 @@ function deleteSnapshot(snapshotID) {
 	});
 }
 
-function toggleSelectAllSnapshots(checked) {
-	document.querySelectorAll('.snapshot-checkbox').forEach(cb => {
-		cb.checked = checked;
-	});
-	updateBulkDeleteButton();
-}
-
+// Toggle the bulk-delete button visibility/label based on Tabulator selection.
+// Called from the snapshots grid's `rowSelectionChanged` callback in
+// initSnapshotsGrid(). Also called manually after delete-one to refresh state.
 function updateBulkDeleteButton() {
 	const btn = document.getElementById('bulk-delete-snapshots-btn');
 	if (!btn) return;
-	const all = document.querySelectorAll('.snapshot-checkbox');
-	const checked = document.querySelectorAll('.snapshot-checkbox:checked');
-	const selectAll = document.getElementById('select-all-snapshots');
-	if (selectAll) {
-		selectAll.checked = all.length > 0 && checked.length === all.length;
-		selectAll.indeterminate = checked.length > 0 && checked.length < all.length;
-	}
-	if (checked.length > 0) {
+	const grid = SECTIONS.snapshots && SECTIONS.snapshots.grid;
+	const count = grid ? grid.getSelectedData().length : 0;
+	if (count > 0) {
 		btn.classList.remove('hidden');
-		btn.textContent = 'Delete Selected (' + checked.length + ')';
+		btn.textContent = 'Delete Selected (' + count + ')';
 	} else {
 		btn.classList.add('hidden');
 	}
 }
 
 function bulkDeleteSnapshots() {
-	const checked = document.querySelectorAll('.snapshot-checkbox:checked');
-	if (checked.length === 0) return;
+	const grid = SECTIONS.snapshots && SECTIONS.snapshots.grid;
+	if (!grid) return;
+	const selected = grid.getSelectedData();
+	if (selected.length === 0) return;
+	const ids = selected.map(s => s.id);
 
-	const ids = Array.from(checked).map(cb => cb.dataset.snapshotId);
 	showConfirmModal({
 		title: 'Delete Snapshots',
 		message: 'Delete ' + ids.length + ' selected snapshot(s)? This action cannot be undone.',
@@ -745,13 +754,8 @@ function bulkDeleteSnapshots() {
 					const response = await fetch('/api/os-updates/snapshots/' + id + '?server=' + currentServerID, {
 						method: 'DELETE'
 					});
-					if (!response.ok) {
-						failed++;
-						continue;
-					}
+					if (!response.ok) { failed++; continue; }
 					deleted++;
-					const row = document.querySelector('[data-snapshot-row="' + id + '"]');
-					if (row) row.remove();
 				} catch {
 					failed++;
 				}
@@ -761,10 +765,10 @@ function bulkDeleteSnapshots() {
 			} else {
 				showToast(deleted + ' snapshot(s) deleted', 'success');
 			}
+			// Refresh the grid from the server rather than DOM-manipulating —
+			// Tabulator owns the row state now.
+			await SECTIONS.snapshots.refresh();
 			updateBulkDeleteButton();
-			if (document.querySelectorAll('[data-snapshot-row]').length === 0) {
-				setTimeout(() => window.location.reload(), 1000);
-			}
 		}
 	});
 }
@@ -897,54 +901,176 @@ function showRebootNotRequiredStatus() {
 	}
 }
 
-// Async version check — fetches latest PyPI versions and updates the Latest cells
+// pipx + pip live in Tabulator grids — see initPythonToolsGrids().
+let pipxGrid = null;
+let pipGrid = null;
+
+// Cell formatter for the "Latest" column shared by pipx and pip grids.
+// While latest_version is undefined the cell shows a spinner; once
+// loadPythonVersions() populates it the cell shows either a muted "in sync"
+// value, an amber "Update" badge for upgradable packages, or a dash when
+// PyPI didn't return anything for this package.
+function pythonLatestFormatter(cell) {
+	const row = cell.getRow().getData();
+	if (row.latest_version === undefined) {
+		return '<svg class="w-3.5 h-3.5 animate-spin text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>';
+	}
+	if (row.update_available) {
+		return '<span class="font-mono text-xs text-amber-600 dark:text-amber-400">' + escapeHtml(row.latest_version || '') + '</span>'
+		     + ' <span class="px-1.5 py-0.5 text-xs bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded">Update</span>';
+	}
+	if (row.latest_version) {
+		return '<span class="font-mono text-xs text-gray-500 dark:text-gray-400">' + escapeHtml(row.latest_version) + '</span>';
+	}
+	return '<span class="text-xs text-gray-400 dark:text-gray-500">—</span>';
+}
+
+// Build a per-row "Upgrade / Uninstall" action column. The kind argument is
+// either 'pipx' or 'pip' so the cellClick can dispatch to the right handlers.
+function pythonActionColumn(kind) {
+	return {
+		title: '', headerSort: false, hozAlign: 'right', width: 200,
+		formatter: function(cell) {
+			const row = cell.getRow().getData();
+			const updateAvail = !!row.update_available;
+			const upgradeCls = 'py-upgrade-btn px-3 py-1 text-xs bg-blue-100 dark:bg-blue-900/30 hover:bg-blue-200 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-400 rounded transition-colors mr-1.5 disabled:opacity-40 disabled:cursor-not-allowed';
+			const upgradeAttrs = updateAvail ? '' : ' disabled';
+			return '<button class="' + upgradeCls + '"' + upgradeAttrs + '>Upgrade</button>'
+			     + '<button class="py-uninstall-btn px-3 py-1 text-xs bg-red-100 dark:bg-red-900/30 hover:bg-red-200 dark:hover:bg-red-900/50 text-red-700 dark:text-red-400 rounded transition-colors">Uninstall</button>';
+		},
+		cellClick: function(e, cell) {
+			const name = cell.getRow().getData().name;
+			const btn = e.target;
+			if (btn.classList.contains('py-upgrade-btn') && !btn.disabled) {
+				if (kind === 'pipx') upgradePipxPackage(btn, name);
+				else                 upgradePipPackage(btn, name);
+			} else if (btn.classList.contains('py-uninstall-btn')) {
+				if (kind === 'pipx') uninstallPipxPackage(btn, name);
+				else                 uninstallPipPackage(btn, name);
+			}
+		},
+	};
+}
+
+function readJSONScript(id) {
+	const tag = document.getElementById(id);
+	if (!tag) return [];
+	try {
+		const parsed = JSON.parse(tag.textContent || 'null');
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+function initPythonToolsGrids() {
+	const canAction = document.getElementById('can-action')?.value === 'true';
+
+	const pipxEl = document.getElementById('pipx-grid');
+	if (pipxEl) {
+		const cols = [];
+		if (canAction) {
+			cols.push({
+				formatter: 'rowSelection', titleFormatter: 'rowSelection',
+				hozAlign: 'center', headerSort: false, width: 40,
+				cellClick: function(e, cell) { cell.getRow().toggleSelect(); },
+			});
+		}
+		cols.push({ title: 'Package',  field: 'name', sorter: 'string', minWidth: 160, widthGrow: 2,
+			formatter: cell => '<span class="font-mono text-xs font-medium">' + escapeHtml(cell.getValue() || '') + '</span>' });
+		cols.push({ title: 'Installed', field: 'version', sorter: 'string', width: 150,
+			formatter: cell => '<span class="font-mono text-xs">' + escapeHtml(cell.getValue() || '') + '</span>' });
+		cols.push({ title: 'Latest', field: 'latest_version', sorter: 'string', width: 170, formatter: pythonLatestFormatter });
+		cols.push({ title: 'Apps', field: 'apps', sorter: 'string', minWidth: 140, widthGrow: 2,
+			formatter: function(cell) {
+				const apps = cell.getValue();
+				if (Array.isArray(apps) && apps.length > 0) {
+					return '<span class="text-xs text-gray-500 dark:text-gray-400">' + escapeHtml(apps.join(', ')) + '</span>';
+				}
+				return '<span class="text-xs text-gray-400 dark:text-gray-500">—</span>';
+			},
+		});
+		if (canAction) cols.push(pythonActionColumn('pipx'));
+
+		pipxGrid = createDataGrid(pipxEl, {
+			data: readJSONScript('pipx-data'),
+			columns: cols,
+			maxHeight: '474px',
+			rowHeight: 36,
+			placeholder: 'No pipx packages installed',
+			initialSort: [{ column: 'name', dir: 'asc' }],
+			selectableRows: canAction,
+		});
+		if (canAction) {
+			pipxGrid.on('rowSelectionChanged', updatePipxBulkBar);
+		}
+	}
+
+	const pipEl = document.getElementById('pip-grid');
+	if (pipEl) {
+		const cols = [];
+		if (canAction) {
+			cols.push({
+				formatter: 'rowSelection', titleFormatter: 'rowSelection',
+				hozAlign: 'center', headerSort: false, width: 40,
+				cellClick: function(e, cell) { cell.getRow().toggleSelect(); },
+			});
+		}
+		cols.push({ title: 'Package', field: 'name', sorter: 'string', minWidth: 160, widthGrow: 3,
+			formatter: cell => '<span class="font-mono text-xs font-medium">' + escapeHtml(cell.getValue() || '') + '</span>' });
+		cols.push({ title: 'Installed', field: 'version', sorter: 'string', width: 150,
+			formatter: cell => '<span class="font-mono text-xs">' + escapeHtml(cell.getValue() || '') + '</span>' });
+		cols.push({ title: 'Latest', field: 'latest_version', sorter: 'string', width: 170, formatter: pythonLatestFormatter });
+		if (canAction) cols.push(pythonActionColumn('pip'));
+
+		pipGrid = createDataGrid(pipEl, {
+			data: readJSONScript('pip-data'),
+			columns: cols,
+			maxHeight: '474px',
+			rowHeight: 36,
+			placeholder: 'No user-installed pip packages',
+			initialSort: [{ column: 'name', dir: 'asc' }],
+			selectableRows: canAction,
+		});
+		if (canAction) {
+			pipGrid.on('rowSelectionChanged', updatePipBulkBar);
+		}
+	}
+}
+
+// Async PyPI version check — replaces the per-row spinner cells with real
+// latest-version info. Merges into the grid rows in place so sort/filter
+// state is preserved.
 async function loadPythonVersions() {
 	try {
 		const response = await fetch('/api/os-updates/python-tools/versions?server=' + currentServerID);
 		if (!response.ok) return;
 		const data = await response.json();
 
-		// Update pipx version cells
-		document.querySelectorAll('.pipx-version-cell').forEach(cell => {
-			const pkg = data.pipx?.packages?.find(p => p.name === cell.dataset.package);
-			renderVersionCell(cell, pkg);
-		});
+		const mergeLatest = (grid, pkgs) => {
+			if (!grid || !Array.isArray(pkgs)) return;
+			const byName = {};
+			pkgs.forEach(p => { byName[p.name] = p; });
+			grid.getRows().forEach(row => {
+				const d = row.getData();
+				const upd = byName[d.name];
+				if (upd) {
+					row.update({
+						latest_version: upd.latest_version || '',
+						update_available: !!upd.update_available,
+					});
+				} else {
+					// PyPI returned nothing for this package — clear the spinner
+					row.update({ latest_version: '', update_available: false });
+				}
+			});
+		};
 
-		// Update pip version cells
-		document.querySelectorAll('.pip-version-cell').forEach(cell => {
-			const pkg = data.pip?.packages?.find(p => p.name === cell.dataset.package);
-			renderVersionCell(cell, pkg);
-		});
+		mergeLatest(pipxGrid, data.pipx?.packages);
+		mergeLatest(pipGrid,  data.pip?.packages);
 	} catch {
-		// Non-fatal: leave spinners as-is on network error
+		// Non-fatal: spinners stay if the network blip; user can refresh.
 	}
-}
-
-function renderVersionCell(cell, pkg) {
-	if (!pkg) {
-		cell.innerHTML = '<span class="text-gray-400 dark:text-gray-500">—</span>';
-		disableUpgradeBtn(cell);
-		return;
-	}
-	if (pkg.update_available) {
-		cell.innerHTML =
-			'<span class="text-amber-600 dark:text-amber-400">' + pkg.latest_version + '</span>' +
-			'<span class="ml-1 px-1.5 py-0.5 text-xs bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded">Update</span>';
-	} else if (pkg.latest_version) {
-		cell.innerHTML = '<span class="text-gray-500 dark:text-gray-400">' + pkg.latest_version + '</span>';
-		disableUpgradeBtn(cell);
-	} else {
-		cell.innerHTML = '<span class="text-gray-400 dark:text-gray-500">—</span>';
-		disableUpgradeBtn(cell);
-	}
-}
-
-// Disables the upgrade button in the same table row as the given version cell.
-function disableUpgradeBtn(cell) {
-	const row = cell.closest('tr');
-	if (!row) return;
-	const btn = row.querySelector('.pipx-upgrade-btn, .pip-upgrade-btn');
-	if (btn) btn.disabled = true;
 }
 
 // Button loading state helpers
@@ -965,33 +1091,24 @@ function clearButtonLoading(btn) {
 }
 
 // ── Multi-select: pipx ────────────────────────────────────────────────────────
+// Tabulator owns row selection state. These helpers project that state onto
+// the bulk-action bar in the section header.
 
-function onPipxCheckboxChange() {
-	const checked = document.querySelectorAll('.pipx-checkbox:checked');
-	const all = document.querySelectorAll('.pipx-checkbox');
+function updatePipxBulkBar() {
 	const bar = document.getElementById('pipx-bulk-bar');
 	const count = document.getElementById('pipx-selected-count');
-	const selectAll = document.getElementById('pipx-select-all');
-	if (bar) bar.classList.toggle('hidden', checked.length === 0);
-	if (count) count.textContent = checked.length + ' selected';
-	if (selectAll) selectAll.indeterminate = checked.length > 0 && checked.length < all.length;
-	if (selectAll) selectAll.checked = checked.length === all.length && all.length > 0;
-}
-
-function togglePipxSelectAll(cb) {
-	document.querySelectorAll('.pipx-checkbox').forEach(c => { c.checked = cb.checked; });
-	onPipxCheckboxChange();
+	const n = pipxGrid ? pipxGrid.getSelectedData().length : 0;
+	if (bar) bar.classList.toggle('hidden', n === 0);
+	if (count) count.textContent = n + ' selected';
 }
 
 function clearPipxSelection() {
-	document.querySelectorAll('.pipx-checkbox').forEach(c => { c.checked = false; });
-	const selectAll = document.getElementById('pipx-select-all');
-	if (selectAll) { selectAll.checked = false; selectAll.indeterminate = false; }
-	onPipxCheckboxChange();
+	if (pipxGrid) pipxGrid.deselectRow();
 }
 
 async function bulkUpgradePipx() {
-	const names = [...document.querySelectorAll('.pipx-checkbox:checked')].map(c => c.value);
+	if (!pipxGrid) return;
+	const names = pipxGrid.getSelectedData().map(r => r.name);
 	if (names.length === 0) return;
 	const btn = document.getElementById('pipx-bulk-upgrade-btn');
 	setButtonLoading(btn, 'Upgrading...');
@@ -1015,7 +1132,8 @@ async function bulkUpgradePipx() {
 }
 
 function bulkUninstallPipx() {
-	const names = [...document.querySelectorAll('.pipx-checkbox:checked')].map(c => c.value);
+	if (!pipxGrid) return;
+	const names = pipxGrid.getSelectedData().map(r => r.name);
 	if (names.length === 0) return;
 	showConfirmModal({
 		title: 'Uninstall Packages',
@@ -1045,32 +1163,21 @@ function bulkUninstallPipx() {
 
 // ── Multi-select: pip ─────────────────────────────────────────────────────────
 
-function onPipCheckboxChange() {
-	const checked = document.querySelectorAll('.pip-checkbox:checked');
-	const all = document.querySelectorAll('.pip-checkbox');
+function updatePipBulkBar() {
 	const bar = document.getElementById('pip-bulk-bar');
 	const count = document.getElementById('pip-selected-count');
-	const selectAll = document.getElementById('pip-select-all');
-	if (bar) bar.classList.toggle('hidden', checked.length === 0);
-	if (count) count.textContent = checked.length + ' selected';
-	if (selectAll) selectAll.indeterminate = checked.length > 0 && checked.length < all.length;
-	if (selectAll) selectAll.checked = checked.length === all.length && all.length > 0;
-}
-
-function togglePipSelectAll(cb) {
-	document.querySelectorAll('.pip-checkbox').forEach(c => { c.checked = cb.checked; });
-	onPipCheckboxChange();
+	const n = pipGrid ? pipGrid.getSelectedData().length : 0;
+	if (bar) bar.classList.toggle('hidden', n === 0);
+	if (count) count.textContent = n + ' selected';
 }
 
 function clearPipSelection() {
-	document.querySelectorAll('.pip-checkbox').forEach(c => { c.checked = false; });
-	const selectAll = document.getElementById('pip-select-all');
-	if (selectAll) { selectAll.checked = false; selectAll.indeterminate = false; }
-	onPipCheckboxChange();
+	if (pipGrid) pipGrid.deselectRow();
 }
 
 async function bulkUpgradePip() {
-	const names = [...document.querySelectorAll('.pip-checkbox:checked')].map(c => c.value);
+	if (!pipGrid) return;
+	const names = pipGrid.getSelectedData().map(r => r.name);
 	if (names.length === 0) return;
 	const btn = document.getElementById('pip-bulk-upgrade-btn');
 	setButtonLoading(btn, 'Upgrading...');
@@ -1094,7 +1201,8 @@ async function bulkUpgradePip() {
 }
 
 function bulkUninstallPip() {
-	const names = [...document.querySelectorAll('.pip-checkbox:checked')].map(c => c.value);
+	if (!pipGrid) return;
+	const names = pipGrid.getSelectedData().map(r => r.name);
 	if (names.length === 0) return;
 	showConfirmModal({
 		title: 'Uninstall Packages',
@@ -1901,68 +2009,8 @@ handleAptCompleted = function(event) {
 };
 
 // ============================================================================
-// Update Logs
+// Update Logs (lazy-loaded via SECTIONS.logs, see Collapsible Sections below)
 // ============================================================================
-
-async function loadUpdateLogs() {
-	const table = document.getElementById('update-logs-table');
-	if (!table) return;
-
-	table.innerHTML = '<tr><td colspan="5" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">Loading logs...</td></tr>';
-
-	try {
-		const response = await fetch(`/api/os-updates/logs?server=${currentServerID}&limit=50`);
-		if (!response.ok) {
-			throw new Error(await extractErrorMessage(response));
-		}
-
-		const data = await response.json();
-
-		if (!data.logs || data.logs.length === 0) {
-			table.innerHTML = '<tr><td colspan="5" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">No update logs available</td></tr>';
-			return;
-		}
-
-		table.innerHTML = '';
-		data.logs.forEach(log => {
-			const row = document.createElement('tr');
-			row.className = 'hover:bg-gray-50 dark:hover:bg-slate-700';
-
-			const date = new Date(log.started_at).toLocaleString();
-			const statusColor = log.status === 'completed'
-				? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
-				: log.status === 'failed'
-					? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
-					: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
-
-			const typeLabel = log.type === 'check' ? 'Update Check' : log.type === 'install' ? 'Install' : log.type;
-			let details = '';
-			if (log.packages && log.packages.length > 0) {
-				details = `${log.packages.length} package(s)`;
-			} else if (log.security_only) {
-				details = 'Security only';
-			}
-			if (log.error) {
-				details = log.error.substring(0, 60);
-			}
-
-			row.innerHTML = `
-				<td class="px-4 py-3 text-gray-600 dark:text-gray-400">${date}</td>
-				<td class="px-4 py-3"><span class="px-2 py-1 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded">${typeLabel}</span></td>
-				<td class="px-4 py-3"><span class="px-2 py-1 text-xs ${statusColor} rounded">${log.status}</span></td>
-				<td class="px-4 py-3 text-gray-600 dark:text-gray-400 text-xs">${details}</td>
-				<td class="px-4 py-3">
-					<button onclick="viewUpdateLog('${log.id}')" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs font-medium">
-						View Output
-					</button>
-				</td>
-			`;
-			table.appendChild(row);
-		});
-	} catch (err) {
-		table.innerHTML = `<tr><td colspan="5" class="px-4 py-8 text-center text-red-500">${err.message}</td></tr>`;
-	}
-}
 
 async function viewUpdateLog(logID) {
 	const modal = document.getElementById('update-log-modal');
@@ -2141,18 +2189,17 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 	const loading = document.getElementById('installed-packages-loading');
 	if (loading) loading.remove();
 
-	// Row height × 12 visible rows + header (~42px) + header filter row (~34px)
+	// Row height × 12 visible rows + header (~42px). Per-column filter row
+	// has been replaced by a toolbar-mounted global search (see #pkg-search).
 	const ROW_HEIGHT = 36;
 	const VISIBLE_ROWS = 12;
-	const gridHeight = (ROW_HEIGHT * VISIBLE_ROWS) + 42 + 34;
+	const gridHeight = (ROW_HEIGHT * VISIBLE_ROWS) + 42;
 
 	const columns = [
 		{
 			title: 'Package',
 			field: 'name',
 			sorter: 'string',
-			headerFilter: 'input',
-			headerFilterPlaceholder: 'filter...',
 			minWidth: 180,
 			formatter: function(cell) {
 				const row = cell.getRow().getData();
@@ -2175,9 +2222,7 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 			title: 'Installed Version',
 			field: 'version',
 			sorter: 'string',
-			headerFilter: 'input',
-			headerFilterPlaceholder: 'filter...',
-			width: 160,
+			width: 170,
 			formatter: function(cell) {
 				return '<span class="font-mono text-xs">' + escapeHtml(cell.getValue() || '') + '</span>';
 			}
@@ -2186,9 +2231,7 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 			title: 'Available Version',
 			field: 'available_version',
 			sorter: 'string',
-			headerFilter: 'input',
-			headerFilterPlaceholder: 'filter...',
-			width: 160,
+			width: 170,
 			formatter: function(cell) {
 				const val = cell.getValue();
 				if (val) {
@@ -2203,9 +2246,8 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 			title: 'Description',
 			field: 'description',
 			sorter: 'string',
-			headerFilter: 'input',
-			headerFilterPlaceholder: 'filter...',
-			minWidth: 200,
+			minWidth: 160,
+			widthGrow: 3,
 			formatter: function(cell) {
 				return '<span class="text-xs">' + escapeHtml(cell.getValue() || '') + '</span>';
 			}
@@ -2217,7 +2259,7 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 			title: '',
 			field: 'name',
 			headerSort: false,
-			width: 260,
+			width: 150,
 			hozAlign: 'right',
 			formatter: function(cell) {
 				const row = cell.getRow().getData();
@@ -2250,23 +2292,26 @@ function initInstalledPackagesGrid(el, packages, canAction) {
 	const filterSelect = document.getElementById('pkg-view-filter');
 	const initialFilter = filterSelect ? filterSelect.value : 'updates';
 
-	installedPkgTable = new Tabulator(el, {
+	installedPkgTable = createDataGrid(el, {
 		data: packages,
 		columns: columns,
-		layout: 'fitColumns',
 		height: gridHeight + 'px',
 		virtualDom: true,
 		virtualDomBuffer: 180,
 		rowHeight: ROW_HEIGHT,
-		sortMode: 'local',
-		filterMode: 'local',
 		initialSort: [{ column: 'name', dir: 'asc' }],
 		placeholder: 'No packages found',
-		tableBuilt: function() {
-			// Apply initial filter and show/hide Update All button after table is ready
-			_applyPkgViewFilter(initialFilter, packages);
-		},
+		searchInput: '#pkg-search',
+		searchFields: ['name', 'version', 'available_version', 'description'],
 	});
+
+	// Apply initial filter + visibility AFTER the constructor returns so
+	// `installedPkgTable` is guaranteed assigned. Previously this lived in the
+	// `tableBuilt` callback, where the timing was unreliable: on some loads it
+	// fired before _applyPkgViewFilter's `if (!installedPkgTable) return` had
+	// a truthy reference to bail past, leaving the "Update All (N)" button
+	// stuck in its hidden template state.
+	_applyPkgViewFilter(initialFilter, packages);
 }
 
 function onPkgViewFilterChange(value) {
@@ -2286,14 +2331,16 @@ function _applyPkgViewFilter(value, allData) {
 	if (value === 'updates') {
 		// Active updates: upgradable AND not held. "Hold" is an explicit operator
 		// opt-out from upgrade, so held rows do not belong in the updates view.
-		installedPkgTable.setFilter([
+		// setViewFilters composes with the toolbar search box; setFilter would
+		// clobber it.
+		installedPkgTable.setViewFilters([
 			{ field: 'update_available', type: '=', value: true },
 			{ field: 'is_held', type: '=', value: false },
 		]);
 	} else if (value === 'held') {
-		installedPkgTable.setFilter('is_held', '=', true);
+		installedPkgTable.setViewFilters({ field: 'is_held', type: '=', value: true });
 	} else {
-		installedPkgTable.clearFilter();
+		installedPkgTable.clearViewFilters();
 	}
 
 	// Count packages excluding held ones — held packages are intentionally
@@ -2302,10 +2349,14 @@ function _applyPkgViewFilter(value, allData) {
 	const updateCount = allData.filter(p => p.update_available && !p.is_held).length;
 	const securityCount = allData.filter(p => p.is_security_update && !p.is_held).length;
 
-	// Show/hide Update All button
+	// Update All / Security buttons drive the active-upgrades plan, so they
+	// only make sense on the "updates" view. On "held" or "all" they would be
+	// misleading (the visible rows are not what would be upgraded).
+	const onUpdatesView = value === 'updates';
+
 	const updateAllBtn = document.getElementById('pkg-update-all-btn');
 	const updateAllLabel = document.getElementById('pkg-update-all-label');
-	if (updateAllBtn && updateCount > 0) {
+	if (updateAllBtn && onUpdatesView && updateCount > 0) {
 		updateAllBtn.classList.remove('hidden');
 		if (updateAllLabel) {
 			updateAllLabel.textContent = 'Update All (' + updateCount + ')';
@@ -2314,10 +2365,9 @@ function _applyPkgViewFilter(value, allData) {
 		updateAllBtn.classList.add('hidden');
 	}
 
-	// Show/hide Security button
 	const secBtn = document.getElementById('pkg-update-security-btn');
 	if (secBtn) {
-		if (securityCount > 0) {
+		if (onUpdatesView && securityCount > 0) {
 			secBtn.classList.remove('hidden');
 		} else {
 			secBtn.classList.add('hidden');
@@ -2590,3 +2640,361 @@ async function confirmAptInstall() {
 		showToast('Failed to install package: ' + err.message, 'error');
 	}
 }
+
+// ============================================================================
+// Collapsible Sections (Snapshots, History, Logs)
+//
+// These three sections sit in <details data-section="..."> wrappers and are
+// lazy-loaded on first expand. While a section is open, apt.completed SSE
+// events trigger a refetch so the grid stays live. Closing the section stops
+// future refreshes. The grid instance itself is kept around — re-expanding
+// shows the cached data instantly (and then a refresh fires if SSE arrives).
+//
+// Caveat: apt operations performed OUTSIDE gearbox (e.g. `ssh dave@host;
+// apt install x`) won't fire the SSE event, so those changes only show up
+// after a manual refresh (page reload or the top-right refresh icon). A
+// future filesystem-watch on the agent could cover that.
+// ============================================================================
+
+const SECTIONS = {
+	snapshots: { details: null, grid: null, init: null, refresh: null },
+	history:   { details: null, grid: null, init: null, refresh: null },
+	logs:      { details: null, grid: null, init: null, refresh: null },
+};
+
+function isSectionOpen(name) {
+	const s = SECTIONS[name];
+	return !!(s && s.details && s.details.open);
+}
+
+function fmtLocalDateTime(value) {
+	if (!value) return '';
+	const d = new Date(value);
+	if (isNaN(d.getTime())) return escapeHtml(String(value));
+	return d.toLocaleString();
+}
+
+function snapshotIsAuto(reason) {
+	return typeof reason === 'string' && reason.indexOf('auto:') === 0;
+}
+
+function snapshotDescriptionText(reason) {
+	if (!reason || reason === 'manual') return '';
+	if (typeof reason === 'string' && reason.indexOf('auto: ') === 0) {
+		return reason.substring(6);
+	}
+	return reason;
+}
+
+function historyActionColor(action) {
+	switch (action) {
+		case 'install': return 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400';
+		case 'upgrade': return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400';
+		case 'remove':
+		case 'purge':   return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
+		default:        return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
+	}
+}
+
+async function fetchSnapshots() {
+	const r = await fetch('/api/os-updates/snapshots?server=' + currentServerID);
+	if (!r.ok) throw new Error(await extractErrorMessage(r));
+	const data = await r.json();
+	let snaps = data.snapshots || data || [];
+	if (!Array.isArray(snaps)) snaps = [];
+	return snaps.map(s => ({
+		id: s.id || s.ID || s.name || '',
+		createdAt: s.createdAt || s.created_at || s.CreatedAt || '',
+		reason: s.reason || s.Reason || '',
+	}));
+}
+
+function initSnapshotsGrid() {
+	const canAction = document.getElementById('can-action')?.value === 'true';
+	const el = document.getElementById('snapshots-grid');
+	if (!el) return;
+
+	const columns = [];
+	if (canAction) {
+		columns.push({
+			formatter: 'rowSelection', titleFormatter: 'rowSelection',
+			hozAlign: 'center', headerSort: false, width: 40,
+			cellClick: function(e, cell) { cell.getRow().toggleSelect(); },
+		});
+	}
+	columns.push({
+		title: 'Date', field: 'createdAt', sorter: 'string', width: 200,
+		formatter: cell => '<span class="text-xs">' + escapeHtml(fmtLocalDateTime(cell.getValue())) + '</span>',
+	});
+	columns.push({
+		title: 'Name', field: 'id', sorter: 'string', width: 170,
+		formatter: cell => '<span class="font-mono text-xs font-medium">' + escapeHtml(cell.getValue() || '') + '</span>',
+	});
+	columns.push({
+		title: 'Type', field: 'reason', sorter: 'string', width: 140,
+		formatter: function(cell) {
+			const reason = cell.getValue() || '';
+			const isFirst = cell.getRow().getPosition(true) === 1;
+			const typeBadge = snapshotIsAuto(reason)
+				? '<span class="px-2 py-0.5 text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded font-medium">auto</span>'
+				: '<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-slate-600 text-gray-600 dark:text-gray-400 rounded font-medium">manual</span>';
+			const latest = isFirst
+				? ' <span class="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded font-medium">Latest</span>'
+				: '';
+			return typeBadge + latest;
+		},
+	});
+	columns.push({
+		title: 'Description', field: 'reason', sorter: 'string',
+		minWidth: 160, widthGrow: 3,
+		formatter: cell => '<span class="text-xs">' + escapeHtml(snapshotDescriptionText(cell.getValue())) + '</span>',
+	});
+	if (canAction) {
+		columns.push({
+			title: '', field: 'id', headerSort: false, width: 200, hozAlign: 'right',
+			formatter: function() {
+				return '<button class="snap-preview-btn text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs font-medium mr-3">Preview</button>'
+				     + '<button class="snap-restore-btn text-yellow-600 dark:text-yellow-400 hover:text-yellow-800 dark:hover:text-yellow-300 text-xs font-medium mr-3">Restore</button>'
+				     + '<button class="snap-delete-btn text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-xs font-medium">Delete</button>';
+			},
+			cellClick: function(e, cell) {
+				const id = cell.getRow().getData().id;
+				if (e.target.classList.contains('snap-preview-btn')) previewSnapshot(id);
+				else if (e.target.classList.contains('snap-restore-btn')) restoreSnapshot(id);
+				else if (e.target.classList.contains('snap-delete-btn')) deleteSnapshot(id);
+			},
+		});
+	}
+
+	SECTIONS.snapshots.grid = createDataGrid(el, {
+		data: [],
+		columns: columns,
+		// Auto-size to content, capped at 474px (12 rows × 36 + header). Sparse
+		// lists feel right-sized; long lists scroll inside the card.
+		maxHeight: '474px',
+		rowHeight: 36,
+		placeholder: 'No snapshots available',
+		initialSort: [{ column: 'createdAt', dir: 'desc' }],
+		selectableRows: canAction,
+	});
+	// Constructor-level event callbacks aren't reliably picked up in
+	// Tabulator 6.3 — subscribe imperatively after the table exists.
+	SECTIONS.snapshots.grid.on('rowSelectionChanged', updateBulkDeleteButton);
+}
+
+async function refreshSnapshotsGrid() {
+	if (!SECTIONS.snapshots.grid) return;
+	try {
+		const rows = await fetchSnapshots();
+		SECTIONS.snapshots.grid.setData(rows);
+	} catch (err) {
+		console.warn('Snapshots refresh failed:', err.message);
+	}
+}
+
+async function fetchHistory() {
+	const r = await fetch('/api/os-updates/history?server=' + currentServerID + '&limit=50');
+	if (!r.ok) throw new Error(await extractErrorMessage(r));
+	const data = await r.json();
+	let hist = data.history || data || [];
+	if (!Array.isArray(hist)) hist = [];
+	return hist.map(h => ({
+		timestamp:   h.timestamp || h.Timestamp || '',
+		action:      h.action || h.Action || '',
+		package:     h.package || h.Package || '',
+		fromVersion: h.fromVersion || h.from_version || h.FromVersion || '',
+		toVersion:   h.toVersion || h.to_version || h.ToVersion || '',
+		status:      h.status || h.Status || '',
+	}));
+}
+
+function initHistoryGrid() {
+	const el = document.getElementById('history-grid');
+	if (!el) return;
+	const columns = [
+		{
+			title: 'Timestamp', field: 'timestamp', sorter: 'string', width: 200,
+			formatter: cell => '<span class="text-xs">' + escapeHtml(fmtLocalDateTime(cell.getValue())) + '</span>',
+		},
+		{
+			title: 'Action', field: 'action', sorter: 'string', width: 110,
+			formatter: function(cell) {
+				const v = cell.getValue() || '';
+				return '<span class="px-2 py-0.5 text-xs rounded ' + historyActionColor(v) + '">' + escapeHtml(v) + '</span>';
+			},
+		},
+		{
+			title: 'Package', field: 'package', sorter: 'string', minWidth: 160, widthGrow: 2,
+			formatter: cell => '<span class="font-mono text-xs font-medium">' + escapeHtml(cell.getValue() || '') + '</span>',
+		},
+		{
+			title: 'Version Change', field: 'toVersion', sorter: 'string', minWidth: 160, widthGrow: 2,
+			formatter: function(cell) {
+				const row = cell.getRow().getData();
+				if (row.fromVersion && row.toVersion) {
+					return '<span class="font-mono text-xs">' + escapeHtml(row.fromVersion) + ' → ' + escapeHtml(row.toVersion) + '</span>';
+				}
+				if (row.toVersion) {
+					return '<span class="font-mono text-xs">' + escapeHtml(row.toVersion) + '</span>';
+				}
+				return '<span class="text-xs text-gray-500 dark:text-gray-400">—</span>';
+			},
+		},
+		{
+			title: 'Status', field: 'status', sorter: 'string', width: 110,
+			formatter: function(cell) {
+				const v = cell.getValue() || '';
+				if (v === 'success' || v === 'install' || v === 'upgrade') {
+					return '<span class="px-2 py-0.5 text-xs bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 rounded">Success</span>';
+				}
+				if (v === 'remove' || v === 'purge') {
+					return '<span class="px-2 py-0.5 text-xs bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 rounded">Removed</span>';
+				}
+				return '<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">' + escapeHtml(v) + '</span>';
+			},
+		},
+	];
+
+	SECTIONS.history.grid = createDataGrid(el, {
+		data: [],
+		columns: columns,
+		maxHeight: '474px',
+		rowHeight: 36,
+		placeholder: 'No update history available',
+		initialSort: [{ column: 'timestamp', dir: 'desc' }],
+	});
+}
+
+async function refreshHistoryGrid() {
+	if (!SECTIONS.history.grid) return;
+	try {
+		const rows = await fetchHistory();
+		SECTIONS.history.grid.setData(rows);
+	} catch (err) {
+		console.warn('History refresh failed:', err.message);
+	}
+}
+
+async function fetchLogs() {
+	const r = await fetch('/api/os-updates/logs?server=' + currentServerID + '&limit=50');
+	if (!r.ok) throw new Error(await extractErrorMessage(r));
+	const data = await r.json();
+	let logs = data.logs || data || [];
+	if (!Array.isArray(logs)) logs = [];
+	return logs;
+}
+
+function initLogsGrid() {
+	const el = document.getElementById('logs-grid');
+	if (!el) return;
+	const columns = [
+		{
+			title: 'Date', field: 'started_at', sorter: 'string', width: 200,
+			formatter: cell => '<span class="text-xs">' + escapeHtml(fmtLocalDateTime(cell.getValue())) + '</span>',
+		},
+		{
+			title: 'Type', field: 'type', sorter: 'string', width: 140,
+			formatter: function(cell) {
+				const v = cell.getValue() || '';
+				const label = v === 'check' ? 'Update Check' : v === 'install' ? 'Install' : v;
+				return '<span class="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded">' + escapeHtml(label) + '</span>';
+			},
+		},
+		{
+			title: 'Status', field: 'status', sorter: 'string', width: 120,
+			formatter: function(cell) {
+				const v = cell.getValue() || '';
+				const cls = v === 'completed'
+					? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
+					: v === 'failed'
+						? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
+						: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
+				return '<span class="px-2 py-0.5 text-xs rounded ' + cls + '">' + escapeHtml(v) + '</span>';
+			},
+		},
+		{
+			title: 'Details', field: 'packages', sorter: 'string', minWidth: 160, widthGrow: 3,
+			formatter: function(cell) {
+				const row = cell.getRow().getData();
+				let detail = '';
+				if (row.error) detail = String(row.error).substring(0, 120);
+				else if (row.packages && row.packages.length > 0) detail = row.packages.length + ' package(s)';
+				else if (row.security_only) detail = 'Security only';
+				return '<span class="text-xs">' + escapeHtml(detail) + '</span>';
+			},
+		},
+		{
+			title: '', field: 'id', headerSort: false, width: 120, hozAlign: 'right',
+			formatter: () => '<button class="log-view-btn text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs font-medium">View Output</button>',
+			cellClick: function(e, cell) {
+				if (e.target.classList.contains('log-view-btn')) viewUpdateLog(cell.getRow().getData().id);
+			},
+		},
+	];
+
+	SECTIONS.logs.grid = createDataGrid(el, {
+		data: [],
+		columns: columns,
+		maxHeight: '474px',
+		rowHeight: 36,
+		placeholder: 'No update logs available',
+		initialSort: [{ column: 'started_at', dir: 'desc' }],
+	});
+}
+
+async function refreshLogsGrid() {
+	if (!SECTIONS.logs.grid) return;
+	try {
+		const rows = await fetchLogs();
+		SECTIONS.logs.grid.setData(rows);
+	} catch (err) {
+		console.warn('Logs refresh failed:', err.message);
+	}
+}
+
+function initCollapsibleSections() {
+	const map = {
+		snapshots: { init: initSnapshotsGrid, refresh: refreshSnapshotsGrid },
+		history:   { init: initHistoryGrid,   refresh: refreshHistoryGrid },
+		logs:      { init: initLogsGrid,      refresh: refreshLogsGrid },
+	};
+
+	document.querySelectorAll('details.datagrid-card[data-section]').forEach(d => {
+		const name = d.dataset.section;
+		const cfg = map[name];
+		if (!cfg) return;
+		SECTIONS[name].details = d;
+		SECTIONS[name].init = cfg.init;
+		SECTIONS[name].refresh = cfg.refresh;
+
+		// Action buttons inside <summary> need to NOT toggle the details on
+		// click — without this, clicking "Create Snapshot" would also collapse
+		// the section.
+		const summary = d.querySelector(':scope > summary');
+		if (summary) {
+			summary.addEventListener('click', function(e) {
+				if (e.target.closest('button')) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
+			});
+		}
+
+		d.addEventListener('toggle', async function() {
+			if (!d.open) return;
+			if (!SECTIONS[name].grid) cfg.init();
+			await cfg.refresh();
+		});
+	});
+
+	// Live updates: when apt completes, refresh whichever sections are open.
+	if (window.registerEventHandler) {
+		window.registerEventHandler('apt.completed', function() {
+			if (isSectionOpen('snapshots')) refreshSnapshotsGrid();
+			if (isSectionOpen('history'))   refreshHistoryGrid();
+			if (isSectionOpen('logs'))      refreshLogsGrid();
+		});
+	}
+}
+
+document.addEventListener('DOMContentLoaded', initCollapsibleSections);


### PR DESCRIPTION
## Summary

- New reusable Tabulator skin (`datagrid-unifi`) + `createDataGrid()` factory wrapper under `gearbox/static/css/components/datagrid.css` and `gearbox/static/js/common/datagrid.js`. Flat header, hover-only sort arrows, blue accent on active sort, themed selection checkboxes, drag-to-reorder columns, no zebra stripes. Legacy Tabulator dark-mode CSS is scoped with `:not(.datagrid-unifi)` so existing non-unifi tables (statusgrid) keep their current style.

- **OS Packages**: per-column filter inputs replaced by a single toolbar search input. Description column gets `widthGrow: 3` so it absorbs slack; Actions narrowed from 260 to 150 — fixes horizontal scroll on narrow viewports. Container pre-sized to 474px to prevent layout jump on load.

- **Snapshots / History / Logs**: each becomes a `<details>` collapsible card that starts closed. Lazy-loaded on first expand — handler no longer prefetches `ListSnapshots()` / `GetUpdateHistory()` on every page hit (two agent round-trips saved). "Load Logs" button removed (expanding the section is the trigger). Tables auto-size to row count, capped at 474px. **Live updates while open**: one `apt.completed` SSE subscription walks every section and refetches whichever cards are currently expanded. Snapshots uses Tabulator's `selectableRows` for bulk delete.

- **Python CLI Tools (pipx + pip)**: both subsections converted to the datagrid with themed checkboxes and per-row Upgrade/Uninstall buttons. Initial package data is embedded as a JSON `<script>` block via a new `jsonScriptBody()` helper so the grid renders immediately. The async PyPI version check merges latest-version info into rows via `row.update(...)`, preserving sort/filter/selection state. Whole section is hidden when neither tool is installed; each subsection is hidden when its tool isn't available (replaces the "X is not available" empty state).

- **Top-right refresh**: blue "Check for Updates" button removed. The refresh icon's `manualRefresh()` now awaits `checkForUpdates()` instead of doing a full page reload, preserving scroll/sort/search state and refreshing any open collapsible section.

- **Two Tabulator 6.3 quirks** worked around inline in the factory: (1) the `cssClass` option doesn't always apply to the host element — factory adds the class via `classList` directly; (2) `setFilter([fn])` silently ignores function elements inside an array — when both view filters and a search are active, the factory builds a single composite function instead of a mixed array.

Closes #68

## Test plan

- [ ] OS Packages: column drag reorders; clicking a header sorts and turns it blue; sort arrows hidden until hover; toolbar search filters across name/version/desc
- [ ] OS Packages: no horizontal scroll past wasted whitespace on narrow viewports
- [ ] OS Packages: Updates filter excludes held packages; Held tab shows only held
- [ ] Snapshots/History/Logs: all three start collapsed; expanding fetches data
- [ ] Snapshots: select multiple rows → bulk-delete button appears with count; "select all" supports indeterminate state
- [ ] Snapshots: header checkbox toggles all rows; delete one row → grid refetches
- [ ] Live: install a package via "Install Package" while Snapshots is open → a new "before install" auto-snapshot row appears without manual refresh
- [ ] Live: refresh icon refreshes status cards, OS Packages grid, AND any open collapsible section
- [ ] pipx grid: themed checkboxes, bulk Upgrade/Uninstall work, "Latest" cells fill in once PyPI lookup returns; row Upgrade button disables when no update
- [ ] pip grid: same as pipx
- [ ] Python CLI Tools section hidden when neither pipx nor pip is installed (pip case verified on Light Hugger)
- [ ] Row hover: text stays readable on every cell (the original bug that prompted the `:not(.datagrid-unifi)` scoping); no cell goes invisible

🤖 Generated with [Claude Code](https://claude.com/claude-code)