### PR TITLE
feat(#71): box gear config + capability filter + cmd-k pages

### DIFF
--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -418,6 +418,7 @@ func main() {
 		r.Use(middleware.APIKeyAuth(server.APIKey(), logger, authBackoff))
 	})
 	gearManager.RegisterRoutes(pluginRouter)
+	gearManager.RegisterSystemRoutes(pluginRouter)
 
 	logger.Info("Plugin system initialized",
 		"plugins", gear.Names(),

--- a/gearbox-agent/internal/framework/gear/manager.go
+++ b/gearbox-agent/internal/framework/gear/manager.go
@@ -496,12 +496,7 @@ func (m *Manager) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	out := CapabilitiesResponse{Gears: make(map[string]CapabilityEntry, len(plugins))}
 	for _, p := range plugins {
 		name := p.Info().Name
-		pr := results[name]
-		out.Gears[name] = CapabilityEntry{
-			Status:       pr.Status,
-			Reason:       pr.Reason,
-			Capabilities: pr.Capabilities,
-		}
+		out.Gears[name] = CapabilityEntry(results[name])
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(out); err != nil {

--- a/gearbox-agent/internal/framework/gear/manager.go
+++ b/gearbox-agent/internal/framework/gear/manager.go
@@ -2,9 +2,11 @@ package gear
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -461,6 +463,50 @@ func (m *Manager) RegisterRoutes(r chi.Router) {
 		p.RegisterRoutes(r)
 	}
 	m.logger.Info("registered gear routes", "count", loaded)
+}
+
+// CapabilityEntry is the per-gear shape returned by the capabilities API.
+// Stable JSON keys — the dashboard parses this to decide which gears to
+// surface in the Gears settings page.
+type CapabilityEntry struct {
+	Status       ProbeStatus       `json:"status"`
+	Reason       string            `json:"reason,omitempty"`
+	Capabilities map[string]string `json:"capabilities,omitempty"`
+}
+
+// CapabilitiesResponse is the envelope for GET /api/v1/system/capabilities.
+type CapabilitiesResponse struct {
+	Gears map[string]CapabilityEntry `json:"gears"`
+}
+
+// RegisterSystemRoutes registers cross-cutting agent endpoints that aren't
+// tied to a single gear. Today that's just the capability table; future
+// system-wide endpoints belong here too. Mount under the same auth group as
+// the plugin routes.
+func (m *Manager) RegisterSystemRoutes(r chi.Router) {
+	r.Get("/api/v1/system/capabilities", m.handleCapabilities)
+}
+
+// handleCapabilities renders the probe table — every registered gear, its
+// verdict, reason, and any detected capability key-values. The dashboard
+// uses this to hide gears that can't run on a given box (issue #71 item 2).
+func (m *Manager) handleCapabilities(w http.ResponseWriter, r *http.Request) {
+	plugins := All()
+	results := m.ProbeResults()
+	out := CapabilitiesResponse{Gears: make(map[string]CapabilityEntry, len(plugins))}
+	for _, p := range plugins {
+		name := p.Info().Name
+		pr := results[name]
+		out.Gears[name] = CapabilityEntry{
+			Status:       pr.Status,
+			Reason:       pr.Reason,
+			Capabilities: pr.Capabilities,
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		m.logger.Error("encode capabilities response failed", "error", err)
+	}
 }
 
 // GetHealth returns health status for all plugins.

--- a/gearbox-agent/internal/framework/gear/manager_probe_test.go
+++ b/gearbox-agent/internal/framework/gear/manager_probe_test.go
@@ -3,7 +3,9 @@ package gear
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -232,6 +234,66 @@ func TestProbeTableHasHeaderAndAlignedRows(t *testing.T) {
 		if strings.Contains(line, "alpha") && strings.Contains(line, "ok") {
 			t.Errorf("enabled gear should not show its reason in the table, got line: %q", line)
 		}
+	}
+}
+
+func TestCapabilitiesEndpointReportsEveryGearWithVerdict(t *testing.T) {
+	// Dashboard relies on every probed gear appearing in the response so it
+	// can decide whether to surface or hide each gear's settings card.
+	// Available gears must be flagged available; non-available gears must
+	// carry their reason so the operator can act on it (issue #71 item 2).
+	a := &mockProbeGear{
+		info:        Info{Name: "alpha"},
+		probeResult: ProbeAvailable("ok", map[string]string{"version": "1.0"}),
+	}
+	b := &mockProbeGear{
+		info:        Info{Name: "bravo"},
+		probeResult: ProbeNotInstalled("not on PATH"),
+	}
+	withTestRegistry(t, a, b)
+
+	m, _ := newTestManager(t)
+	m.ProbeAll(context.Background())
+
+	r := chi.NewRouter()
+	m.RegisterSystemRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/capabilities", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+
+	var resp CapabilitiesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	alpha, ok := resp.Gears["alpha"]
+	if !ok {
+		t.Fatalf("alpha missing from response")
+	}
+	if alpha.Status != ProbeStatusAvailable {
+		t.Errorf("alpha status = %v, want available", alpha.Status)
+	}
+	if alpha.Capabilities["version"] != "1.0" {
+		t.Errorf("alpha capabilities = %v, want version=1.0", alpha.Capabilities)
+	}
+
+	bravo, ok := resp.Gears["bravo"]
+	if !ok {
+		t.Fatalf("bravo missing from response")
+	}
+	if bravo.Status != ProbeStatusNotInstalled {
+		t.Errorf("bravo status = %v, want not_installed", bravo.Status)
+	}
+	if bravo.Reason == "" {
+		t.Errorf("bravo reason is empty; operator-facing message lost")
 	}
 }
 

--- a/gearbox/internal/framework/agent/client.go
+++ b/gearbox/internal/framework/agent/client.go
@@ -820,6 +820,24 @@ func (c *Client) GetTrafficSummary() (*TrafficSummaryResponse, error) {
 	return &resp, nil
 }
 
+// GetCapabilities retrieves the agent's probe table — every registered
+// gear's availability verdict and detected capability key-values. Used by
+// the dashboard's Gears settings page to hide gears the active box can't
+// run (issue #71 item 2).
+func (c *Client) GetCapabilities() (*CapabilitiesResponse, error) {
+	body, err := c.doRequest("GET", "/api/v1/system/capabilities", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp CapabilitiesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse capabilities response: %w", err)
+	}
+
+	return &resp, nil
+}
+
 // IsAPIError checks if an error is an API error and returns it.
 func IsAPIError(err error) (*APIError, bool) {
 	if apiErr, ok := err.(*APIError); ok {

--- a/gearbox/internal/framework/agent/models.go
+++ b/gearbox/internal/framework/agent/models.go
@@ -935,3 +935,22 @@ type ConfigureUnattendedRequest struct {
 	Enabled    bool `json:"enabled"`
 	AutoReboot bool `json:"auto_reboot"`
 }
+
+// CapabilityEntry is the per-gear probe verdict returned by
+// GET /api/v1/system/capabilities. Status mirrors the agent's ProbeStatus
+// (available / not_installed / inaccessible / disabled).
+type CapabilityEntry struct {
+	Status       string            `json:"status"`
+	Reason       string            `json:"reason,omitempty"`
+	Capabilities map[string]string `json:"capabilities,omitempty"`
+}
+
+// CapabilitiesResponse mirrors the agent's CapabilitiesResponse.
+type CapabilitiesResponse struct {
+	Gears map[string]CapabilityEntry `json:"gears"`
+}
+
+// IsAvailable reports whether the gear should be surfaced for this box.
+func (e CapabilityEntry) IsAvailable() bool {
+	return e.Status == "available"
+}

--- a/gearbox/internal/framework/handler/gears.go
+++ b/gearbox/internal/framework/handler/gears.go
@@ -32,11 +32,9 @@ func (h *Handler) GearsPage(w http.ResponseWriter, r *http.Request) {
 	// Get enabled servers from database (dynamic, includes newly created servers)
 	servers := h.getEnabledServers()
 
-	// Get server ID from query param, default to first server
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	// Resolve which box to show config for: explicit ?server= wins, then
+	// the persistent active-box cookie (the header pill), then first server.
+	boxID := h.resolveBoxIDFromRequest(r)
 
 	// boxID may be empty on a fresh install — the template renders an
 	// "Add a Box" CTA in place of the per-box gear list. System-scoped
@@ -55,6 +53,9 @@ func (h *Handler) GearsPage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
+		// Hide gears the agent's probe phase says aren't available on this
+		// box (issue #71 item 2). Fails open if the agent is unreachable.
+		plugins = h.filterGearsByAgentCapabilities(boxID, plugins)
 	}
 
 	// Load system-scoped (box-agnostic) gears so they render alongside the
@@ -76,6 +77,59 @@ func (h *Handler) GearsPage(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("Failed to render gears template", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}
+}
+
+// dashboardGearToAgentGear maps a dashboard gear name to the agent gear
+// whose probe verdict gates its visibility. Dashboard gears not in this map
+// have no agent counterpart and are always shown (services & alerts are
+// always-on dashboard concepts; certbot piggy-backs on certificates;
+// system gears like home don't probe any host capability).
+var dashboardGearToAgentGear = map[string]string{
+	database.GearHAProxy:      "haproxy",
+	database.GearLogs:         "logs",
+	database.GearCertificates: "certificates",
+	database.GearMetrics:      "metrics",
+	database.GearTraffic:      "traffic",
+	database.GearOSUpdates:    "updates",
+}
+
+// filterGearsByAgentCapabilities removes gears the agent has reported as
+// not-installed / inaccessible / disabled. Fail-open on any error: when the
+// agent is unreachable or running a version without the capabilities
+// endpoint, we surface the full gear list so users aren't locked out of
+// configuring boxes mid-upgrade. Non-mapped gears are always retained.
+func (h *Handler) filterGearsByAgentCapabilities(boxID string, gears []database.Gear) []database.Gear {
+	serverConfig, exists := h.getServerConfig(boxID)
+	if !exists || !serverConfig.UsesAgentAPI() {
+		return gears
+	}
+
+	client := agent.NewClient(serverConfig.AgentURL, serverConfig.APIKey)
+	caps, err := client.GetCapabilities()
+	if err != nil {
+		h.logger.Debug("capabilities fetch failed; showing all gears", "box_id", boxID, "error", err)
+		return gears
+	}
+
+	out := make([]database.Gear, 0, len(gears))
+	for _, g := range gears {
+		agentName, gated := dashboardGearToAgentGear[g.Name]
+		if !gated {
+			out = append(out, g)
+			continue
+		}
+		entry, present := caps.Gears[agentName]
+		if !present {
+			// Agent didn't report this gear at all — keep it (older agent
+			// or gear not yet probe-aware).
+			out = append(out, g)
+			continue
+		}
+		if entry.IsAvailable() {
+			out = append(out, g)
+		}
+	}
+	return out
 }
 
 // getComponentForGear maps gear names to their corresponding permission component.
@@ -116,14 +170,9 @@ func (h *Handler) GearDetailPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get enabled servers from database (dynamic, includes newly created servers)
-	servers := h.getEnabledServers()
-
-	// Get server ID from query param
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	// Resolve which box to load config for. Same precedence as GearsPage so
+	// the configure link from the gears list lands on the right box.
+	boxID := h.resolveBoxIDFromRequest(r)
 
 	if boxID == "" {
 		http.Error(w, "No servers configured", http.StatusBadRequest)
@@ -202,14 +251,9 @@ func (h *Handler) GearTogglePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get enabled servers from database (dynamic, includes newly created servers)
-	servers := h.getEnabledServers()
-
-	// Get server ID from query param
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	// Resolve which box to toggle for. Honors the active-box cookie when the
+	// AJAX call omits ?server= (some legacy callers do).
+	boxID := h.resolveBoxIDFromRequest(r)
 
 	gearName := chi.URLParam(r, "name")
 
@@ -307,14 +351,8 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get enabled servers from database (dynamic, includes newly created servers)
-	servers := h.getEnabledServers()
-
-	// Get server ID from query param
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	// Resolve which box to update config for. Same precedence as GearsPage.
+	boxID := h.resolveBoxIDFromRequest(r)
 	redirectBase := "/settings/gears/" + gearName + "?server=" + url.QueryEscape(boxID)
 
 	if err := r.ParseForm(); err != nil {
@@ -375,6 +413,12 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		if wantsJSON {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error": err.Error()})
+			return
+		}
 		http.Redirect(w, r, redirectBase+"&error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}
@@ -382,11 +426,22 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 	// Update the gear
 	if err := h.db.SetGearConfig(boxID, gearName, newConfig, &user.ID); err != nil {
 		h.logger.Error("failed to update gear", "gear", gearName, "error", err)
+		if wantsJSON {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error": "Failed to save configuration"})
+			return
+		}
 		http.Redirect(w, r, redirectBase+"&error="+url.QueryEscape("Failed to save configuration"), http.StatusSeeOther)
 		return
 	}
 
 	h.logAudit(r, user.ID, "gear_updated", gearItem.DisplayName+" configuration updated")
+	if wantsJSON {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+		return
+	}
 	http.Redirect(w, r, redirectBase+"&success="+url.QueryEscape("Configuration saved successfully"), http.StatusSeeOther)
 }
 
@@ -815,13 +870,7 @@ func (h *Handler) getCuratedServicesList() []string {
 
 // APIGearsHandler returns all plugins as JSON.
 func (h *Handler) APIGearsHandler(w http.ResponseWriter, r *http.Request) {
-	// Get enabled servers from database (dynamic, includes newly created servers)
-	servers := h.getEnabledServers()
-
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	boxID := h.resolveBoxIDFromRequest(r)
 
 	if boxID == "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -845,13 +894,7 @@ func (h *Handler) APIGearsHandler(w http.ResponseWriter, r *http.Request) {
 
 // APIGearStatusHandler returns enabled status for plugins.
 func (h *Handler) APIGearStatusHandler(w http.ResponseWriter, r *http.Request) {
-	// Get enabled servers from database (dynamic, includes newly created servers)
-	servers := h.getEnabledServers()
-
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	boxID := h.resolveBoxIDFromRequest(r)
 
 	if boxID == "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -914,13 +957,7 @@ func (h *Handler) APIUpdateGearSortOrder(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Get enabled servers from database (dynamic, includes newly created servers)
-	servers := h.getEnabledServers()
-
-	boxID := r.URL.Query().Get("server")
-	if boxID == "" && len(servers) > 0 {
-		boxID = servers[0].ID
-	}
+	boxID := h.resolveBoxIDFromRequest(r)
 
 	if boxID == "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -1030,7 +1067,7 @@ func (h *Handler) HAProxyGitSettingsSave(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	boxID := r.URL.Query().Get("server")
+	boxID := h.resolveBoxIDFromRequest(r)
 	if boxID == "" {
 		http.Error(w, "No server specified", http.StatusBadRequest)
 		return

--- a/gearbox/internal/framework/handler/gears.go
+++ b/gearbox/internal/framework/handler/gears.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/sarg3nt/gearbox/internal/framework/agent"
@@ -93,6 +94,12 @@ var dashboardGearToAgentGear = map[string]string{
 	database.GearOSUpdates:    "updates",
 }
 
+// capabilitiesFetchTimeout caps the synchronous Gears-page → agent call
+// so a dead agent doesn't stall page rendering for the full 30s default.
+// 3s is enough for a healthy LAN agent, short enough that operators don't
+// notice when an agent is gone.
+const capabilitiesFetchTimeout = 3 * time.Second
+
 // filterGearsByAgentCapabilities removes gears the agent has reported as
 // not-installed / inaccessible / disabled. Fail-open on any error: when the
 // agent is unreachable or running a version without the capabilities
@@ -104,7 +111,10 @@ func (h *Handler) filterGearsByAgentCapabilities(boxID string, gears []database.
 		return gears
 	}
 
-	client := agent.NewClient(serverConfig.AgentURL, serverConfig.APIKey)
+	// Short timeout — this call sits on the critical path of every Gears
+	// page render, so a 30s default would freeze the UI when the box is
+	// down. Fail-open if it times out.
+	client := agent.NewClientWithTimeout(serverConfig.AgentURL, serverConfig.APIKey, capabilitiesFetchTimeout)
 	caps, err := client.GetCapabilities()
 	if err != nil {
 		h.logger.Debug("capabilities fetch failed; showing all gears", "box_id", boxID, "error", err)
@@ -355,7 +365,22 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 	boxID := h.resolveBoxIDFromRequest(r)
 	redirectBase := "/settings/gears/" + gearName + "?server=" + url.QueryEscape(boxID)
 
+	// Compute wantsJSON up front so every error path below (parse failures,
+	// gear lookup failures, validation errors, save failures) can respond
+	// in the format the caller actually expects. AJAX auto-savers (services,
+	// logs) request JSON; classic form POSTs accept HTML and get redirects.
+	wantsJSON := strings.Contains(r.Header.Get("Accept"), "application/json")
+	jsonError := func(status int, msg string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error": msg})
+	}
+
 	if err := r.ParseForm(); err != nil {
+		if wantsJSON {
+			jsonError(http.StatusBadRequest, "Invalid form data")
+			return
+		}
 		http.Redirect(w, r, redirectBase+"&error="+url.QueryEscape("Invalid form data"), http.StatusSeeOther)
 		return
 	}
@@ -363,12 +388,15 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 	// Get current gear
 	gearItem, err := h.db.GetGear(boxID, gearName)
 	if err != nil || gearItem == nil {
+		if wantsJSON {
+			jsonError(http.StatusNotFound, "Integration not found")
+			return
+		}
 		http.Redirect(w, r, "/settings/gears?server="+url.QueryEscape(boxID)+"&error="+url.QueryEscape("Integration not found"), http.StatusSeeOther)
 		return
 	}
 
 	// Handle config update based on gear type
-	wantsJSON := strings.Contains(r.Header.Get("Accept"), "application/json")
 	var newConfig json.RawMessage
 	switch gearName {
 	case database.GearServices:
@@ -381,9 +409,7 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 		err = h.saveLogSourcesConfig(boxID, r)
 		if err != nil {
 			if wantsJSON {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error": err.Error()})
+				jsonError(http.StatusInternalServerError, err.Error())
 				return
 			}
 			http.Redirect(w, r, redirectBase+"&error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
@@ -414,9 +440,7 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		if wantsJSON {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error": err.Error()})
+			jsonError(http.StatusBadRequest, err.Error())
 			return
 		}
 		http.Redirect(w, r, redirectBase+"&error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
@@ -427,9 +451,7 @@ func (h *Handler) GearUpdatePost(w http.ResponseWriter, r *http.Request) {
 	if err := h.db.SetGearConfig(boxID, gearName, newConfig, &user.ID); err != nil {
 		h.logger.Error("failed to update gear", "gear", gearName, "error", err)
 		if wantsJSON {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error": "Failed to save configuration"})
+			jsonError(http.StatusInternalServerError, "Failed to save configuration")
 			return
 		}
 		http.Redirect(w, r, redirectBase+"&error="+url.QueryEscape("Failed to save configuration"), http.StatusSeeOther)

--- a/gearbox/internal/framework/handler/handler.go
+++ b/gearbox/internal/framework/handler/handler.go
@@ -207,6 +207,32 @@ func (h *Handler) getDefaultServerID() string {
 	return ""
 }
 
+// resolveBoxIDFromRequest picks the box ID to operate on, in priority:
+//  1. `?server=<id>` query param — explicit per-link override.
+//  2. `gearbox_active_box` cookie — the header pill's selection.
+//  3. The first enabled server — first-login fallback.
+//
+// Previously the Gears settings handlers only consulted `?server=` and fell
+// straight through to the first server when it was missing, which made the
+// page show the first box's gears even while the header pill was on a
+// different box (issue #71 item 1). Reading the cookie aligns these
+// handlers with the pill that's actually visible to the user.
+func (h *Handler) resolveBoxIDFromRequest(r *http.Request) string {
+	if id := r.URL.Query().Get("server"); id != "" {
+		return id
+	}
+	if c, err := r.Cookie(activeBoxCookieName); err == nil && c.Value != "" {
+		// Only honor the cookie if it still resolves to an enabled server —
+		// stale cookies (deleted/disabled boxes) shouldn't dictate behavior.
+		for _, s := range h.getEnabledServers() {
+			if s.ID == c.Value {
+				return c.Value
+			}
+		}
+	}
+	return h.getDefaultServerID()
+}
+
 // activeBoxCookieName is the cookie key that persists the user's selected
 // box across navigations. Lets gear links (e.g. /haproxy) drop the verbose
 // `?box_id=` query string and still resolve the active context.

--- a/gearbox/internal/framework/models/settings_pages.go
+++ b/gearbox/internal/framework/models/settings_pages.go
@@ -1,0 +1,90 @@
+package models
+
+// SettingsPage is a single entry on the /settings root grid. The Settings
+// template renders one card per entry; the Cmd+K palette serializes the
+// same slice into its `cmdk-pages` JSON island. Both consumers go through
+// SettingsPagesFor so permission gating lives in exactly one place — if
+// it drifted, the palette would either dangle 403 destinations or hide
+// pages users can in fact reach (PR #76 Copilot review).
+type SettingsPage struct {
+	// Name is the stable kebab-case slug used as the palette item id and
+	// as the icon-key switch on the Settings card renderer. Must be unique.
+	Name string
+	// Label is the user-facing title shown on the card and in the palette.
+	Label string
+	// Description is the one-line card subtitle. Empty for palette-only
+	// entries (none today, kept as an explicit option).
+	Description string
+	// Path is the destination URL.
+	Path string
+}
+
+// SettingsPagesFor returns the ordered list of settings pages the given
+// user can reach. The Settings template iterates this for card layout;
+// encodePagesJSON iterates the same slice to populate the Cmd+K palette.
+// Adding a new settings page = appending an entry here once.
+//
+// perms may be nil for users whose permission record hasn't loaded — we
+// treat that as "no extra permissions beyond role" so admins still see
+// everything they should.
+func SettingsPagesFor(user *User, perms *UserPermissions) []SettingsPage {
+	isAdmin := user != nil && user.IsAdmin()
+	hasPerm := func(c Component, p Permission) bool {
+		return perms != nil && perms.HasPermission(c, p)
+	}
+
+	pages := make([]SettingsPage, 0, 10)
+	if isAdmin || hasPerm(ComponentSettings, PermissionManageBoxes) {
+		pages = append(pages, SettingsPage{
+			Name:        "boxes",
+			Label:       "Boxes",
+			Description: "Manage monitored boxes",
+			Path:        "/settings/boxes",
+		})
+	}
+	if isAdmin || hasPerm(ComponentGears, PermissionManage) {
+		pages = append(pages, SettingsPage{
+			Name:        "gears",
+			Label:       "Gears",
+			Description: "Enable/disable features and configure gears",
+			Path:        "/settings/gears",
+		})
+	}
+	pages = append(pages, SettingsPage{
+		Name:        "profile",
+		Label:       "Profile",
+		Description: "Update your personal information and passkeys",
+		Path:        "/settings/profile",
+	})
+	if isAdmin || hasPerm(ComponentUsers, PermissionApproveUsers) {
+		pages = append(pages, SettingsPage{
+			Name:        "users",
+			Label:       "User Management",
+			Description: "Manage users and account requests",
+			Path:        "/settings/users",
+		})
+	}
+	if isAdmin {
+		pages = append(pages, SettingsPage{
+			Name:        "smtp",
+			Label:       "Email Settings",
+			Description: "Configure SMTP server for email notifications",
+			Path:        "/settings/smtp",
+		})
+	}
+	pages = append(pages, SettingsPage{
+		Name:        "backups",
+		Label:       "Database Backups",
+		Description: "Create and restore database backups",
+		Path:        "/settings/backup",
+	})
+	if isAdmin {
+		pages = append(pages, SettingsPage{
+			Name:        "permissions",
+			Label:       "Permission Management",
+			Description: "Manage granular permissions for users",
+			Path:        "/settings/permissions",
+		})
+	}
+	return pages
+}

--- a/gearbox/internal/framework/templates/layouts/base.templ
+++ b/gearbox/internal/framework/templates/layouts/base.templ
@@ -117,10 +117,11 @@ func encodeGearsJSON(ctx context.Context) string {
 }
 
 // encodePagesJSON serializes the user's reachable settings/profile pages
-// for the command palette. Each entry has the same shape as a gear: name,
-// label, path. Only pages the current user can actually visit are emitted
-// — admin-only items are filtered out for non-admins so the palette
-// doesn't dangle 403 destinations. Issue #71 item 4.
+// for the command palette. Source of truth is models.SettingsPagesFor —
+// the Settings template renders cards from the same slice, so the palette
+// can never dangle a 403 destination or omit a page the user can reach.
+// Augmented with palette-only entries (Settings root, Profile sub-pages,
+// Add-a-box) that don't need their own Settings card.
 func encodePagesJSON(ctx context.Context) string {
 	type lite struct {
 		Name  string `json:"name"`
@@ -129,35 +130,19 @@ func encodePagesJSON(ctx context.Context) string {
 	}
 	user, _ := auth.GetUserFromContext(ctx)
 	perms, _ := auth.GetUserPermissionsFromContext(ctx)
-	isAdmin := user != nil && user.IsAdmin()
-	hasPerm := func(c models.Component, p models.Permission) bool {
-		return perms != nil && perms.HasPermission(c, p)
-	}
 
-	out := make([]lite, 0, 12)
-	add := func(name, label, path string) {
-		out = append(out, lite{Name: name, Label: label, Path: path})
-	}
-
-	// Always available
-	add("settings", "Settings", "/settings")
-	add("profile", "Profile", "/settings/profile")
-	add("change-password", "Change password", "/settings/change-password")
-	add("backups", "Database backups", "/settings/backup")
-
-	if isAdmin || hasPerm(models.ComponentSettings, models.PermissionManageBoxes) {
-		add("boxes", "Boxes", "/settings/boxes")
-		add("boxes-new", "Add a box", "/settings/boxes/new")
-	}
-	if isAdmin || hasPerm(models.ComponentGears, models.PermissionManage) {
-		add("gears", "Gears", "/settings/gears")
-	}
-	if isAdmin || hasPerm(models.ComponentUsers, models.PermissionApproveUsers) {
-		add("users", "User management", "/settings/users")
-	}
-	if isAdmin {
-		add("smtp", "Email (SMTP) settings", "/settings/smtp")
-		add("permissions", "Permission management", "/settings/permissions")
+	pages := models.SettingsPagesFor(user, perms)
+	out := make([]lite, 0, len(pages)+4)
+	// Always reachable, but not their own Settings card.
+	out = append(out, lite{Name: "settings", Label: "Settings", Path: "/settings"})
+	out = append(out, lite{Name: "change-password", Label: "Change password", Path: "/settings/change-password"})
+	for _, p := range pages {
+		out = append(out, lite{Name: p.Name, Label: p.Label, Path: p.Path})
+		// Surface "Add a box" alongside the Boxes card for one-keystroke
+		// access from anywhere — only when the user can see Boxes itself.
+		if p.Name == "boxes" {
+			out = append(out, lite{Name: "boxes-new", Label: "Add a box", Path: "/settings/boxes/new"})
+		}
 	}
 
 	b, err := json.Marshal(out)

--- a/gearbox/internal/framework/templates/layouts/base.templ
+++ b/gearbox/internal/framework/templates/layouts/base.templ
@@ -116,6 +116,57 @@ func encodeGearsJSON(ctx context.Context) string {
 	return string(b)
 }
 
+// encodePagesJSON serializes the user's reachable settings/profile pages
+// for the command palette. Each entry has the same shape as a gear: name,
+// label, path. Only pages the current user can actually visit are emitted
+// — admin-only items are filtered out for non-admins so the palette
+// doesn't dangle 403 destinations. Issue #71 item 4.
+func encodePagesJSON(ctx context.Context) string {
+	type lite struct {
+		Name  string `json:"name"`
+		Label string `json:"label"`
+		Path  string `json:"path"`
+	}
+	user, _ := auth.GetUserFromContext(ctx)
+	perms, _ := auth.GetUserPermissionsFromContext(ctx)
+	isAdmin := user != nil && user.IsAdmin()
+	hasPerm := func(c models.Component, p models.Permission) bool {
+		return perms != nil && perms.HasPermission(c, p)
+	}
+
+	out := make([]lite, 0, 12)
+	add := func(name, label, path string) {
+		out = append(out, lite{Name: name, Label: label, Path: path})
+	}
+
+	// Always available
+	add("settings", "Settings", "/settings")
+	add("profile", "Profile", "/settings/profile")
+	add("change-password", "Change password", "/settings/change-password")
+	add("backups", "Database backups", "/settings/backup")
+
+	if isAdmin || hasPerm(models.ComponentSettings, models.PermissionManageBoxes) {
+		add("boxes", "Boxes", "/settings/boxes")
+		add("boxes-new", "Add a box", "/settings/boxes/new")
+	}
+	if isAdmin || hasPerm(models.ComponentGears, models.PermissionManage) {
+		add("gears", "Gears", "/settings/gears")
+	}
+	if isAdmin || hasPerm(models.ComponentUsers, models.PermissionApproveUsers) {
+		add("users", "User management", "/settings/users")
+	}
+	if isAdmin {
+		add("smtp", "Email (SMTP) settings", "/settings/smtp")
+		add("permissions", "Permission management", "/settings/permissions")
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
 // gearLabelForName returns the user-facing label for a gear name. Mirrors
 // the labels used by SidebarLink* templates so the palette matches the
 // sidebar's vocabulary exactly.
@@ -2478,6 +2529,7 @@ templ CommandPalette() {
 	     parsed by command-palette.js at open time. -->
 	@templ.Raw("<script type=\"application/json\" id=\"cmdk-boxes\">" + encodeBoxesJSON(boxes) + "</script>")
 	@templ.Raw("<script type=\"application/json\" id=\"cmdk-gears\">" + encodeGearsJSON(ctx) + "</script>")
+	@templ.Raw("<script type=\"application/json\" id=\"cmdk-pages\">" + encodePagesJSON(ctx) + "</script>")
 }
 
 // ShortcutHelp is the `?`-opens overlay listing every global shortcut.

--- a/gearbox/internal/framework/templates/pages/gears.templ
+++ b/gearbox/internal/framework/templates/pages/gears.templ
@@ -288,14 +288,17 @@ templ GearDetailPage(user *models.User, serverID string, serverName string, inte
 }
 
 templ servicesConfigForm(integration *database.Gear, serverID string, availableServices []string) {
-	<form method="POST" action={ templ.SafeURL("/settings/gears/" + integration.Name + "?server=" + serverID) }>
+	<!-- No <form>: each toggle auto-saves via fetch() in services-config.js.
+	     The action URL still lives in data-action so the JS doesn't have to
+	     know how to construct it. -->
+	<div id="services-config-root" data-action={ "/settings/gears/" + integration.Name + "?server=" + serverID }>
 		<div class="space-y-6">
 			<!-- Header with title and filter -->
 			<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
 				<div>
 					<h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Monitored Services</h3>
 					<p class="text-sm text-gray-600 dark:text-gray-400">
-						Select which systemd services to monitor. These services will be displayed on the Services page.
+						Select which systemd services to monitor. Changes save automatically.
 					</p>
 				</div>
 				if len(availableServices) > 0 {
@@ -338,6 +341,7 @@ templ servicesConfigForm(integration *database.Gear, serverID string, availableS
 				<label class="flex items-center space-x-2">
 					<input
 						type="checkbox"
+						id="services-show-all"
 						name="show_all"
 						checked?={ isShowAllEnabled(integration.Config) }
 						class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
@@ -348,17 +352,8 @@ templ servicesConfigForm(integration *database.Gear, serverID string, availableS
 					When enabled, you can query any systemd service by name on the Services page.
 				</p>
 			</div>
-
-			<div class="flex justify-end pt-4">
-				<button
-					type="submit"
-					class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
-				>
-					Save Configuration
-				</button>
-			</div>
 		</div>
-	</form>
+	</div>
 
 	<script src="/static/js/gears/services-config.js"></script>
 }

--- a/gearbox/internal/framework/templates/pages/user_pages.templ
+++ b/gearbox/internal/framework/templates/pages/user_pages.templ
@@ -793,124 +793,13 @@ templ Settings(user *models.User, perms *models.UserPermissions) {
 
 		<div class="max-w-4xl mx-auto">
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-			<!-- Boxes - shown to admins or users with manage_servers permission -->
-			if user.IsAdmin() || perms.HasPermission(models.ComponentSettings, models.PermissionManageBoxes) {
-				<a href="/settings/boxes" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-blue-100 dark:bg-blue-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<rect x="3" y="3" width="18" height="18" rx="3.5" ry="3.5" stroke-width="2"></rect>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Boxes</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Manage monitored boxes</p>
-						</div>
-					</div>
-				</a>
-			}
-
-			<!-- Gears - shown to admins or users with manage permission on gears -->
-			if user.IsAdmin() || perms.HasPermission(models.ComponentGears, models.PermissionManage) {
-				<a href="/settings/gears" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-indigo-600 dark:text-indigo-400" fill="currentColor" viewBox="0 0 24 24">
-								<path d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z"></path>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Gears</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Enable/disable features and configure gears</p>
-						</div>
-					</div>
-				</a>
-			}
-
-				<!-- Profile Settings -->
-				<a href="/settings/profile" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-blue-100 dark:bg-blue-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Profile</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Update your personal information and passkeys</p>
-						</div>
-					</div>
-				</a>
-
-			<!-- Change Password is no longer a top-level Settings card. Per
-			     issue #71 item 5 it lives on the Profile page now (the page
-			     itself is unchanged at /settings/change-password). -->
-
-			<!-- User Management - shown to admins or users with approve_users permission -->
-			if user.IsAdmin() || perms.HasPermission(models.ComponentUsers, models.PermissionApproveUsers) {
-				<a href="/settings/users" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">User Management</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Manage users and account requests</p>
-						</div>
-					</div>
-				</a>
-			}
-
-			<!-- SMTP Settings - admin only -->
-			if user.IsAdmin() {
-				<a href="/settings/smtp" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-purple-100 dark:bg-purple-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Email Settings</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Configure SMTP server for email notifications</p>
-						</div>
-					</div>
-				</a>
-			}
-			<!-- Database Backups - admin only -->
-			<a href="/settings/backup" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-				<div class="flex items-center space-x-4">
-					<div class="w-12 h-12 bg-teal-100 dark:bg-teal-900 rounded-lg flex items-center justify-center">
-						<svg class="w-6 h-6 text-teal-600 dark:text-teal-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"></path>
-						</svg>
-					</div>
-					<div>
-						<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Database Backups</h2>
-						<p class="text-sm text-gray-600 dark:text-gray-400">Create and restore database backups</p>
-					</div>
-				</div>
-			</a>
-
-
-			<!-- Permissions Management - shown to admins only -->
-			if user.IsAdmin() {
-				<a href="/settings/permissions" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-red-100 dark:bg-red-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Permission Management</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Manage granular permissions for users</p>
-						</div>
-					</div>
-				</a>
-			}
+				// Cards are driven by SettingsPagesFor so the visible-page list
+				// here can't drift away from the Cmd+K palette's `cmdk-pages`
+				// island, which iterates the same slice. New pages = one entry
+				// in models.SettingsPagesFor + one icon case in settingsCardIcon.
+				for _, p := range models.SettingsPagesFor(user, perms) {
+					@settingsCard(p)
+				}
 			</div>
 		</div>
 		<script>
@@ -959,6 +848,84 @@ templ Settings(user *models.User, perms *models.UserPermissions) {
 				setupPageHeader();
 			});
 		</script>
+	}
+}
+
+// settingsCard renders one entry from models.SettingsPagesFor as a clickable
+// card on the /settings root grid. Icons + accent colors are keyed off the
+// page Name so adding a new SettingsPage entry only requires extending
+// settingsCardIcon; the perm gating stays in models.SettingsPagesFor.
+templ settingsCard(p models.SettingsPage) {
+	<a href={ templ.SafeURL(p.Path) } class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+		<div class="flex items-center space-x-4">
+			<div class={ "w-12 h-12 rounded-lg flex items-center justify-center", settingsCardIconBg(p.Name) }>
+				@settingsCardIcon(p.Name)
+			</div>
+			<div>
+				<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">{ p.Label }</h2>
+				<p class="text-sm text-gray-600 dark:text-gray-400">{ p.Description }</p>
+			</div>
+		</div>
+	</a>
+}
+
+// settingsCardIconBg returns the icon background + text color classes for
+// the named settings page. Defaults to a neutral gray for unmapped pages
+// so a forgotten entry still renders rather than crashing the template.
+func settingsCardIconBg(name string) string {
+	switch name {
+	case "boxes":
+		return "bg-blue-100 dark:bg-blue-900"
+	case "gears":
+		return "bg-indigo-100 dark:bg-indigo-900"
+	case "profile":
+		return "bg-blue-100 dark:bg-blue-900"
+	case "users":
+		return "bg-green-100 dark:bg-green-900"
+	case "smtp":
+		return "bg-purple-100 dark:bg-purple-900"
+	case "backups":
+		return "bg-teal-100 dark:bg-teal-900"
+	case "permissions":
+		return "bg-red-100 dark:bg-red-900"
+	}
+	return "bg-gray-100 dark:bg-gray-700"
+}
+
+templ settingsCardIcon(name string) {
+	switch name {
+		case "boxes":
+			<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<rect x="3" y="3" width="18" height="18" rx="3.5" ry="3.5" stroke-width="2"></rect>
+			</svg>
+		case "gears":
+			<svg class="w-6 h-6 text-indigo-600 dark:text-indigo-400" fill="currentColor" viewBox="0 0 24 24">
+				<path d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z"></path>
+			</svg>
+		case "profile":
+			<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+			</svg>
+		case "users":
+			<svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
+			</svg>
+		case "smtp":
+			<svg class="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+			</svg>
+		case "backups":
+			<svg class="w-6 h-6 text-teal-600 dark:text-teal-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"></path>
+			</svg>
+		case "permissions":
+			<svg class="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
+			</svg>
+		default:
+			<svg class="w-6 h-6 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+			</svg>
 	}
 }
 

--- a/gearbox/internal/framework/templates/pages/user_pages.templ
+++ b/gearbox/internal/framework/templates/pages/user_pages.templ
@@ -694,6 +694,23 @@ templ Profile(user *models.User, passkeys []*models.Passkey, errorMessage string
 				</form>
 			</div>
 
+			<!-- Password — link to dedicated change-password page. Lives here
+			     since #71 item 5 retired the top-level Settings card. -->
+			<div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+				<div class="flex items-center justify-between gap-4">
+					<div>
+						<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Password</h2>
+						<p class="text-sm text-gray-600 dark:text-gray-400 mt-1">Change the password used to sign in.</p>
+					</div>
+					<a
+						href="/settings/change-password"
+						class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors text-sm"
+					>
+						Change Password
+					</a>
+				</div>
+			</div>
+
 			<!-- Passkeys Section -->
 			<div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
 				<h2 class="text-lg font-semibold mb-4 text-gray-800 dark:text-gray-100">Passkeys</h2>
@@ -825,20 +842,9 @@ templ Settings(user *models.User, perms *models.UserPermissions) {
 					</div>
 				</a>
 
-				<!-- Change Password -->
-				<a href="/settings/change-password" class="block bg-white dark:bg-slate-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
-					<div class="flex items-center space-x-4">
-						<div class="w-12 h-12 bg-yellow-100 dark:bg-yellow-900 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"></path>
-							</svg>
-						</div>
-						<div>
-							<h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Change Password</h2>
-							<p class="text-sm text-gray-600 dark:text-gray-400">Update your account password</p>
-						</div>
-					</div>
-				</a>
+			<!-- Change Password is no longer a top-level Settings card. Per
+			     issue #71 item 5 it lives on the Profile page now (the page
+			     itself is unchanged at /settings/change-password). -->
 
 			<!-- User Management - shown to admins or users with approve_users permission -->
 			if user.IsAdmin() || perms.HasPermission(models.ComponentUsers, models.PermissionApproveUsers) {

--- a/gearbox/static/js/common/command-palette.js
+++ b/gearbox/static/js/common/command-palette.js
@@ -42,6 +42,7 @@
      * -------------------------------------------------------------- */
     let boxes = [];   // [{id, name}]
     let gears = [];   // [{name, label, path, enabled}]
+    let pages = [];   // [{name, label, path}]   (settings + profile pages, perm-filtered)
     let actions = []; // [{id, label, subtitle?, run(), kbd?}]
     const statusByBox = new Map();
     let activeBoxID = '';
@@ -56,6 +57,7 @@
     function loadCatalog() {
         boxes = loadJSONIsland('cmdk-boxes') || [];
         gears = loadJSONIsland('cmdk-gears') || [];
+        pages = loadJSONIsland('cmdk-pages') || [];
         const overlay = document.getElementById('cmdk-overlay');
         if (overlay) activeBoxID = overlay.dataset.activeBoxId || '';
         actions = buildActions();
@@ -150,6 +152,9 @@
     function boxItems() {
         return boxes.map(function (b) { return { kind: 'box', id: 'box:' + b.id, label: b.name, box: b }; });
     }
+    function pageItems() {
+        return pages.map(function (p) { return { kind: 'page', id: 'page:' + p.name, label: p.label, subtitle: p.path, page: p }; });
+    }
     function actionItems() {
         return actions.map(function (a) {
             return { kind: 'action', id: a.id, label: a.label, subtitle: a.subtitle || '', kbd: a.kbd || '', action: a };
@@ -166,6 +171,11 @@
                 const b = boxes.find(function (x) { return ('box:' + x.id) === id; });
                 if (!b) return null;
                 return { kind: 'box', id: id, label: b.name, box: b };
+            }
+            case 'page': {
+                const p = pages.find(function (x) { return ('page:' + x.name) === id; });
+                if (!p) return null;
+                return { kind: 'page', id: id, label: p.label, subtitle: p.path, page: p };
             }
             case 'action': {
                 const a = actions.find(function (x) { return x.id === id; });
@@ -333,6 +343,7 @@
             { title: 'Recent', items: q ? [] : getRecentItems() },
             { title: 'Boxes', items: rankItems(boxItems(), q) },
             { title: 'Gears', items: rankItems(gearItems(), q) },
+            { title: 'Settings', items: rankItems(pageItems(), q) },
             { title: 'Actions', items: rankItems(actionItems(), q) },
         ];
         sections.forEach(function (s) {
@@ -407,6 +418,11 @@
                 pushRecent(item);
                 close();
                 window.location.assign(item.gear.path);
+                return;
+            case 'page':
+                pushRecent(item);
+                close();
+                window.location.assign(item.page.path);
                 return;
             case 'action':
                 pushRecent(item);

--- a/gearbox/static/js/gears/services-config.js
+++ b/gearbox/static/js/gears/services-config.js
@@ -27,6 +27,20 @@
 		return root ? root.dataset.action : '';
 	}
 
+	// Warn loudly when the page renders without a usable save URL. The
+	// previous quiet return path meant a future templ refactor that drops
+	// data-action would make every toggle appear to "save" while doing
+	// nothing — see Copilot review on PR #76.
+	let warnedNoActionURL = false;
+	function warnMissingActionURL() {
+		if (warnedNoActionURL) return;
+		warnedNoActionURL = true;
+		console.error('services-config: #services-config-root[data-action] missing — toggles will not persist');
+		if (window.showToast) {
+			window.showToast('Cannot save services: page is missing its save URL', 'error', 6000);
+		}
+	}
+
 	function gatherFormData() {
 		const data = new FormData();
 		document.querySelectorAll('#services-grid .service-item').forEach(item => {
@@ -49,7 +63,10 @@
 			return;
 		}
 		const url = getActionURL();
-		if (!url) return;
+		if (!url) {
+			warnMissingActionURL();
+			return;
+		}
 
 		saveInFlight = true;
 		fetch(url, {

--- a/gearbox/static/js/gears/services-config.js
+++ b/gearbox/static/js/gears/services-config.js
@@ -1,3 +1,7 @@
+	// Services gear config — every toggle saves immediately (issue #71 item 3).
+	// The legacy "Save Configuration" submit button has been removed; this file
+	// owns the persistence flow now.
+
 	function filterServices(query) {
 		const items = document.querySelectorAll('.service-item');
 		const lowerQuery = query.toLowerCase();
@@ -9,6 +13,70 @@
 				item.style.display = 'none';
 			}
 		});
+	}
+
+	// In-flight save tracking. We coalesce overlapping saves: only one POST
+	// at a time, and if changes pile up while one is flying, queue exactly
+	// one re-save with the latest state when it returns. Avoids stomping
+	// rapid toggles or sending N parallel requests on Enable All.
+	let saveInFlight = false;
+	let savePending = false;
+
+	function getActionURL() {
+		const root = document.getElementById('services-config-root');
+		return root ? root.dataset.action : '';
+	}
+
+	function gatherFormData() {
+		const data = new FormData();
+		document.querySelectorAll('#services-grid .service-item').forEach(item => {
+			const enabledInput = item.querySelector('input[name^="service_enabled_"]');
+			if (enabledInput && enabledInput.value === 'true') {
+				const name = item.dataset.name;
+				if (name) data.append('services', name);
+			}
+		});
+		const showAll = document.getElementById('services-show-all');
+		if (showAll && showAll.checked) {
+			data.append('show_all', 'on');
+		}
+		return data;
+	}
+
+	function autoSave() {
+		if (saveInFlight) {
+			savePending = true;
+			return;
+		}
+		const url = getActionURL();
+		if (!url) return;
+
+		saveInFlight = true;
+		fetch(url, {
+			method: 'POST',
+			headers: { 'Accept': 'application/json' },
+			body: gatherFormData(),
+			credentials: 'same-origin',
+		})
+			.then(r => r.json().catch(() => ({ success: r.ok })))
+			.then(data => {
+				if (data && data.success === false && window.showToast) {
+					window.showToast(data.error || 'Failed to save services', 'error', 4000);
+				}
+			})
+			.catch(err => {
+				console.error('services auto-save failed', err);
+				if (window.showToast) {
+					window.showToast('Failed to save services', 'error', 4000);
+				}
+			})
+			.finally(() => {
+				saveInFlight = false;
+				if (savePending) {
+					savePending = false;
+					autoSave();
+				}
+			});
 	}
 
 	function toggleServiceItem(button, serviceName) {
@@ -35,6 +103,7 @@
 			button.querySelector('span').classList.add('translate-x-0');
 		}
 		button.setAttribute('aria-checked', newValue ? 'true' : 'false');
+		autoSave();
 	}
 
 	function toggleAllServices(enable) {
@@ -62,4 +131,12 @@
 				button.setAttribute('aria-checked', enable ? 'true' : 'false');
 			}
 		});
+		autoSave();
 	}
+
+	document.addEventListener('DOMContentLoaded', function () {
+		const showAll = document.getElementById('services-show-all');
+		if (showAll) {
+			showAll.addEventListener('change', autoSave);
+		}
+	});


### PR DESCRIPTION
Closes #71.

## Summary

Five UX fixes around box gear configuration, bundled per the issue's "all in one PR please". Each item maps directly to issue #71's numbered list.

1. **Settings → Gears now respects the active-box pill.** `?server=` still wins as an explicit override; when missing, the handler reads the `gearbox_active_box` cookie before falling back to the first server. Previously the page always showed the *first* box's gears regardless of which box the header pill was on. New helper `Handler.resolveBoxIDFromRequest` applied to `GearsPage`, `GearDetailPage`, `GearTogglePost`, `GearUpdatePost`, the `APIGears*` handlers, `APIUpdateGearSortOrder`, and `HAProxyGitSettingsSave`.

2. **Agent capabilities → dashboard filter.** New `GET /api/v1/system/capabilities` on the agent renders the probe table that #74 already collects. Dashboard fetches it when rendering the Gears settings page and *hides* gears the agent reports as `not_installed` / `inaccessible` / `disabled`. Fail-open on any error (unreachable agent, older agent without the endpoint) so users aren't locked out of configuring a box mid-upgrade. Mapping table covers `haproxy/logs/certificates/metrics/traffic/os_updates → updates`; gears with no agent counterpart (`services/alerts/certbot/home`) stay unfiltered.

3. **Services gear config form auto-saves.** Drops the *Save Configuration* button — every service toggle and the *Show All* checkbox POSTs immediately via `fetch` with `Accept: application/json`. Saves are coalesced (only one request in flight at a time, exactly one queued re-save) so *Enable All* doesn't fan out N parallel requests. `GearUpdatePost` gains a `wantsJSON` branch on the success/error paths. Gears toggles already auto-saved; this brings Services into line.

4. **Cmd+K palette grows a Settings section.** Every settings/profile page the current user has permission to visit is rendered as a JSON island (`cmdk-pages`) and shown alongside Boxes / Gears / Actions. Server-side perm filtering so non-admins don't see admin-only destinations dangle in the list.

5. **Change Password is no longer a top-level Settings card.** The `/settings/change-password` route is unchanged; the entry point now lives on the Profile page as a labeled section + button.

## Architecture note

Issue called for capabilities to be "pushed" from agent to dashboard, but the agent has no dashboard URL or push channel today (all comms are dashboard→agent pull). Implemented as **pull**: agent exposes `GET /api/v1/system/capabilities`, dashboard fetches per Gears-page render. Matches the existing architecture and the `// the upcoming /api/v1/system/capabilities endpoint` comment in `interface.go`. Confirmed with the user before implementing.

## Test plan

- [ ] `go test ./...` passes in both `gearbox/` and `gearbox-agent/` (CI).
- [ ] On a multi-box install: switch the header pill to box B, click Settings → Gears, verify the page header reads box B's name (not box A's).
- [ ] Stop a service the agent's probe depends on (e.g. uninstall HAProxy on a box), redeploy the agent, reload Settings → Gears, verify the HAProxy gear card disappears for that box only.
- [ ] On Settings → Gears → Services *Configure* page: toggle a service, navigate away, come back — selection is persisted (no Save click needed). Toggle multiple services rapidly; only one save fires at a time.
- [ ] Press Cmd+K (or Ctrl+K). New "Settings" section appears with Profile, Boxes, Gears, Change password, etc. As a non-admin: User Management / SMTP / Permission Management entries are absent.
- [ ] Visit /settings — Change Password card is gone. Visit /settings/profile — new "Password" section with a "Change Password" button is present and routes to /settings/change-password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)