### PR TITLE
feat(#87): metrics gear — KPI band, Error Insights, drill-down drawer

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -23,6 +23,11 @@ This directory contains active design documents and architectural research for t
   - Best-practice survey (Portainer, Lens, ArgoCD, Datadog, HAProxy stats, Grafana, NN/g)
   - Three layout options with ASCII mockups, recommendation, and implementation outline
 
+- **[metrics-source-agnostic.md](metrics-source-agnostic.md)**
+  - Plan to evolve the Metrics gear from "HAProxy with extras" to a source-agnostic dashboard with per-source attribution ([#87](https://github.com/sarg3nt/gearbox/issues/87))
+  - Surveys the existing capability/probe + discovery infrastructure on the agent side
+  - 9-phase rollout, each independently shippable, starting from a capability manifest endpoint and ending at multi-source (HAProxy + nginx + Apache + Caddy + Docker) drill-down
+
 ## Purpose
 
 These documents serve as:

--- a/docs/research/metrics-source-agnostic.md
+++ b/docs/research/metrics-source-agnostic.md
@@ -1,0 +1,352 @@
+# Metrics gear — source-agnostic & multi-service plan
+
+## TOC
+
+- [Context](#context)
+- [Today's reality](#todays-reality)
+- [Target shape](#target-shape)
+- [Architectural model: metric sources](#architectural-model-metric-sources)
+- [Phased rollout](#phased-rollout)
+  - [Phase 0 — Capability manifest endpoint](#phase-0--capability-manifest-endpoint)
+  - [Phase 1 — Source attribution in the UI](#phase-1--source-attribution-in-the-ui)
+  - [Phase 2 — Graceful no-HAProxy mode](#phase-2--graceful-no-haproxy-mode)
+  - [Phase 3 — Service detection layer](#phase-3--service-detection-layer)
+  - [Phase 4 — nginx metrics gear (proof of source generality)](#phase-4--nginx-metrics-gear-proof-of-source-generality)
+  - [Phase 5 — Generic access-log abstraction](#phase-5--generic-access-log-abstraction)
+  - [Phase 6 — Multi-source Error Insights](#phase-6--multi-source-error-insights)
+  - [Phase 7 — Apache, Caddy, Docker, Traefik](#phase-7--apache-caddy-docker-traefik)
+  - [Phase 8 — Cross-source aggregates (optional)](#phase-8--cross-source-aggregates-optional)
+- [Data model changes](#data-model-changes)
+- [API additions and stability](#api-additions-and-stability)
+- [Scope of agent changes by phase](#scope-of-agent-changes-by-phase)
+- [Risks and open questions](#risks-and-open-questions)
+
+## Context
+
+The Metrics gear (`/history`) was designed around HAProxy. Its KPI band, charts grid, and (as of [#87](https://github.com/sarg3nt/gearbox/issues/87)) Error Insights panel implicitly assume HAProxy is present and is the only source of request-level metrics. Pointed at a plain Linux box, the dashboard either renders empty panels or shows misleading "0" values.
+
+This document plans the evolution to a **source-agnostic** metrics dashboard that:
+
+1. Works on any host with the gearbox-agent installed, even with no proxy / web server present.
+2. Becomes richer automatically as the agent detects services (HAProxy, nginx, Apache, Caddy, Traefik, Docker, …).
+3. Attributes every metric to its source in the UI (e.g. "HAProxy: Response Times", "nginx: 5xx", "Host: CPU Load") so users always know what they're looking at.
+
+## Today's reality
+
+Audited 2026-05-14 against `gearbox-agent` and `gearbox`:
+
+| Concern                              | Status                                                                                                                                                                                                                                                                                            |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Probe phase / capability manifest    | Exists in-memory only. `gear.ProbeResult` schema is well-defined ([interface.go:208–297](../../gearbox-agent/internal/framework/gear/interface.go)). Result map populated at startup. **No API endpoint exposes it** — a comment in `manager.go:114` references an "upcoming" endpoint that hasn't shipped. |
+| Service discovery                    | `gearbox-agent/internal/framework/discovery/` has detectors for **HAProxy, Docker, systemd**. No nginx/Apache/Caddy/Traefik. Detectors are not wired into the probe phase yet.                                                                                                                    |
+| Host metrics                         | Solid: `collector.go` collects CPU load, memory, disk, network, plus per-systemd-unit status.                                                                                                                                                                                                     |
+| HAProxy metrics                      | Pulled via admin socket or stats URL; parsed from CSV; per-frontend / per-backend / per-server.                                                                                                                                                                                                    |
+| Access-log parsing                   | **Only on the dashboard side.** Agent streams raw text from `/api/v1/logs/haproxy`. Dashboard's `parseHAProxyLogLine` in `api_metrics_insights.go` is the only structured parser.                                                                                                                  |
+| Metrics collector extensibility      | Hard-coded to one host source. No plugin-style "register an additional source" mechanism.                                                                                                                                                                                                          |
+| Source attribution in UI             | None. Chart titles like "Response Times" / "5xx Errors" implicitly mean "HAProxy".                                                                                                                                                                                                                 |
+
+The good news: the bones are in place. `ProbeResult` is the right schema, the gear framework already has the "probe phase" concept, and `discovery/` is the right package. The work is mostly **filling in what's already named** rather than redesigning.
+
+## Target shape
+
+A user pointing the dashboard at a box should see:
+
+1. **Always:** host metrics (CPU, memory, disk, network, load, uptime, systemd service status). Labelled "Host".
+2. **When detected:** a section per service. HAProxy → request-level metrics + Error Insights + drill-down (as today). nginx → analogous. Caddy → analogous. Docker → per-container CPU/mem/network.
+3. **KPI band:** core host KPIs at the front (always). One additional KPI per detected service (e.g. "HAProxy req/s", "nginx req/s"), shown only when that source is present.
+4. **Source attribution:** every card, chart and panel header carries the source name. Tooltips on the KPI cards explain *which collector* produced the number.
+5. **Cross-source views (later):** when 2+ proxies are on the same box, a "Combined" toggle aggregates request/error metrics across them.
+
+## Architectural model: metric sources
+
+Introduce a first-class **MetricSource** concept on both sides:
+
+```text
+MetricSource
+├── ID        e.g. "haproxy", "nginx", "host", "docker"
+├── Label     e.g. "HAProxy", "nginx", "Host", "Docker"
+├── Icon      sidebar/badge icon
+├── Version   e.g. "2.8.5"
+├── Status    e.g. "available", "stopped", "not_installed"
+├── Reason    human-readable detail
+└── Metrics   what this source can produce
+    ├── kpis           [ "requests_rate", "5xx_count", ... ]
+    ├── timeseries     [ "request_rate", "response_time_ms", ... ]
+    └── breakdowns     [ "by_backend", "by_source_ip", "by_country", ... ]
+```
+
+On the agent: a `MetricSource` is a gear-level concept. Each agent gear that produces request-level metrics implements a small interface that returns its `MetricSource` descriptor plus standardised series.
+
+On the dashboard: the metrics page renders cards/charts/panels by iterating the box's `sources[]` list. Cards for sources that aren't present simply don't render.
+
+This means **adding a new service (nginx, Caddy) becomes a matter of writing one agent gear** — no dashboard change required to surface it, beyond per-source labels.
+
+## Phased rollout
+
+Each phase is independently shippable and improves the page on its own. **Stop after any phase and the dashboard is still strictly better than today.**
+
+### Phase 0 — Capability manifest endpoint
+
+**Agent**: ship the endpoint the comment promises.
+
+- Add `GET /api/v1/system/capabilities` returning the probe map as JSON.
+- Schema:
+
+  ```json
+  {
+    "agent_version": "...",
+    "collected_at": "2026-05-14T...",
+    "sources": [
+      {
+        "id": "host",
+        "label": "Host",
+        "status": "available",
+        "version": "Linux 6.x",
+        "capabilities": {"cpu_count": "8", "kernel": "..."}
+      },
+      {
+        "id": "haproxy",
+        "label": "HAProxy",
+        "status": "available",
+        "version": "2.8.5",
+        "capabilities": {"stats_socket": "/run/haproxy/admin.sock"}
+      }
+    ]
+  }
+  ```
+
+- Reuse the existing `gear.ProbeResult` map; add a thin marshalling layer.
+
+**Dashboard**: query and cache `capabilities` per box.
+
+- Surface in `BoxConfig` or a sibling `BoxCapabilities` struct.
+- Refresh on box reconnect + a 5-min TTL.
+- No UI change yet — purely plumbing.
+
+**Effort:** small. **Risk:** very low; purely additive.
+
+### Phase 1 — Source attribution in the UI
+
+Every chart and KPI now declares its source.
+
+- Update the existing 7 charts: titles become "HAProxy: Sessions & Requests", "Host: CPU Load", "HAProxy: 5xx Errors", etc.
+- KPI cards get a small source badge in the upper-right corner (`HAProxy`, `Host`).
+- Error Insights renamed to "HAProxy Error Insights".
+- Tooltips on cards explain the source ("Reported by HAProxy stats via /api/{id}/metrics/summary").
+
+This phase **changes wording only** — no behaviour change. But it sets up the user expectation that metrics are tied to sources, and prepares the UI for additional sources.
+
+**Effort:** small. **Risk:** very low.
+
+### Phase 2 — Graceful no-HAProxy mode
+
+Make the page useful on a plain Linux box.
+
+- If `capabilities.sources` does not include `haproxy`, hide:
+  - "HAProxy: Sessions & Requests"
+  - "HAProxy: Server Health"
+  - "HAProxy: Response Times"
+  - "HAProxy: 5xx Errors"
+  - The Error Insights panel
+  - Request-related KPIs (Requests/min, Error Rate, 5xx, Active Sessions, Healthy Backends)
+- Keep showing:
+  - "Host: CPU Load", "Host: Memory", "Host: Network"
+  - Host KPIs (we'll add some): CPU %, Memory %, Disk %, Load (1m), Uptime, Systemd services failed
+- Empty-state banner: "No HAProxy detected on this host. Showing host-level metrics only. Install HAProxy or enable the agent's HAProxy gear to see proxy metrics."
+
+This phase makes the page **honest** on non-HAProxy boxes for the first time.
+
+**Effort:** small/medium (mostly conditional rendering + a few new host KPIs).
+**Risk:** low — purely additive in the missing-source case.
+
+### Phase 3 — Service detection layer
+
+Flesh out `gearbox-agent/internal/framework/discovery/`:
+
+- Add `nginx.go`, `apache.go`, `caddy.go`, `traefik.go` detectors. Each:
+  - Tries the binary on `PATH` and a `--version` invocation.
+  - Locates the config file (well-known paths).
+  - Probes for a status / metrics endpoint:
+    - nginx: `http://127.0.0.1/nginx_status` (stub_status), `/basic_status`, or Plus API.
+    - Apache: `http://127.0.0.1/server-status?auto` (mod_status).
+    - Caddy: admin API at `http://127.0.0.1:2019/metrics`.
+    - Traefik: `:8082/metrics` or dashboard API.
+  - Returns a `ProbeResult` with status + capabilities (e.g. `status_endpoint: http://127.0.0.1/nginx_status`).
+- Wire detectors into the existing probe phase so they appear in the capabilities manifest.
+
+After this phase, the manifest tells the dashboard *what's installed*. The dashboard doesn't yet know how to read those services' metrics — that's Phase 4+.
+
+**Effort:** medium (one detector per service, ~50–100 lines each).
+**Risk:** medium — has to be robust against permission and network failures.
+
+### Phase 4 — nginx metrics gear (proof of source generality)
+
+Implement the first non-HAProxy source end-to-end. Choose nginx because it's the most-deployed alternative.
+
+**Agent side:**
+
+- New gear: `gearbox-agent/internal/gears/nginx/`.
+- Strategy 1 (preferred when available): scrape `stub_status`. Returns requests/sec, active_connections, reading/writing/waiting counters.
+- Strategy 2 (fallback): tail and parse the access log. Use a configurable format profile (default: combined). Same regex-based parsing approach as the dashboard's `parseHAProxyLogLine`, generalised.
+- Reports a `NginxStats` struct with:
+  - `requests_total`, `requests_rate`
+  - `active_connections`
+  - `response_2xx/3xx/4xx/5xx` (from log when stub_status doesn't cover them)
+  - `avg_response_time_ms` (when available — nginx logs only have it with `$request_time`)
+  - per-vhost breakdown (parsed from log's `$host`)
+- New agent endpoints:
+  - `GET /api/v1/nginx/stats`
+  - `GET /api/v1/nginx/summary`
+- Reuses the traffic delta-tracking pattern HAProxy already uses.
+
+**Dashboard side:**
+
+- New "nginx" section in the charts grid when capabilities include nginx.
+- Reuses the existing chart components (gradient fill, crosshair tooltip).
+- New KPI cards: "nginx: req/s", "nginx: 5xx", "nginx: 5xx %".
+- Error Insights gets a second panel: "nginx Error Insights" with top vhosts / source IPs / paths.
+- Drill-down drawer reused; backend → "vhost or location block" depending on what nginx reports.
+
+This phase proves the architecture handles a second source cleanly.
+
+**Effort:** medium-large (~2–3 days). **Risk:** medium — log-format variations are the main hazard.
+
+### Phase 5 — Generic access-log abstraction
+
+The agent's current logs gear streams raw text. The dashboard parses HAProxy lines server-side. nginx (Phase 4) will do its own log parsing. Apache/Caddy (Phase 7) will too.
+
+Refactor before adding more:
+
+- Promote `parseHAProxyLogLine` to the agent side as one profile of a `AccessLogParser`.
+- Define profiles for: `haproxy-http`, `nginx-combined`, `apache-common`, `apache-combined`, `caddy-json`.
+- Agent endpoint: `GET /api/v1/access-log/{source}/recent?status_min=500&limit=500` returning structured records.
+- Dashboard's `/metrics/log-errors` becomes a thin proxy to this.
+
+This consolidates parsing in one place and removes the dashboard-side regex maintenance.
+
+**Effort:** medium. **Risk:** medium (must not regress the dashboard's current log-errors feature).
+
+### Phase 6 — Multi-source Error Insights
+
+The Error Insights panel currently shows one block of "Top backends / sources / countries" — implicitly HAProxy.
+
+Generalise:
+
+- One block per detected request-source. HAProxy block has "Top backends". nginx block has "Top vhosts". Apache block likewise.
+- "Top source IPs" and "Top countries" sections aggregate across sources (an IP is an IP regardless of which proxy logged it).
+- KPI band gains a per-source error count when multiple sources are present.
+
+**Effort:** medium. **Risk:** low — additive UI; existing HAProxy code path doesn't change.
+
+### Phase 7 — Apache, Caddy, Docker, Traefik
+
+Each follows the nginx pattern:
+
+- **Apache:** `mod_status` scraping; access-log parsing for status codes.
+- **Caddy:** scrape the Prometheus endpoint at `:2019/metrics`. Caddy is the easiest because it emits well-structured Prometheus metrics already.
+- **Traefik:** scrape Prometheus endpoint. Adds router/service-level granularity.
+- **Docker:** new agent gear `gears/docker/` running `docker stats --no-stream --format` periodically. Per-container CPU/mem/network/disk-io. Especially useful on TrueNAS / mjolnir.
+
+Each ships as its own gear and capability source. Pick the order based on user demand (Docker is high-value for the current homelab).
+
+**Effort:** ~2 days each, parallelisable.
+**Risk:** per-service quirks.
+
+### Phase 8 — Cross-source aggregates (optional)
+
+Once two or more proxies coexist on the same box, offer:
+
+- A "Combined" toggle in the KPI band: sums requests/sec, 5xx, etc. across all sources.
+- A "By source" view: stacked area chart showing what fraction of traffic each proxy is handling.
+
+This is sweet-but-not-critical. Skip unless feedback demands it.
+
+## Data model changes
+
+### Agent
+
+- `gear.ProbeResult` already exists; no change to the schema.
+- New endpoint **`/api/v1/system/capabilities`** (Phase 0) exposes the probe map.
+- New gears under `gearbox-agent/internal/gears/` for nginx, apache, caddy, docker (one per phase).
+- `gearbox-agent/internal/framework/discovery/` grows one file per detected service.
+
+### Dashboard
+
+- New table: nothing required for Phases 0–2.
+- For Phases 4+, `traffic_flows` (or a new `request_flows`) gains a `source` column:
+
+  ```sql
+  ALTER TABLE traffic_flows ADD COLUMN source TEXT NOT NULL DEFAULT 'haproxy';
+  CREATE INDEX idx_traffic_flows_source ON traffic_flows(server_id, source, bucket_time);
+  ```
+
+  Migration: existing rows default to `'haproxy'`, since that's what they are today. Forward-compatible.
+- `BoxCapabilities` cached per box. Roughly:
+
+  ```go
+  type BoxCapabilities struct {
+      AgentVersion string
+      CollectedAt  time.Time
+      Sources      []SourceCapability
+  }
+  type SourceCapability struct {
+      ID         string            // "haproxy", "nginx", "host", "docker"
+      Label      string
+      Status     string            // "available", "stopped", "not_installed"
+      Version    string
+      Reason     string
+      Capabilities map[string]string
+  }
+  ```
+
+## API additions and stability
+
+### Agent
+
+| Phase | Endpoint                              | Purpose                                                        |
+|-------|---------------------------------------|----------------------------------------------------------------|
+| 0     | `GET /api/v1/system/capabilities`     | Probe results as JSON                                          |
+| 4     | `GET /api/v1/nginx/stats`             | nginx stub_status + log-derived counts                         |
+| 4     | `GET /api/v1/nginx/summary`           | nginx summary (per-vhost top-N)                                |
+| 5     | `GET /api/v1/access-log/{src}/recent` | Structured recent log lines for any registered source          |
+| 7     | `GET /api/v1/apache/stats`            | Apache mod_status                                              |
+| 7     | `GET /api/v1/caddy/stats`             | Caddy Prometheus scrape (re-emitted as gearbox shape)          |
+| 7     | `GET /api/v1/docker/stats`            | docker stats per container                                     |
+| 7     | `GET /api/v1/traefik/stats`           | Traefik Prometheus scrape                                      |
+
+All additions — no breaking changes to existing endpoints. The existing `/api/v1/haproxy/*` endpoints stay exactly as they are.
+
+### Dashboard
+
+The KPI / error-breakdown / backend-details endpoints added in [#87](https://github.com/sarg3nt/gearbox/issues/87) gain an optional `source` query parameter (default: `haproxy`). New endpoints aren't required initially — same shapes, scoped to a source.
+
+| Endpoint                                              | Change                                                                                                  |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `/api/{id}/metrics/summary?range=…&source=…`          | Optional source. When omitted: returns "all sources" combined view.                                     |
+| `/api/{id}/metrics/error-breakdown?range=…&source=…`  | Optional source filter.                                                                                 |
+| `/api/{id}/metrics/backend/{name}/details?source=…`   | Path-param `{name}` becomes "logical entity name" — backend for HAProxy, vhost for nginx, etc.          |
+| `/api/{id}/metrics/log-errors?source=…`               | Optional source. Default still `haproxy` for backwards compatibility.                                   |
+| `/api/{id}/capabilities`                              | **New** — proxies the agent's capability manifest to the dashboard's auth-scoped clients.               |
+
+## Scope of agent changes by phase
+
+| Phase | Files touched                                                             | New gears | Risk to running agents      |
+|-------|---------------------------------------------------------------------------|-----------|-----------------------------|
+| 0     | `internal/api/system.go` (new handler) + 1 route                          | 0         | None                        |
+| 3     | `internal/framework/discovery/` (4 new files)                             | 0         | None                        |
+| 4     | `internal/gears/nginx/` (new gear) + route registration                   | 1         | Low — gear is opt-in        |
+| 5     | New parser package; refactor logs gear                                    | 0         | Medium — touches logs gear  |
+| 7     | One gear per service                                                      | 3–4       | Per-gear isolation          |
+
+The agent's existing gear architecture is well-suited: each new source is its own self-contained gear. Disabling a gear disables that source cleanly.
+
+## Risks and open questions
+
+1. **Permissions.** Many web servers' status endpoints aren't world-readable. The agent must run with whatever permissions the host configures. For nginx `stub_status`, that usually means a `location /nginx_status { allow 127.0.0.1; }` block — we may need to detect "stub_status returns 403/404" and tell the user how to enable it.
+2. **Log file paths.** Distros vary (`/var/log/nginx/access.log` vs `/usr/local/nginx/logs/access.log`). The discovery phase needs a config-file parse for the truth, with fallbacks.
+3. **Disk pressure from log parsing.** Tailing busy access logs to compute response-time histograms is CPU/IO work. Consider: only sample N lines per minute, or only parse on-demand when the user opens the drill-down.
+4. **Backwards compatibility.** Existing dashboards talking to existing agents must keep working through every phase. The capability manifest is opt-in; absent it, the dashboard treats the box as "HAProxy-only" exactly like today.
+5. **Multiple instances of the same service.** What about two nginx instances on one host? Today's HAProxy code assumes one. Probably out of scope until someone hits it; flag as "future work".
+6. **Per-source retention.** Currently retention is one knob applied to `traffic_flows`. With multiple sources, the data volume per source can differ wildly. May need per-source retention later.
+
+This plan is deliberately conservative: every phase ships value on its own and the architecture choices (capability manifest, per-source gears, optional `source` API params) are additive. Worst case, we stop after Phase 2 and the dashboard finally treats non-HAProxy hosts honestly. Best case, we end up with a tool that's genuinely a "platform monitor", not "HAProxy with extras".

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -682,6 +682,12 @@ func main() {
 			r.Get("/{boxID}/history/backend/{backendName}", h.APIBackendHistoryHandler)
 			r.Get("/{boxID}/incidents", h.APIIncidentsHandler)
 
+			// Metrics gear v2 — insights & drill-down endpoints
+			r.Get("/{boxID}/metrics/summary", h.APIMetricsSummaryHandler)
+			r.Get("/{boxID}/metrics/error-breakdown", h.APIMetricsErrorBreakdownHandler)
+			r.Get("/{boxID}/metrics/backend/{backendName}/details", h.APIMetricsBackendDetailsHandler)
+			r.Get("/{boxID}/metrics/log-errors", h.APIMetricsLogErrorsHandler)
+
 			// Disabled entities management
 			r.Get("/{boxID}/disabled-entities", h.APIDisabledEntitiesHandler)
 			r.Post("/{boxID}/disable-entity", h.APIDisableEntityHandler)

--- a/gearbox/internal/framework/database/metrics_insights.go
+++ b/gearbox/internal/framework/database/metrics_insights.go
@@ -1,0 +1,391 @@
+package database
+
+import (
+	"time"
+)
+
+// ErrorTotals holds the response totals over a window for the error-rate KPI.
+type ErrorTotals struct {
+	Response2xx int64
+	Response3xx int64
+	Response4xx int64
+	Response5xx int64
+	Total       int64
+}
+
+// QueryRowContext sums response counts from traffic_flows over the window.
+// It never returns nil — callers can rely on the zero value if no rows match.
+func (d *DB) QueryRowContext(boxID string, since, until time.Time) *ErrorTotals {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	row := d.db.QueryRow(`
+		SELECT
+			COALESCE(SUM(response_2xx), 0),
+			COALESCE(SUM(response_3xx), 0),
+			COALESCE(SUM(response_4xx), 0),
+			COALESCE(SUM(response_5xx), 0)
+		FROM traffic_flows
+		WHERE server_id = ? AND bucket_time >= ? AND bucket_time <= ?`,
+		boxID, since, until,
+	)
+
+	t := &ErrorTotals{}
+	if err := row.Scan(&t.Response2xx, &t.Response3xx, &t.Response4xx, &t.Response5xx); err != nil {
+		return t
+	}
+	t.Total = t.Response2xx + t.Response3xx + t.Response4xx + t.Response5xx
+	return t
+}
+
+// GetErrorRateBuckets returns per-minute error-rate percentages over the
+// window, suitable for sparkline rendering.
+func (d *DB) GetErrorRateBuckets(boxID string, since, until time.Time) []float64 {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT
+			COALESCE(SUM(response_4xx + response_5xx), 0) AS errs,
+			COALESCE(SUM(response_2xx + response_3xx + response_4xx + response_5xx), 0) AS total
+		FROM traffic_flows
+		WHERE server_id = ? AND bucket_time >= ? AND bucket_time <= ?
+		GROUP BY bucket_time
+		ORDER BY bucket_time ASC`,
+		boxID, since, until,
+	)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []float64
+	for rows.Next() {
+		var errs, total int64
+		if err := rows.Scan(&errs, &total); err != nil {
+			continue
+		}
+		if total == 0 {
+			out = append(out, 0)
+			continue
+		}
+		out = append(out, float64(errs)/float64(total)*100)
+	}
+	return out
+}
+
+// Get5xxCountBuckets returns per-minute 5xx counts over the window.
+func (d *DB) Get5xxCountBuckets(boxID string, since, until time.Time) []float64 {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT COALESCE(SUM(response_5xx), 0)
+		FROM traffic_flows
+		WHERE server_id = ? AND bucket_time >= ? AND bucket_time <= ?
+		GROUP BY bucket_time
+		ORDER BY bucket_time ASC`,
+		boxID, since, until,
+	)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []float64
+	for rows.Next() {
+		var c int64
+		if err := rows.Scan(&c); err != nil {
+			continue
+		}
+		out = append(out, float64(c))
+	}
+	return out
+}
+
+// ErrorBackendRow describes a backend's traffic + error breakdown over a window.
+// Used by the Error Insights panel on the metrics page.
+type ErrorBackendRow struct {
+	BackendName   string  `json:"backend_name"`
+	Requests      int64   `json:"requests"`
+	Response2xx   int64   `json:"response_2xx"`
+	Response3xx   int64   `json:"response_3xx"`
+	Response4xx   int64   `json:"response_4xx"`
+	Response5xx   int64   `json:"response_5xx"`
+	ErrorRate     float64 `json:"error_rate"`
+	BytesIn       int64   `json:"bytes_in"`
+	BytesOut      int64   `json:"bytes_out"`
+	UniqueIPs     int     `json:"unique_ips"`
+	AvgResponseMs int64   `json:"avg_response_ms"`
+}
+
+// ErrorSourceRow describes a source IP's traffic + error breakdown over a window.
+type ErrorSourceRow struct {
+	SourceIP      string  `json:"source_ip"`
+	Country       string  `json:"country"`
+	CountryCode   string  `json:"country_code"`
+	Requests      int64   `json:"requests"`
+	Response4xx   int64   `json:"response_4xx"`
+	Response5xx   int64   `json:"response_5xx"`
+	ErrorCount    int64   `json:"error_count"`
+	ErrorRate     float64 `json:"error_rate"`
+	Backends      int     `json:"backends_hit"`
+}
+
+// ErrorCountryRow describes a country's request + error totals.
+type ErrorCountryRow struct {
+	Country     string  `json:"country"`
+	CountryCode string  `json:"country_code"`
+	Requests    int64   `json:"requests"`
+	Errors      int64   `json:"errors"`
+	ErrorRate   float64 `json:"error_rate"`
+	UniqueIPs   int     `json:"unique_ips"`
+}
+
+// BackendTimeBucket is a single per-minute aggregate row for one backend.
+type BackendTimeBucket struct {
+	BucketTime    time.Time `json:"bucket_time"`
+	Requests      int64     `json:"requests"`
+	Response2xx   int64     `json:"response_2xx"`
+	Response3xx   int64     `json:"response_3xx"`
+	Response4xx   int64     `json:"response_4xx"`
+	Response5xx   int64     `json:"response_5xx"`
+	AvgResponseMs int64     `json:"avg_response_ms"`
+	BytesIn       int64     `json:"bytes_in"`
+	BytesOut      int64     `json:"bytes_out"`
+}
+
+// GetTopErrorBackends returns backends ordered by 5xx error count (desc) over
+// the time window. Backends with zero 5xx are excluded — this view is for
+// "what's broken?", not "what's quiet?".
+func (d *DB) GetTopErrorBackends(boxID string, since, until time.Time, limit int) ([]ErrorBackendRow, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT
+			backend_name,
+			COALESCE(SUM(request_count), 0)  AS requests,
+			COALESCE(SUM(response_2xx), 0)   AS r2xx,
+			COALESCE(SUM(response_3xx), 0)   AS r3xx,
+			COALESCE(SUM(response_4xx), 0)   AS r4xx,
+			COALESCE(SUM(response_5xx), 0)   AS r5xx,
+			COALESCE(AVG(avg_response_time), 0) AS avg_rt,
+			COALESCE(SUM(bytes_in), 0)       AS bin,
+			COALESCE(SUM(bytes_out), 0)      AS bout,
+			COUNT(DISTINCT source_ip)        AS unique_ips
+		FROM traffic_flows
+		WHERE server_id = ? AND bucket_time >= ? AND bucket_time <= ?
+		  AND backend_name != '' AND backend_name != '_unknown'
+		GROUP BY backend_name
+		HAVING r5xx > 0 OR r4xx > 0
+		ORDER BY r5xx DESC, r4xx DESC
+		LIMIT ?`,
+		boxID, since, until, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []ErrorBackendRow
+	for rows.Next() {
+		var r ErrorBackendRow
+		if err := rows.Scan(
+			&r.BackendName, &r.Requests,
+			&r.Response2xx, &r.Response3xx, &r.Response4xx, &r.Response5xx,
+			&r.AvgResponseMs, &r.BytesIn, &r.BytesOut, &r.UniqueIPs,
+		); err != nil {
+			return nil, err
+		}
+		total := r.Response2xx + r.Response3xx + r.Response4xx + r.Response5xx
+		if total > 0 {
+			r.ErrorRate = float64(r.Response4xx+r.Response5xx) / float64(total) * 100
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// GetTopErrorSources returns source IPs ranked by 4xx+5xx error count over the
+// window. Source IPs marked as aggregates (the "_aggregate" sentinel used in
+// persistTrafficData) and local addresses are excluded.
+func (d *DB) GetTopErrorSources(boxID string, since, until time.Time, limit int) ([]ErrorSourceRow, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT
+			source_ip,
+			MAX(country)       AS country,
+			MAX(country_code)  AS country_code,
+			COALESCE(SUM(request_count), 0) AS requests,
+			COALESCE(SUM(response_4xx), 0)  AS r4xx,
+			COALESCE(SUM(response_5xx), 0)  AS r5xx,
+			COALESCE(SUM(response_2xx + response_3xx + response_4xx + response_5xx), 0) AS total_resp,
+			COUNT(DISTINCT backend_name) AS backends
+		FROM traffic_flows
+		WHERE server_id = ? AND bucket_time >= ? AND bucket_time <= ?
+		  AND source_ip != '' AND source_ip != '_aggregate'
+		GROUP BY source_ip
+		HAVING (r4xx + r5xx) > 0
+		ORDER BY (r4xx + r5xx) DESC, r5xx DESC
+		LIMIT ?`,
+		boxID, since, until, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []ErrorSourceRow
+	for rows.Next() {
+		var r ErrorSourceRow
+		var totalResp int64
+		if err := rows.Scan(
+			&r.SourceIP, &r.Country, &r.CountryCode,
+			&r.Requests, &r.Response4xx, &r.Response5xx, &totalResp, &r.Backends,
+		); err != nil {
+			return nil, err
+		}
+		r.ErrorCount = r.Response4xx + r.Response5xx
+		if totalResp > 0 {
+			r.ErrorRate = float64(r.ErrorCount) / float64(totalResp) * 100
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// GetTopErrorCountries returns countries ranked by error count.
+func (d *DB) GetTopErrorCountries(boxID string, since, until time.Time, limit int) ([]ErrorCountryRow, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT
+			country, country_code,
+			COALESCE(SUM(request_count), 0) AS requests,
+			COALESCE(SUM(response_4xx + response_5xx), 0) AS errors,
+			COALESCE(SUM(response_2xx + response_3xx + response_4xx + response_5xx), 0) AS total_resp,
+			COUNT(DISTINCT source_ip) AS unique_ips
+		FROM traffic_flows
+		WHERE server_id = ? AND bucket_time >= ? AND bucket_time <= ?
+		  AND country_code != '' AND country_code != 'AG'
+		GROUP BY country, country_code
+		HAVING errors > 0
+		ORDER BY errors DESC
+		LIMIT ?`,
+		boxID, since, until, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []ErrorCountryRow
+	for rows.Next() {
+		var r ErrorCountryRow
+		var totalResp int64
+		if err := rows.Scan(&r.Country, &r.CountryCode, &r.Requests, &r.Errors, &totalResp, &r.UniqueIPs); err != nil {
+			return nil, err
+		}
+		if totalResp > 0 {
+			r.ErrorRate = float64(r.Errors) / float64(totalResp) * 100
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// GetBackendTimeSeries returns per-minute buckets for one backend in the
+// window — used by the drill-down drawer's mini-charts.
+func (d *DB) GetBackendTimeSeries(boxID, backendName string, since, until time.Time, limit int) ([]BackendTimeBucket, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT
+			bucket_time,
+			COALESCE(SUM(request_count), 0),
+			COALESCE(SUM(response_2xx), 0),
+			COALESCE(SUM(response_3xx), 0),
+			COALESCE(SUM(response_4xx), 0),
+			COALESCE(SUM(response_5xx), 0),
+			COALESCE(AVG(avg_response_time), 0),
+			COALESCE(SUM(bytes_in), 0),
+			COALESCE(SUM(bytes_out), 0)
+		FROM traffic_flows
+		WHERE server_id = ? AND backend_name = ? AND bucket_time >= ? AND bucket_time <= ?
+		GROUP BY bucket_time
+		ORDER BY bucket_time ASC
+		LIMIT ?`,
+		boxID, backendName, since, until, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []BackendTimeBucket
+	for rows.Next() {
+		var b BackendTimeBucket
+		if err := rows.Scan(
+			&b.BucketTime, &b.Requests,
+			&b.Response2xx, &b.Response3xx, &b.Response4xx, &b.Response5xx,
+			&b.AvgResponseMs, &b.BytesIn, &b.BytesOut,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// GetTopSourcesForBackend returns the top source IPs sending traffic to the
+// given backend in the window.
+func (d *DB) GetTopSourcesForBackend(boxID, backendName string, since, until time.Time, limit int) ([]ErrorSourceRow, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT
+			source_ip,
+			MAX(country) AS country,
+			MAX(country_code) AS country_code,
+			COALESCE(SUM(request_count), 0)  AS requests,
+			COALESCE(SUM(response_4xx), 0)   AS r4xx,
+			COALESCE(SUM(response_5xx), 0)   AS r5xx,
+			COALESCE(SUM(response_2xx + response_3xx + response_4xx + response_5xx), 0) AS total_resp
+		FROM traffic_flows
+		WHERE server_id = ? AND backend_name = ?
+		  AND bucket_time >= ? AND bucket_time <= ?
+		  AND source_ip != '' AND source_ip != '_aggregate'
+		GROUP BY source_ip
+		ORDER BY requests DESC
+		LIMIT ?`,
+		boxID, backendName, since, until, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []ErrorSourceRow
+	for rows.Next() {
+		var r ErrorSourceRow
+		var totalResp int64
+		if err := rows.Scan(
+			&r.SourceIP, &r.Country, &r.CountryCode,
+			&r.Requests, &r.Response4xx, &r.Response5xx, &totalResp,
+		); err != nil {
+			return nil, err
+		}
+		r.ErrorCount = r.Response4xx + r.Response5xx
+		if totalResp > 0 {
+			r.ErrorRate = float64(r.ErrorCount) / float64(totalResp) * 100
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}

--- a/gearbox/internal/framework/handler/api_metrics_insights.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights.go
@@ -85,23 +85,26 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
 		return
 	}
-	prev, err := h.db.GetStatsHistory(boxID, prevSince, 5000)
+	prevRaw, err := h.db.GetStatsHistory(boxID, prevSince, 5000)
 	if err != nil {
 		h.logger.Error("metrics summary: prev stats history", "error", err)
 		http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
 		return
 	}
-	// prev contains both windows; trim to "previous-window only".
-	prevOnly := make([]int, 0, len(prev))
-	for i, s := range prev {
+	// GetStatsHistory takes a lower bound only, so prevRaw spans both the
+	// previous AND current windows. Trim to entries strictly before `since`
+	// so the prev-window aggregates (max counter, avg response time, …)
+	// reflect the prior window in isolation — otherwise every delta vs.
+	// prior is ~0% because we'd be comparing each window to its own union
+	// with the current window.
+	prev := prevRaw[:0]
+	for _, s := range prevRaw {
 		if s.CollectedAt.Before(since) {
-			prevOnly = append(prevOnly, i)
+			prev = append(prev, s)
 		}
 	}
 
 	cards := []kpiCard{}
-
-	_ = prevOnly
 
 	currReqMax := maxStatField(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) })
 	prevReqMax := maxStatField(prev, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) })
@@ -434,8 +437,18 @@ func (h *Handler) APIMetricsLogErrorsHandler(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
 		return
 	}
+	// Lack of `logs:view` is the only "you're allowed on the metrics page,
+	// but this one sub-panel needs more permission" case we have. Return a
+	// soft envelope rather than 403 so the drawer can render the documented
+	// "logs unavailable" hint instead of the generic "fetch failed" error.
 	if !h.authManager.HasPermission(r, "logs", "view") {
-		http.Error(w, "Forbidden: log access required for log correlation", http.StatusForbidden)
+		h.writeJSON(w, map[string]interface{}{
+			"server_id":  chi.URLParam(r, "boxID"),
+			"available":  false,
+			"reason":     "Logs permission required to correlate access-log lines with metrics.",
+			"matchCount": 0,
+			"matches":    []haproxyLogLine{},
+		})
 		return
 	}
 

--- a/gearbox/internal/framework/handler/api_metrics_insights.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights.go
@@ -1,0 +1,517 @@
+// Package handler — api_metrics_insights.go
+//
+// HTTP handlers backing the Metrics gear's "insights" surface: KPI band,
+// Error Insights panel, per-backend drill-down drawer, and the related-log
+// snippet pulled from the agent. These endpoints exist to turn the
+// historical metrics page from "pretty graphs you can't act on" into
+// something a user can use to answer "what is broken, and where?".
+package handler
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
+)
+
+// metricsRangeToTimes parses the ?range= query param ("5m", "30m", "1h",
+// "6h", "24h", "3d", "7d") and returns (since, until, label). until is
+// always "now". Unknown values fall back to 24h to match the page selector.
+func metricsRangeToTimes(rangeStr string) (time.Time, time.Time, string) {
+	now := time.Now()
+	switch rangeStr {
+	case "5m":
+		return now.Add(-5 * time.Minute), now, "5m"
+	case "30m":
+		return now.Add(-30 * time.Minute), now, "30m"
+	case "1h":
+		return now.Add(-1 * time.Hour), now, "1h"
+	case "6h":
+		return now.Add(-6 * time.Hour), now, "6h"
+	case "24h":
+		return now.Add(-24 * time.Hour), now, "24h"
+	case "3d":
+		return now.Add(-72 * time.Hour), now, "3d"
+	case "7d":
+		return now.Add(-7 * 24 * time.Hour), now, "7d"
+	}
+	return now.Add(-24 * time.Hour), now, "24h"
+}
+
+// kpiCard is one square in the KPI band at the top of the metrics page.
+type kpiCard struct {
+	Key         string    `json:"key"`           // stable identifier (e.g. "requests")
+	Label       string    `json:"label"`         // human-readable
+	Value       float64   `json:"value"`         // current value
+	Unit        string    `json:"unit"`          // "ms", "%", "" etc.
+	Decimals    int       `json:"decimals"`      // display precision
+	PrevValue   float64   `json:"prev_value"`    // same metric, previous window of equal length
+	DeltaPct    float64   `json:"delta_pct"`     // (value - prev) / prev * 100
+	Status      string    `json:"status"`        // "good" | "warn" | "bad"
+	Sparkline   []float64 `json:"sparkline"`     // 30 points spanning the current window
+	IsCount     bool      `json:"is_count"`      // hint to UI: render as integer count
+	Description string    `json:"description"`   // tooltip body
+}
+
+// APIMetricsSummaryHandler returns the KPI band data for the top of the
+// metrics page. It runs on top of the existing stats_history table — no
+// new collection required.
+//
+// Each KPI has a sparkline (downsampled to ~30 points) plus a delta vs.
+// the same-length window immediately preceding the current one.
+func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	since, until, label := metricsRangeToTimes(r.URL.Query().Get("range"))
+	prevSince := since.Add(-until.Sub(since))
+
+	curr, err := h.db.GetStatsHistory(boxID, since, 5000)
+	if err != nil {
+		h.logger.Error("metrics summary: stats history", "error", err)
+		http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
+		return
+	}
+	prev, err := h.db.GetStatsHistory(boxID, prevSince, 5000)
+	if err != nil {
+		h.logger.Error("metrics summary: prev stats history", "error", err)
+		http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
+		return
+	}
+	// prev contains both windows; trim to "previous-window only".
+	prevOnly := make([]int, 0, len(prev))
+	for i, s := range prev {
+		if s.CollectedAt.Before(since) {
+			prevOnly = append(prevOnly, i)
+		}
+	}
+
+	cards := []kpiCard{}
+
+	_ = prevOnly
+
+	currReqMax := maxStatField(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) })
+	prevReqMax := maxStatField(prev, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) })
+	currReqRate := perMinute(currReqMax, since, until)
+	prevReqRate := perMinute(prevReqMax, prevSince, since)
+	cards = append(cards, kpiCard{
+		Key:         "requests",
+		Label:       "Requests / min",
+		Value:       currReqRate,
+		Unit:        "/min",
+		Decimals:    1,
+		PrevValue:   prevReqRate,
+		DeltaPct:    pctDelta(currReqRate, prevReqRate),
+		Status:      "good",
+		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) }, 30),
+		Description: "Total HTTP requests served per minute, averaged across the window.",
+	})
+
+	currRT := avgPositiveStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.AvgResponseTime) })
+	prevRT := avgPositiveStat(prev, func(s database.StatsSnapshot) float64 { return float64(s.AvgResponseTime) })
+	rtStatus := "good"
+	if currRT > 250 {
+		rtStatus = "warn"
+	}
+	if currRT > 1000 {
+		rtStatus = "bad"
+	}
+	cards = append(cards, kpiCard{
+		Key:         "response_time",
+		Label:       "Avg Response",
+		Value:       currRT,
+		Unit:        "ms",
+		Decimals:    0,
+		PrevValue:   prevRT,
+		DeltaPct:    pctDelta(currRT, prevRT),
+		Status:      rtStatus,
+		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.AvgResponseTime) }, 30),
+		Description: "Mean backend response time across all backends.",
+	})
+
+	curr5xx, curr4xx, currTotalResp := h.errorTotals(boxID, since, until)
+	prev5xx, prev4xx, prevTotalResp := h.errorTotals(boxID, prevSince, since)
+	currErrPct := pctOf(curr4xx+curr5xx, currTotalResp)
+	prevErrPct := pctOf(prev4xx+prev5xx, prevTotalResp)
+	errStatus := "good"
+	if currErrPct >= 1 {
+		errStatus = "warn"
+	}
+	if currErrPct >= 5 {
+		errStatus = "bad"
+	}
+	cards = append(cards, kpiCard{
+		Key:         "error_rate",
+		Label:       "Error Rate",
+		Value:       currErrPct,
+		Unit:        "%",
+		Decimals:    2,
+		PrevValue:   prevErrPct,
+		DeltaPct:    pctDelta(currErrPct, prevErrPct),
+		Status:      errStatus,
+		Sparkline:   h.errorRateSparkline(boxID, since, until, 30),
+		Description: "Percentage of requests with 4xx or 5xx status. Click the Error Insights panel below to see which backend / source is responsible.",
+	})
+
+	cards = append(cards, kpiCard{
+		Key:         "errors_5xx",
+		Label:       "5xx Errors",
+		Value:       float64(curr5xx),
+		Unit:        "",
+		Decimals:    0,
+		IsCount:     true,
+		PrevValue:   float64(prev5xx),
+		DeltaPct:    pctDelta(float64(curr5xx), float64(prev5xx)),
+		Status:      statusFromCount(curr5xx, 5, 50),
+		Sparkline:   h.errorCountSparkline(boxID, since, until, 30),
+		Description: "Total HTTP 5xx server errors in this window.",
+	})
+
+	currSess := lastStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalSessions) })
+	prevSess := avgPositiveStat(prev, func(s database.StatsSnapshot) float64 { return float64(s.TotalSessions) })
+	cards = append(cards, kpiCard{
+		Key:         "sessions",
+		Label:       "Active Sessions",
+		Value:       currSess,
+		Unit:        "",
+		Decimals:    0,
+		IsCount:     true,
+		PrevValue:   prevSess,
+		DeltaPct:    pctDelta(currSess, prevSess),
+		Status:      "good",
+		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalSessions) }, 30),
+		Description: "Current concurrent sessions across all backends.",
+	})
+
+	currHealthy := lastStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.HealthyServers) })
+	currTotal := lastStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalServers) })
+	healthStatus := "good"
+	if currTotal > 0 {
+		ratio := currHealthy / currTotal
+		if ratio < 1 {
+			healthStatus = "warn"
+		}
+		if ratio < 0.6 {
+			healthStatus = "bad"
+		}
+	}
+	cards = append(cards, kpiCard{
+		Key:         "health",
+		Label:       "Healthy Backends",
+		Value:       currHealthy,
+		PrevValue:   currTotal,
+		Unit:        "",
+		Decimals:    0,
+		IsCount:     true,
+		Status:      healthStatus,
+		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.HealthyServers) }, 30),
+		Description: "Live healthy backend servers out of total configured.",
+	})
+
+	h.writeJSON(w, map[string]interface{}{
+		"server_id":     boxID,
+		"range":         label,
+		"window_start":  since,
+		"window_end":    until,
+		"prev_window_start": prevSince,
+		"cards":         cards,
+	})
+}
+
+// APIMetricsErrorBreakdownHandler powers the "Error Insights" panel: a
+// three-column view of top-N backends, source IPs, and countries
+// responsible for 4xx/5xx in the window.
+func (h *Handler) APIMetricsErrorBreakdownHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	since, until, label := metricsRangeToTimes(r.URL.Query().Get("range"))
+
+	limit := 10
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 && l <= 100 {
+		limit = l
+	}
+
+	backends, err := h.db.GetTopErrorBackends(boxID, since, until, limit)
+	if err != nil {
+		h.logger.Error("error breakdown: backends", "error", err)
+		http.Error(w, "Failed to load error breakdown", http.StatusInternalServerError)
+		return
+	}
+	sources, err := h.db.GetTopErrorSources(boxID, since, until, limit)
+	if err != nil {
+		h.logger.Error("error breakdown: sources", "error", err)
+		http.Error(w, "Failed to load error breakdown", http.StatusInternalServerError)
+		return
+	}
+	countries, err := h.db.GetTopErrorCountries(boxID, since, until, limit)
+	if err != nil {
+		h.logger.Error("error breakdown: countries", "error", err)
+		http.Error(w, "Failed to load error breakdown", http.StatusInternalServerError)
+		return
+	}
+
+	// Enrich source rows with GeoIP if available — handy for sources whose
+	// `traffic_sources` row hasn't been written yet (very-recent IPs).
+	if h.geoipClient != nil {
+		ips := make([]string, 0, len(sources))
+		for _, s := range sources {
+			if s.SourceIP != "" && (s.Country == "" || s.Country == "Unknown") {
+				ips = append(ips, s.SourceIP)
+			}
+		}
+		if len(ips) > 0 {
+			geo := h.geoipClient.LookupBatch(ips)
+			for i := range sources {
+				if loc, ok := geo[sources[i].SourceIP]; ok && loc != nil {
+					if sources[i].Country == "" || sources[i].Country == "Unknown" {
+						sources[i].Country = loc.Country
+					}
+					if sources[i].CountryCode == "" || sources[i].CountryCode == "XX" {
+						sources[i].CountryCode = loc.CountryCode
+					}
+				}
+			}
+		}
+	}
+
+	h.writeJSON(w, map[string]interface{}{
+		"server_id": boxID,
+		"range":     label,
+		"backends":  backends,
+		"sources":   sources,
+		"countries": countries,
+	})
+}
+
+// APIMetricsBackendDetailsHandler powers the drill-down drawer for one
+// backend. Returns the time-series for that backend (so the drawer can
+// draw mini-charts) plus the top source IPs hitting it.
+func (h *Handler) APIMetricsBackendDetailsHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	backendName := chi.URLParam(r, "backendName")
+	if boxID == "" || backendName == "" {
+		http.Error(w, "Server ID and backend name required", http.StatusBadRequest)
+		return
+	}
+
+	since, until, label := metricsRangeToTimes(r.URL.Query().Get("range"))
+
+	timeseries, err := h.db.GetBackendTimeSeries(boxID, backendName, since, until, 2000)
+	if err != nil {
+		h.logger.Error("backend details: timeseries", "error", err)
+		http.Error(w, "Failed to load backend timeseries", http.StatusInternalServerError)
+		return
+	}
+
+	topSources, err := h.db.GetTopSourcesForBackend(boxID, backendName, since, until, 10)
+	if err != nil {
+		h.logger.Error("backend details: sources", "error", err)
+		http.Error(w, "Failed to load top sources", http.StatusInternalServerError)
+		return
+	}
+
+	// Also pull per-backend snapshot history (from backend_history table) so
+	// we can show backend-server health over time.
+	bhSince := since
+	bh, err := h.db.GetBackendHistory(boxID, backendName, bhSince, 2000)
+	if err != nil {
+		h.logger.Warn("backend details: backend_history fallback", "error", err)
+	}
+
+	h.writeJSON(w, map[string]interface{}{
+		"server_id":      boxID,
+		"backend_name":   backendName,
+		"range":          label,
+		"window_start":   since,
+		"window_end":     until,
+		"timeseries":     timeseries,
+		"top_sources":    topSources,
+		"backend_history": bh,
+	})
+}
+
+// haproxyLogLine is a parsed structured form of a recent HAProxy access log
+// line. We don't try to be exhaustive — the goal is "give the user enough
+// to find what's failing without reading the raw log".
+type haproxyLogLine struct {
+	Timestamp  string `json:"timestamp"`
+	SourceIP   string `json:"source_ip"`
+	Frontend   string `json:"frontend"`
+	Backend    string `json:"backend"`
+	Server     string `json:"server"`
+	StatusCode int    `json:"status_code"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	Raw        string `json:"raw"`
+}
+
+// HAProxy HTTP log format:
+//   <date> <host> haproxy[pid]: <client_ip>:<port> [<accept_date>] <frontend>~ <backend>/<server> <Tq>/<Tw>/<Tc>/<Tr>/<Tt> <status> <bytes_read> ... "<method> <path> HTTP/1.x"
+//
+// We parse defensively — fields can vary by HAProxy version and logformat.
+var (
+	reHAProxyStatus = regexp.MustCompile(`\s(\d{3})\s+\d+\s`)
+	reHAProxyReq    = regexp.MustCompile(`"([A-Z]+)\s+([^\s"]+)`)
+	reHAProxyBkSvr  = regexp.MustCompile(`\s([A-Za-z0-9_.\-]+)/([A-Za-z0-9_.\-]+)\s+\d+\/\-?\d+\/\-?\d+\/\-?\d+\/\-?\d+\s`)
+	reHAProxyClient = regexp.MustCompile(`(?:^|\s)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|[0-9a-fA-F:]+):\d+\s+\[`)
+	reHAProxyDate   = regexp.MustCompile(`\[([^\]]+)\]`)
+)
+
+// parseHAProxyLogLine pulls the interesting fields out of one access-log
+// line. Returns nil if the line doesn't look like an HTTP access log.
+func parseHAProxyLogLine(raw string) *haproxyLogLine {
+	statusMatch := reHAProxyStatus.FindStringSubmatch(raw)
+	if len(statusMatch) < 2 {
+		return nil
+	}
+	status, _ := strconv.Atoi(statusMatch[1])
+	if status < 100 || status > 599 {
+		return nil
+	}
+
+	line := &haproxyLogLine{StatusCode: status, Raw: raw}
+
+	if m := reHAProxyDate.FindStringSubmatch(raw); len(m) > 1 {
+		line.Timestamp = m[1]
+	}
+	if m := reHAProxyClient.FindStringSubmatch(raw); len(m) > 1 {
+		line.SourceIP = m[1]
+	}
+	if m := reHAProxyBkSvr.FindStringSubmatch(raw); len(m) > 2 {
+		line.Backend = m[1]
+		line.Server = m[2]
+	}
+	if m := reHAProxyReq.FindStringSubmatch(raw); len(m) > 2 {
+		line.Method = m[1]
+		line.Path = m[2]
+	}
+
+	// Trim raw line to a reasonable length — full HAProxy lines can be 2+ KB
+	// and we don't want to ship that to the browser.
+	if len(line.Raw) > 1024 {
+		line.Raw = line.Raw[:1024] + "…"
+	}
+
+	return line
+}
+
+// APIMetricsLogErrorsHandler fetches recent HAProxy log lines from the
+// agent, parses status codes, and returns the lines >= 400. The dashboard
+// surfaces these on the metrics page so the user can see exactly which
+// URLs / source IPs are responsible for the error rate.
+//
+// Query params:
+//   - status_min: minimum status code to return (default 500)
+//   - lines:      number of recent log lines to fetch from the agent (default 2000, max 10000)
+//   - backend:    optional filter — only return lines whose backend matches
+func (h *Handler) APIMetricsLogErrorsHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	if !h.authManager.HasPermission(r, "logs", "view") {
+		http.Error(w, "Forbidden: log access required for log correlation", http.StatusForbidden)
+		return
+	}
+
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	serverConfig, exists := h.getServerConfig(boxID)
+	if !exists || !serverConfig.UsesAgentAPI() {
+		http.Error(w, "Agent API not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	statusMin := 500
+	if s, err := strconv.Atoi(r.URL.Query().Get("status_min")); err == nil && s >= 100 && s <= 599 {
+		statusMin = s
+	}
+	lines := 2000
+	if l, err := strconv.Atoi(r.URL.Query().Get("lines")); err == nil && l > 0 && l <= 10000 {
+		lines = l
+	}
+	backendFilter := strings.TrimSpace(r.URL.Query().Get("backend"))
+
+	client := agent.NewClient(serverConfig.AgentURL, serverConfig.APIKey)
+	resp, err := client.GetLogs("haproxy", lines)
+	if err != nil {
+		// Don't 500 — return an empty result with a hint. The metrics page
+		// shouldn't break just because logs are unavailable on this box.
+		h.writeJSON(w, map[string]interface{}{
+			"server_id":  boxID,
+			"available":  false,
+			"reason":     err.Error(),
+			"matches":    []haproxyLogLine{},
+			"matchCount": 0,
+		})
+		return
+	}
+
+	matches := make([]haproxyLogLine, 0, 64)
+	for _, raw := range strings.Split(resp.Content, "\n") {
+		raw = strings.TrimRight(raw, "\r")
+		if raw == "" {
+			continue
+		}
+		parsed := parseHAProxyLogLine(raw)
+		if parsed == nil || parsed.StatusCode < statusMin {
+			continue
+		}
+		if backendFilter != "" && !strings.EqualFold(parsed.Backend, backendFilter) {
+			continue
+		}
+		matches = append(matches, *parsed)
+	}
+
+	// Most-recent first (HAProxy logs are appended in chronological order).
+	// We display newest-on-top in the UI.
+	for i, j := 0, len(matches)-1; i < j; i, j = i+1, j-1 {
+		matches[i], matches[j] = matches[j], matches[i]
+	}
+
+	// Cap the response — 500 lines of error context is plenty for a UI list.
+	if len(matches) > 500 {
+		matches = matches[:500]
+	}
+
+	h.writeJSON(w, map[string]interface{}{
+		"server_id":  boxID,
+		"available":  true,
+		"status_min": statusMin,
+		"backend":    backendFilter,
+		"matchCount": len(matches),
+		"matches":    matches,
+	})
+}
+
+// Helpers (KPI math, sparkline downsampling, error totals) live in
+// api_metrics_insights_helpers.go.

--- a/gearbox/internal/framework/handler/api_metrics_insights_helpers.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights_helpers.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+)
+
+// snapshotField is a function returning a numeric field from one
+// StatsSnapshot row — lets us reuse the sparkline / aggregate helpers
+// across the different KPIs without writing per-field boilerplate.
+type snapshotField func(s database.StatsSnapshot) float64
+
+// lastStat returns the most recent value of f, or 0 for an empty slice.
+// Snapshots are stored chronologically (oldest → newest).
+func lastStat(curr []database.StatsSnapshot, f snapshotField) float64 {
+	if len(curr) == 0 {
+		return 0
+	}
+	return f(curr[len(curr)-1])
+}
+
+// maxStatField returns max(f(s)) across the slice. Used for cumulative
+// counters where we want the highest observation in the window — the
+// snapshot table stores absolute counters, so max == "value at the end of
+// the window" for monotonically-increasing fields like TotalRequests.
+func maxStatField(curr []database.StatsSnapshot, f snapshotField) float64 {
+	var max float64
+	for i := range curr {
+		v := f(curr[i])
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+// avgPositiveStat averages f(s) over rows where f(s) > 0. Skipping zero
+// rows matters for fields like AvgResponseTime, where "no traffic in this
+// bucket" gets recorded as 0 and would otherwise drag the average down.
+func avgPositiveStat(curr []database.StatsSnapshot, f snapshotField) float64 {
+	var sum float64
+	var n int
+	for i := range curr {
+		v := f(curr[i])
+		if v > 0 {
+			sum += v
+			n++
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+// statSparkline downsamples a stats slice to roughly `points` values for
+// rendering inline sparklines in KPI cards. Returns at most `points`
+// floats; for short series it returns the full series.
+func statSparkline(curr []database.StatsSnapshot, f snapshotField, points int) []float64 {
+	if len(curr) == 0 {
+		return []float64{}
+	}
+	if len(curr) <= points {
+		out := make([]float64, len(curr))
+		for i := range curr {
+			out[i] = f(curr[i])
+		}
+		return out
+	}
+	out := make([]float64, 0, points)
+	step := float64(len(curr)) / float64(points)
+	for i := 0; i < points; i++ {
+		idx := int(float64(i) * step)
+		if idx >= len(curr) {
+			idx = len(curr) - 1
+		}
+		out = append(out, f(curr[idx]))
+	}
+	return out
+}
+
+// errorTotals returns (5xx, 4xx, total responses) over the window. The
+// numbers come from traffic_flows because that table stores actual
+// per-bucket response counts rather than cumulative counters — it
+// answers "how many errors in the last hour" directly without delta
+// computation.
+//
+// All three int64s default to 0 on error so callers don't have to special-
+// case it; we log warnings but never fail the whole KPI fetch over an
+// error-rate cell.
+func (h *Handler) errorTotals(boxID string, since, until time.Time) (int64, int64, int64) {
+	row := h.db.QueryRowContext(boxID, since, until)
+	if row == nil {
+		return 0, 0, 0
+	}
+	return row.Response5xx, row.Response4xx, row.Total
+}
+
+// errorRateSparkline returns ~`points` per-bucket error-rate percentages
+// across the window — used to draw the Error Rate KPI's sparkline.
+func (h *Handler) errorRateSparkline(boxID string, since, until time.Time, points int) []float64 {
+	buckets := h.db.GetErrorRateBuckets(boxID, since, until)
+	return downsampleFloats(buckets, points)
+}
+
+// errorCountSparkline returns ~`points` per-bucket 5xx counts.
+func (h *Handler) errorCountSparkline(boxID string, since, until time.Time, points int) []float64 {
+	buckets := h.db.Get5xxCountBuckets(boxID, since, until)
+	return downsampleFloats(buckets, points)
+}
+
+func downsampleFloats(in []float64, points int) []float64 {
+	if len(in) == 0 {
+		return []float64{}
+	}
+	if len(in) <= points {
+		return in
+	}
+	out := make([]float64, 0, points)
+	step := float64(len(in)) / float64(points)
+	for i := 0; i < points; i++ {
+		idx := int(float64(i) * step)
+		if idx >= len(in) {
+			idx = len(in) - 1
+		}
+		out = append(out, in[idx])
+	}
+	return out
+}
+
+func pctDelta(curr, prev float64) float64 {
+	if prev == 0 {
+		if curr == 0 {
+			return 0
+		}
+		return 100
+	}
+	return (curr - prev) / prev * 100
+}
+
+func pctOf(part, total int64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(part) / float64(total) * 100
+}
+
+func perMinute(value float64, since, until time.Time) float64 {
+	mins := until.Sub(since).Minutes()
+	if mins <= 0 {
+		return 0
+	}
+	return value / mins
+}
+
+func statusFromCount(count int64, warnAt, badAt int64) string {
+	if count >= badAt {
+		return "bad"
+	}
+	if count >= warnAt {
+		return "warn"
+	}
+	return "good"
+}

--- a/gearbox/internal/framework/handler/api_metrics_insights_test.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights_test.go
@@ -1,0 +1,207 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+)
+
+func TestMetricsRangeToTimes(t *testing.T) {
+	tests := []struct {
+		in            string
+		wantLabel     string
+		wantDeltaMin  float64 // minutes from now
+	}{
+		{"5m", "5m", 5},
+		{"30m", "30m", 30},
+		{"1h", "1h", 60},
+		{"6h", "6h", 360},
+		{"24h", "24h", 24 * 60},
+		{"3d", "3d", 3 * 24 * 60},
+		{"7d", "7d", 7 * 24 * 60},
+		{"", "24h", 24 * 60},
+		{"banana", "24h", 24 * 60},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			since, until, label := metricsRangeToTimes(tt.in)
+			if label != tt.wantLabel {
+				t.Errorf("label = %q, want %q", label, tt.wantLabel)
+			}
+			delta := until.Sub(since).Minutes()
+			if delta < tt.wantDeltaMin-0.5 || delta > tt.wantDeltaMin+0.5 {
+				t.Errorf("window = %v min, want ~%v min", delta, tt.wantDeltaMin)
+			}
+		})
+	}
+}
+
+func TestPctDelta(t *testing.T) {
+	tests := []struct {
+		name       string
+		curr, prev float64
+		want       float64
+	}{
+		{"both zero → no change", 0, 0, 0},
+		{"prev zero, curr non-zero → 100% jump", 50, 0, 100},
+		{"50% up", 150, 100, 50},
+		{"50% down", 50, 100, -50},
+		{"flat", 100, 100, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pctDelta(tt.curr, tt.prev)
+			if got != tt.want {
+				t.Errorf("pctDelta(%v, %v) = %v, want %v", tt.curr, tt.prev, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPctOf(t *testing.T) {
+	if got := pctOf(0, 0); got != 0 {
+		t.Errorf("0/0 expected 0 to avoid NaN, got %v", got)
+	}
+	if got := pctOf(50, 100); got != 50 {
+		t.Errorf("50/100 = 50%%, got %v", got)
+	}
+}
+
+func TestPerMinute(t *testing.T) {
+	now := time.Now()
+	got := perMinute(120, now.Add(-2*time.Minute), now)
+	if got != 60 {
+		t.Errorf("120 reqs in 2 min should be 60/min, got %v", got)
+	}
+	if got := perMinute(0, now, now); got != 0 {
+		t.Errorf("zero-length window should be 0, got %v", got)
+	}
+}
+
+func TestStatusFromCount(t *testing.T) {
+	if statusFromCount(0, 5, 50) != "good" {
+		t.Error("count=0 should be good")
+	}
+	if statusFromCount(10, 5, 50) != "warn" {
+		t.Error("count=10 should be warn")
+	}
+	if statusFromCount(100, 5, 50) != "bad" {
+		t.Error("count=100 should be bad")
+	}
+}
+
+func TestStatSparklineDownsamples(t *testing.T) {
+	// Build a 100-element series of monotonically increasing values.
+	rows := make([]database.StatsSnapshot, 100)
+	for i := range rows {
+		rows[i].TotalRequests = int64(i)
+	}
+	out := statSparkline(rows, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) }, 30)
+	if len(out) != 30 {
+		t.Errorf("expected 30 sparkline points, got %d", len(out))
+	}
+	if out[0] != 0 {
+		t.Errorf("first point should be 0, got %v", out[0])
+	}
+	// Last sampled index is int(29 * 100/30) = 96, so out[29] should be 96.
+	if out[29] < 90 {
+		t.Errorf("last sparkline point should be near the end of series, got %v", out[29])
+	}
+}
+
+func TestStatSparklineShortSeriesPassThrough(t *testing.T) {
+	rows := []database.StatsSnapshot{
+		{TotalRequests: 1},
+		{TotalRequests: 2},
+		{TotalRequests: 3},
+	}
+	out := statSparkline(rows, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) }, 30)
+	if len(out) != 3 {
+		t.Errorf("expected pass-through of 3 points, got %d", len(out))
+	}
+}
+
+func TestAvgPositiveStatSkipsZeros(t *testing.T) {
+	rows := []database.StatsSnapshot{
+		{AvgResponseTime: 100},
+		{AvgResponseTime: 0}, // empty bucket — should be skipped
+		{AvgResponseTime: 200},
+	}
+	got := avgPositiveStat(rows, func(s database.StatsSnapshot) float64 { return float64(s.AvgResponseTime) })
+	if got != 150 {
+		t.Errorf("expected avg of (100, 200) = 150, got %v", got)
+	}
+}
+
+func TestParseHAProxyLogLine_5xx(t *testing.T) {
+	// Representative HAProxy HTTP log line with a 502 response.
+	raw := `Apr 14 02:13:45 lighthugger haproxy[1234]: 203.0.113.42:51234 [14/Apr/2026:02:13:45.123] https-in~ app-backend/server1 0/0/1/0/1 502 1234 - - ---- 5/5/0/0/0 0/0 "GET /api/widgets HTTP/1.1"`
+	got := parseHAProxyLogLine(raw)
+	if got == nil {
+		t.Fatal("expected to parse 502 line, got nil")
+	}
+	if got.StatusCode != 502 {
+		t.Errorf("status = %d, want 502", got.StatusCode)
+	}
+	if got.SourceIP != "203.0.113.42" {
+		t.Errorf("source_ip = %q, want 203.0.113.42", got.SourceIP)
+	}
+	if got.Backend != "app-backend" {
+		t.Errorf("backend = %q, want app-backend", got.Backend)
+	}
+	if got.Server != "server1" {
+		t.Errorf("server = %q, want server1", got.Server)
+	}
+	if got.Method != "GET" {
+		t.Errorf("method = %q, want GET", got.Method)
+	}
+	if got.Path != "/api/widgets" {
+		t.Errorf("path = %q, want /api/widgets", got.Path)
+	}
+}
+
+func TestParseHAProxyLogLine_NoMatch(t *testing.T) {
+	if parseHAProxyLogLine("") != nil {
+		t.Error("empty line should not parse")
+	}
+	if parseHAProxyLogLine("not an haproxy log line at all") != nil {
+		t.Error("garbage line should not parse")
+	}
+	if parseHAProxyLogLine("haproxy[42]: SSL handshake failure from 1.2.3.4") != nil {
+		t.Error("non-HTTP-access-log line should not parse")
+	}
+}
+
+func TestParseHAProxyLogLine_RawTruncated(t *testing.T) {
+	// Build a 2000-char raw line.
+	pad := ""
+	for i := 0; i < 200; i++ {
+		pad += "0123456789"
+	}
+	raw := `Apr 14 02:13:45 host haproxy[1]: 1.2.3.4:1234 [14/Apr/2026:02:13:45] f~ b/s 0/0/0/0/0 200 100 - - ---- 1/1/0/0/0 0/0 "GET /` + pad + ` HTTP/1.1"`
+	got := parseHAProxyLogLine(raw)
+	if got == nil {
+		t.Fatal("expected to parse line")
+	}
+	if len(got.Raw) > 1100 {
+		t.Errorf("raw should be truncated, got %d chars", len(got.Raw))
+	}
+}
+
+func TestDownsampleFloats(t *testing.T) {
+	if got := downsampleFloats(nil, 30); len(got) != 0 {
+		t.Errorf("nil input should give empty output, got %d", len(got))
+	}
+	short := []float64{1, 2, 3}
+	if got := downsampleFloats(short, 30); len(got) != 3 {
+		t.Errorf("short input should pass through, got %d", len(got))
+	}
+	long := make([]float64, 100)
+	for i := range long {
+		long[i] = float64(i)
+	}
+	if got := downsampleFloats(long, 30); len(got) != 30 {
+		t.Errorf("long input should sample to 30, got %d", len(got))
+	}
+}

--- a/gearbox/internal/framework/templates/pages/history.templ
+++ b/gearbox/internal/framework/templates/pages/history.templ
@@ -1866,9 +1866,22 @@ templ History(user *models.User, servers []models.BoxConfig) {
 		}
 
 		// escapeJSArg escapes a string for safe inclusion as a single-quoted
-		// JS argument inside an HTML onclick attribute.
+		// JS argument inside a double-quoted HTML attribute, e.g.
+		//   <div onclick="openDrillDown('source', 'VALUE')">
+		// It must therefore neutralise BOTH the JS string context (\\ and ')
+		// AND the HTML attribute context (", <, >, & — otherwise a value
+		// containing `"` would break out of the attribute and a `<` could
+		// start a new tag). Backend names come from operator-controlled
+		// HAProxy config, but source IPs and country codes flow from
+		// agent-collected data, so defence-in-depth is warranted.
 		function escapeJSArg(s) {
-			return String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+			return String(s)
+				.replace(/\\/g, '\\\\')
+				.replace(/'/g, "\\'")
+				.replace(/&/g, '&amp;')
+				.replace(/"/g, '&quot;')
+				.replace(/</g, '&lt;')
+				.replace(/>/g, '&gt;');
 		}
 
 		// Move page header content to main header

--- a/gearbox/internal/framework/templates/pages/history.templ
+++ b/gearbox/internal/framework/templates/pages/history.templ
@@ -68,6 +68,19 @@ templ History(user *models.User, servers []models.BoxConfig) {
 		if len(servers) == 0 {
 			@components.InfoAlert("No servers configured.")
 		} else {
+			<!-- KPI summary band — populated by loadKPISummary().
+			     Each card shows a current value, delta vs the previous
+			     window of equal length, and an inline sparkline. -->
+			<div id="kpi-band" class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3 mb-4">
+				<!-- 6 skeleton placeholders so the layout doesn't pop in. -->
+				for i := 0; i < 6; i++ {
+					<div class="kpi-card-skel bg-white dark:bg-slate-800 rounded-lg shadow-sm p-3 h-[88px] animate-pulse">
+						<div class="h-3 w-20 bg-gray-200 dark:bg-slate-700 rounded mb-2"></div>
+						<div class="h-6 w-28 bg-gray-200 dark:bg-slate-700 rounded"></div>
+					</div>
+				}
+			</div>
+
 			<div class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6">
 
 				<!-- Charts Grid - 4 columns on 2xl, 3 on xl, 2 on lg, 1 on smaller -->
@@ -179,13 +192,73 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				</div>
 			</div>
 
-			<!-- Recent Incidents -->
-			<div class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6">
-				<h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">Recent Incidents</h3>
-				<div id="incidents-container">
-					<p class="text-gray-500 dark:text-gray-400">Loading incidents...</p>
+			<!-- Error Insights — replaces the old "Recent Incidents" list.
+			     Three columns answer "where are my errors coming from?":
+			     top backends by 5xx, top source IPs by 4xx+5xx, and top
+			     countries. Each row is clickable and opens the drill-down
+			     drawer. The panel renders nothing when there are no errors
+			     in the window — silence is the desired state. -->
+			<div id="error-insights-section" class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6">
+				<div class="flex items-center justify-between mb-4">
+					<div>
+						<h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100">Error Insights</h3>
+						<p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+							Where the 4xx/5xx responses in this window are coming from. Click any row to drill in.
+						</p>
+					</div>
+					<button
+						id="error-insights-refresh"
+						class="text-sm px-2 py-1 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+						title="Refresh error breakdown"
+						onclick="loadErrorInsights()"
+					>↻</button>
+				</div>
+				<div id="error-insights-body" class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+					<p class="text-gray-500 dark:text-gray-400 col-span-3 text-sm">Loading…</p>
+				</div>
+				<div id="error-insights-empty" class="hidden text-center py-6">
+					<svg class="w-10 h-10 mx-auto text-green-500 dark:text-green-400 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+					</svg>
+					<p class="text-gray-600 dark:text-gray-400 text-sm">No 4xx/5xx responses in this window. Everything's green.</p>
 				</div>
 			</div>
+
+			<!-- Drill-down drawer — slides in from the right with backend
+			     details, time series, top sources, and recent HAProxy error
+			     log lines. Backed by /api/{id}/metrics/backend/{name}/details
+			     plus /api/{id}/metrics/log-errors?backend=…. -->
+			<div id="drilldown-backdrop"
+				class="fixed inset-0 bg-black/40 z-[10000] hidden opacity-0 transition-opacity duration-200"
+				onclick="closeDrillDown()"
+			></div>
+			<aside id="drilldown-drawer"
+				class="fixed top-0 right-0 h-full w-full md:w-[640px] xl:w-[760px] bg-white dark:bg-slate-900 shadow-2xl z-[10001] hidden translate-x-full transition-transform duration-200 ease-out overflow-y-auto"
+				role="dialog"
+				aria-modal="true"
+			>
+				<header class="sticky top-0 bg-white dark:bg-slate-900 border-b border-gray-200 dark:border-slate-700 px-5 py-3 flex items-center justify-between z-10">
+					<div>
+						<div id="drilldown-eyebrow" class="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500">Backend</div>
+						<h2 id="drilldown-title" class="text-lg font-semibold text-gray-900 dark:text-gray-100">—</h2>
+					</div>
+					<div class="flex items-center gap-2">
+						<a id="drilldown-logs-link"
+							class="text-sm px-2 py-1 rounded bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 hidden"
+							target="_blank"
+							rel="noopener"
+						>View logs →</a>
+						<button onclick="closeDrillDown()" class="p-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700" title="Close (Esc)">
+							<svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+							</svg>
+						</button>
+					</div>
+				</header>
+				<div id="drilldown-body" class="p-5 space-y-5">
+					<p class="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
+				</div>
+			</aside>
 		}
 
 		<style>
@@ -202,6 +275,14 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			width: 100% !important;
 			height: 100% !important;
 		}
+		.chart-card {
+			cursor: pointer;
+			transition: box-shadow 0.15s ease, transform 0.15s ease;
+		}
+		.chart-card:hover {
+			box-shadow: 0 8px 24px -8px rgba(15, 23, 42, 0.15);
+			transform: translateY(-1px);
+		}
 		.chart-card.fullscreen {
 			position: fixed !important;
 			top: 0 !important;
@@ -216,12 +297,166 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			padding: 2rem !important;
 			display: flex !important;
 			flex-direction: column !important;
+			transform: none !important;
 		}
 		.chart-card.fullscreen .chart-aspect-container {
 			padding-bottom: 0 !important;
 			height: 100% !important;
 			flex: 1 !important;
 		}
+
+		/* KPI band */
+		.kpi-card {
+			position: relative;
+			background: white;
+			border-radius: 0.5rem;
+			padding: 0.75rem 0.9rem;
+			box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+			border-left: 3px solid transparent;
+			min-height: 88px;
+		}
+		.dark .kpi-card { background: rgb(30, 41, 59); box-shadow: 0 1px 2px rgba(0,0,0,0.3); }
+		.kpi-card.status-good { border-left-color: #10b981; }
+		.kpi-card.status-warn { border-left-color: #f59e0b; }
+		.kpi-card.status-bad  { border-left-color: #ef4444; }
+		.kpi-label {
+			font-size: 0.75rem;
+			color: #6b7280;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			font-weight: 500;
+		}
+		.dark .kpi-label { color: #94a3b8; }
+		.kpi-value {
+			font-size: 1.5rem;
+			font-weight: 600;
+			color: #111827;
+			line-height: 1.1;
+			margin-top: 0.1rem;
+		}
+		.dark .kpi-value { color: #f1f5f9; }
+		.kpi-unit { font-size: 0.85rem; color: #6b7280; font-weight: 400; margin-left: 0.15rem; }
+		.dark .kpi-unit { color: #94a3b8; }
+		.kpi-delta { font-size: 0.75rem; font-weight: 500; }
+		.kpi-delta.up   { color: #ef4444; }
+		.kpi-delta.down { color: #10b981; }
+		.kpi-delta.neutral { color: #6b7280; }
+		.kpi-delta.inverse-good.up   { color: #10b981; } /* For traffic, going up is good */
+		.kpi-delta.inverse-good.down { color: #6b7280; }
+		.kpi-sparkline {
+			position: absolute;
+			right: 0.5rem;
+			bottom: 0.5rem;
+			width: 70px;
+			height: 24px;
+			pointer-events: none;
+		}
+
+		/* Error Insights tables */
+		.ei-col h4 {
+			font-size: 0.85rem;
+			font-weight: 600;
+			color: #374151;
+			margin-bottom: 0.5rem;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+		}
+		.dark .ei-col h4 { color: #e5e7eb; }
+		.ei-row {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			padding: 0.5rem 0.6rem;
+			border-radius: 0.375rem;
+			cursor: pointer;
+			transition: background 0.1s;
+			border-left: 2px solid transparent;
+		}
+		.ei-row:hover {
+			background: rgb(243, 244, 246);
+			border-left-color: #3b82f6;
+		}
+		.dark .ei-row:hover { background: rgb(51, 65, 85); }
+		.ei-row + .ei-row { margin-top: 0.15rem; }
+		.ei-row .ei-primary { font-size: 0.875rem; color: #111827; font-weight: 500; }
+		.dark .ei-row .ei-primary { color: #f1f5f9; }
+		.ei-row .ei-secondary { font-size: 0.7rem; color: #6b7280; }
+		.dark .ei-row .ei-secondary { color: #94a3b8; }
+		.ei-row .ei-count {
+			font-size: 0.75rem;
+			font-weight: 600;
+			padding: 0.1rem 0.5rem;
+			border-radius: 999px;
+			background: rgb(254, 226, 226);
+			color: rgb(153, 27, 27);
+			white-space: nowrap;
+		}
+		.dark .ei-row .ei-count { background: rgba(239, 68, 68, 0.2); color: #fca5a5; }
+		.ei-row .ei-count.warning { background: rgb(254, 243, 199); color: rgb(146, 64, 14); }
+		.dark .ei-row .ei-count.warning { background: rgba(245, 158, 11, 0.2); color: #fcd34d; }
+
+		/* Drill-down drawer */
+		#drilldown-drawer.open { transform: translateX(0); }
+		#drilldown-backdrop.open { opacity: 1; }
+		.drilldown-section h3 {
+			font-size: 0.85rem;
+			font-weight: 600;
+			color: #374151;
+			margin-bottom: 0.5rem;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+		}
+		.dark .drilldown-section h3 { color: #e5e7eb; }
+		.drilldown-kv {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+			gap: 0.75rem;
+		}
+		.drilldown-kv > div {
+			background: rgb(249, 250, 251);
+			border-radius: 0.375rem;
+			padding: 0.55rem 0.75rem;
+		}
+		.dark .drilldown-kv > div { background: rgb(30, 41, 59); }
+		.drilldown-kv .k {
+			font-size: 0.7rem;
+			color: #6b7280;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+		}
+		.dark .drilldown-kv .k { color: #94a3b8; }
+		.drilldown-kv .v {
+			font-size: 1.15rem;
+			font-weight: 600;
+			color: #111827;
+		}
+		.dark .drilldown-kv .v { color: #f1f5f9; }
+		.drilldown-chart {
+			position: relative;
+			height: 160px;
+			background: rgb(249, 250, 251);
+			border-radius: 0.375rem;
+			padding: 0.5rem;
+		}
+		.dark .drilldown-chart { background: rgb(30, 41, 59); }
+		.log-line {
+			font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+			font-size: 0.72rem;
+			padding: 0.35rem 0.55rem;
+			border-radius: 0.25rem;
+			background: rgb(249, 250, 251);
+			color: #1f2937;
+			word-break: break-all;
+			margin-bottom: 0.25rem;
+			border-left: 2px solid #ef4444;
+		}
+		.dark .log-line { background: rgb(30, 41, 59); color: #e2e8f0; }
+		.log-line .lc-status { color: #ef4444; font-weight: 600; }
+		.log-line .lc-status.s4 { color: #f59e0b; }
+		.log-line .lc-path { color: #2563eb; }
+		.dark .log-line .lc-path { color: #93c5fd; }
+		.log-line .lc-ip { color: #7c3aed; }
+		.dark .log-line .lc-ip { color: #c4b5fd; }
 		</style>
 
 		<script>
@@ -242,6 +477,44 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				danger: '#ef4444',
 				purple: '#8b5cf6',
 				cyan: '#06b6d4'
+			};
+		}
+
+		// gradientFor returns a Chart.js-compatible vertical gradient for the
+		// background fill of a line/area dataset. Falls back to a transparent
+		// background if no rendering context is available yet.
+		function gradientFor(ctx, hexColor) {
+			if (!ctx) return 'transparent';
+			const chart = ctx.chart || ctx;
+			const area = chart.chartArea;
+			if (!area) return 'transparent';
+			// Convert the line color to a low-opacity fill at the top and
+			// fully transparent at the bottom — Grafana-style trace area.
+			const fillTop = hexColor + '40';   // ~25% alpha
+			const fillMid = hexColor + '14';   // ~8% alpha
+			const fillBot = hexColor + '00';
+			const g = chart.ctx.createLinearGradient(0, area.top, 0, area.bottom);
+			g.addColorStop(0, fillTop);
+			g.addColorStop(0.5, fillMid);
+			g.addColorStop(1, fillBot);
+			return g;
+		}
+
+		// Build a filled-area dataset with a gradient. Used instead of the
+		// flat `backgroundColor: 'transparent'` we were using before so the
+		// charts look modern (gradient under the line) without needing a new
+		// chart library.
+		function makeAreaDataset(label, data, color) {
+			return {
+				label: label,
+				data: data,
+				borderColor: color,
+				backgroundColor: function(context) { return gradientFor(context, color); },
+				fill: true,
+				borderWidth: 1.6,
+				pointRadius: 0,
+				pointHoverRadius: 3,
+				tension: 0.4
 			};
 		}
 
@@ -269,12 +542,25 @@ templ History(user *models.User, servers []models.BoxConfig) {
 
 		function createChartOptions(minY = undefined) {
 			const colors = getChartColors();
+			const isDark = document.documentElement.classList.contains('dark');
 			return {
 				responsive: true,
 				maintainAspectRatio: false,
+				interaction: { mode: 'index', intersect: false }, // crosshair tooltip
 				plugins: {
 					legend: {
 						labels: { color: colors.text }
+					},
+					tooltip: {
+						backgroundColor: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.97)',
+						titleColor: colors.text,
+						bodyColor: colors.text,
+						borderColor: colors.grid,
+						borderWidth: 1,
+						padding: 8,
+						boxPadding: 4,
+						usePointStyle: true,
+						titleFont: { weight: '600' }
 					},
 					zoom: getZoomOptions()
 				},
@@ -297,12 +583,25 @@ templ History(user *models.User, servers []models.BoxConfig) {
 
 		function createIntegerYAxisOptions() {
 			const colors = getChartColors();
+			const isDark = document.documentElement.classList.contains('dark');
 			return {
 				responsive: true,
 				maintainAspectRatio: false,
+				interaction: { mode: 'index', intersect: false },
 				plugins: {
 					legend: {
 						labels: { color: colors.text }
+					},
+					tooltip: {
+						backgroundColor: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.97)',
+						titleColor: colors.text,
+						bodyColor: colors.text,
+						borderColor: colors.grid,
+						borderWidth: 1,
+						padding: 8,
+						boxPadding: 4,
+						usePointStyle: true,
+						titleFont: { weight: '600' }
 					},
 					zoom: getZoomOptions()
 				},
@@ -504,10 +803,6 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				const metricsResponse = await fetch(`/api/${serverID}/history/metrics?hours=${hours}`);
 				const metricsData = await metricsResponse.json();
 
-				// Fetch incidents
-				const incidentsResponse = await fetch(`/api/${serverID}/incidents?limit=20`);
-				const incidentsData = await incidentsResponse.json();
-
 				// Cache the data for fullscreen toggle
 				cachedStatsData = statsData.data || [];
 				cachedMetricsData = metricsData.data || [];
@@ -515,14 +810,33 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				// Render charts
 				destroyCharts();
 				renderAllCharts();
-				renderIncidents(incidentsData.incidents || []);
 
 				// Setup SSE connection for real-time updates
 				setupSSE(serverID);
 
+				// Kick off insights loads (don't block charts on these).
+				loadKPISummary();
+				loadErrorInsights();
+
 			} catch (error) {
 				console.error('Failed to load history data:', error);
 			}
+		}
+
+		// hoursToRange maps the hours-select dropdown value (e.g. "0.083",
+		// "24") to the human-readable range token the new /metrics/* APIs
+		// accept ("5m", "24h", …). Anything we don't recognise falls back
+		// to "24h" — matches the API's default and the dropdown's default.
+		function hoursToRange(hours) {
+			const h = parseFloat(hours);
+			if (h <= 0.1)   return '5m';
+			if (h <= 0.5)   return '30m';
+			if (h <= 1)     return '1h';
+			if (h <= 6)     return '6h';
+			if (h <= 24)    return '24h';
+			if (h <= 72)    return '3d';
+			if (h <= 168)   return '7d';
+			return '24h';
 		}
 
 		function setupSSE(serverID) {
@@ -1064,59 +1378,497 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				data: {
 					labels: sampledData.map(d => formatTime(d.collected_at)),
 					datasets: [
-						{
-							label: '5xx Errors',
-							data: sampledData.map(d => d.total_5xx_errors),
-							borderColor: colors.danger,
-							backgroundColor: 'transparent',
-							borderWidth: 1.5,
-							pointRadius: 0,
-							pointHoverRadius: 3,
-							tension: 0.4
-						}
+						makeAreaDataset('5xx Errors', sampledData.map(d => d.total_5xx_errors), colors.danger)
 					]
 				},
 				options: createIntegerYAxisOptions()
 			});
 		}
 
-		function renderIncidents(incidents) {
-			const container = document.getElementById('incidents-container');
+		// ──────────────────────────────────────────────────────────────
+		// KPI band
+		// ──────────────────────────────────────────────────────────────
 
-			if (!incidents || incidents.length === 0) {
-				container.innerHTML = '<p class="text-gray-500 dark:text-gray-400">No recent incidents.</p>';
-				return;
+		async function loadKPISummary() {
+			const serverID = getServerID();
+			if (!serverID) return;
+			const range = hoursToRange(document.getElementById('hours-select').value);
+			try {
+				const res = await fetch('/api/' + serverID + '/metrics/summary?range=' + encodeURIComponent(range));
+				if (!res.ok) {
+					throw new Error('HTTP ' + res.status);
+				}
+				const data = await res.json();
+				renderKPICards(data.cards || []);
+			} catch (err) {
+				console.error('Failed to load KPI summary', err);
+				const band = document.getElementById('kpi-band');
+				if (band) band.innerHTML = '<div class="col-span-full text-sm text-red-500">Failed to load summary.</div>';
 			}
+		}
 
-			const html = incidents.map(function(incident) {
-				const severityClasses = {
-					'critical': 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200',
-					'warning': 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200',
-					'info': 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200'
-				};
-				const severityClass = severityClasses[incident.severity] || severityClasses.info;
-				const resolved = incident.resolved_at ?
-					'<span class="text-green-600 dark:text-green-400">Resolved: ' + new Date(incident.resolved_at).toLocaleString() + '</span>' :
-					'<span class="text-red-600 dark:text-red-400">Active</span>';
+		function renderKPICards(cards) {
+			const band = document.getElementById('kpi-band');
+			if (!band) return;
 
-				const backendSpan = incident.backend_name ?
-					'<span class="ml-2 text-sm text-blue-600 dark:text-blue-400">' + incident.backend_name + '</span>' : '';
-
-				return '<div class="border border-gray-200 dark:border-slate-600 rounded-lg p-4 mb-3">' +
-					'<div class="flex justify-between items-start">' +
-					'<div>' +
-					'<span class="px-2 py-1 text-xs font-semibold rounded ' + severityClass + '">' + incident.severity.toUpperCase() + '</span>' +
-					'<span class="ml-2 text-sm text-gray-500 dark:text-gray-400">' + incident.incident_type + '</span>' +
-					backendSpan +
-					'</div>' +
-					'<span class="text-sm text-gray-500 dark:text-gray-400">' + new Date(incident.started_at).toLocaleString() + '</span>' +
-					'</div>' +
-					'<p class="mt-2 text-gray-700 dark:text-gray-300">' + incident.message + '</p>' +
-					'<div class="mt-2 text-sm">' + resolved + '</div>' +
-					'</div>';
+			band.innerHTML = cards.map(function(c) {
+				const valueText = formatKPIValue(c);
+				const deltaHTML = formatKPIDelta(c);
+				return ''
+					+ '<div class="kpi-card status-' + (c.status || 'good') + '" title="' + escapeAttr(c.description || '') + '">'
+					+   '<div class="kpi-label">' + escapeHtml(c.label) + '</div>'
+					+   '<div class="kpi-value">' + valueText + '</div>'
+					+   '<div class="kpi-delta-row mt-1">' + deltaHTML + '</div>'
+					+   '<canvas class="kpi-sparkline" data-spark="' + escapeAttr(JSON.stringify(c.sparkline || [])) + '"'
+					+     ' data-status="' + (c.status || 'good') + '"></canvas>'
+					+ '</div>';
 			}).join('');
 
-			container.innerHTML = html;
+			// Render sparklines.
+			band.querySelectorAll('canvas.kpi-sparkline').forEach(function(canvas) {
+				try {
+					const pts = JSON.parse(canvas.dataset.spark || '[]');
+					drawSparkline(canvas, pts, canvas.dataset.status);
+				} catch (e) { /* ignore */ }
+			});
+		}
+
+		function formatKPIValue(c) {
+			// Health card uses PrevValue as the "total" — show as N/M.
+			if (c.key === 'health') {
+				return Math.round(c.value) + '<span class="kpi-unit">/ ' + Math.round(c.prev_value || 0) + '</span>';
+			}
+			let v = c.value;
+			let decimals = (typeof c.decimals === 'number') ? c.decimals : 1;
+			if (c.is_count && !c.unit) decimals = 0;
+			let displayValue;
+			if (Math.abs(v) >= 1e6) {
+				displayValue = (v / 1e6).toFixed(1) + 'M';
+			} else if (Math.abs(v) >= 1e4) {
+				displayValue = (v / 1e3).toFixed(1) + 'k';
+			} else {
+				displayValue = v.toFixed(decimals);
+			}
+			const unit = c.unit ? ('<span class="kpi-unit">' + escapeHtml(c.unit) + '</span>') : '';
+			return displayValue + unit;
+		}
+
+		function formatKPIDelta(c) {
+			// Health KPI doesn't need a delta — the N/M conveys state already.
+			if (c.key === 'health') {
+				return '<span class="kpi-delta neutral">live</span>';
+			}
+			const d = c.delta_pct || 0;
+			if (!isFinite(d) || (c.prev_value === 0 && c.value === 0)) {
+				return '<span class="kpi-delta neutral">no prior data</span>';
+			}
+			let cls = 'neutral';
+			let arrow = '→';
+			if (Math.abs(d) < 0.5) {
+				cls = 'neutral';
+			} else if (d > 0) {
+				cls = 'up'; arrow = '▲';
+			} else {
+				cls = 'down'; arrow = '▼';
+			}
+			// "Going up" is bad for error rate / 5xx / response time; good for traffic / sessions.
+			let inv = '';
+			if (c.key === 'requests' || c.key === 'sessions') {
+				inv = 'inverse-good ';
+			}
+			return '<span class="kpi-delta ' + inv + cls + '">'
+				+ arrow + ' ' + Math.abs(d).toFixed(1) + '% vs prior window</span>';
+		}
+
+		function drawSparkline(canvas, pts, status) {
+			if (!pts || pts.length < 2) return;
+			const dpr = window.devicePixelRatio || 1;
+			const w = canvas.clientWidth || 70;
+			const h = canvas.clientHeight || 24;
+			canvas.width = w * dpr;
+			canvas.height = h * dpr;
+			const ctx = canvas.getContext('2d');
+			ctx.scale(dpr, dpr);
+			const min = Math.min.apply(null, pts);
+			const max = Math.max.apply(null, pts);
+			const range = max - min || 1;
+			const color = status === 'bad' ? '#ef4444'
+				: status === 'warn' ? '#f59e0b'
+				: '#10b981';
+			ctx.lineWidth = 1.25;
+			ctx.strokeStyle = color;
+			ctx.beginPath();
+			for (let i = 0; i < pts.length; i++) {
+				const x = (i / (pts.length - 1)) * (w - 2) + 1;
+				const y = h - 1 - ((pts[i] - min) / range) * (h - 2);
+				if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+			}
+			ctx.stroke();
+			ctx.lineTo(w - 1, h);
+			ctx.lineTo(1, h);
+			ctx.closePath();
+			ctx.globalAlpha = 0.12;
+			ctx.fillStyle = color;
+			ctx.fill();
+			ctx.globalAlpha = 1;
+		}
+
+		// ──────────────────────────────────────────────────────────────
+		// Error Insights panel
+		// ──────────────────────────────────────────────────────────────
+
+		async function loadErrorInsights() {
+			const serverID = getServerID();
+			if (!serverID) return;
+			const range = hoursToRange(document.getElementById('hours-select').value);
+			const body = document.getElementById('error-insights-body');
+			const empty = document.getElementById('error-insights-empty');
+			try {
+				const res = await fetch('/api/' + serverID + '/metrics/error-breakdown?range=' + encodeURIComponent(range));
+				if (!res.ok) throw new Error('HTTP ' + res.status);
+				const data = await res.json();
+				renderErrorInsights(data);
+				const hasAny = (data.backends || []).length + (data.sources || []).length + (data.countries || []).length;
+				if (hasAny === 0) {
+					body.classList.add('hidden');
+					empty.classList.remove('hidden');
+				} else {
+					body.classList.remove('hidden');
+					empty.classList.add('hidden');
+				}
+			} catch (err) {
+				console.error('Failed to load error insights', err);
+				body.innerHTML = '<div class="col-span-3 text-sm text-red-500">Failed to load error breakdown.</div>';
+			}
+		}
+
+		function renderErrorInsights(data) {
+			const body = document.getElementById('error-insights-body');
+			if (!body) return;
+
+			const backendCol = renderEIBackends(data.backends || []);
+			const sourceCol  = renderEISources(data.sources || []);
+			const countryCol = renderEICountries(data.countries || []);
+
+			body.innerHTML = ''
+				+ '<div class="ei-col"><h4>Top backends by errors</h4><div>' + backendCol + '</div></div>'
+				+ '<div class="ei-col"><h4>Top source IPs</h4><div>' + sourceCol + '</div></div>'
+				+ '<div class="ei-col"><h4>Top countries</h4><div>' + countryCol + '</div></div>';
+		}
+
+		function renderEIBackends(rows) {
+			if (rows.length === 0) return '<p class="text-xs text-gray-500 dark:text-gray-400">No backend errors.</p>';
+			return rows.map(function(r) {
+				const total = (r.response_5xx || 0) + (r.response_4xx || 0);
+				const label5 = (r.response_5xx || 0) + ' 5xx';
+				const label4 = (r.response_4xx || 0) + ' 4xx';
+				const errorRate = (r.error_rate || 0).toFixed(1) + '%';
+				const cls = (r.response_5xx || 0) > 0 ? '' : ' warning';
+				return ''
+					+ '<div class="ei-row" data-backend="' + escapeAttr(r.backend_name) + '" onclick="openDrillDown(\'backend\', \'' + escapeJSArg(r.backend_name) + '\')">'
+					+   '<div>'
+					+     '<div class="ei-primary">' + escapeHtml(r.backend_name) + '</div>'
+					+     '<div class="ei-secondary">' + label5 + ' · ' + label4 + ' · ' + errorRate + ' err rate</div>'
+					+   '</div>'
+					+   '<div class="ei-count' + cls + '">' + total.toLocaleString() + '</div>'
+					+ '</div>';
+			}).join('');
+		}
+
+		function renderEISources(rows) {
+			if (rows.length === 0) return '<p class="text-xs text-gray-500 dark:text-gray-400">No erroring source IPs.</p>';
+			return rows.map(function(r) {
+				const flag = r.country_code && r.country_code !== 'XX' && r.country_code !== 'AG' ? r.country_code : '';
+				const meta = (r.country || 'Unknown') + ' · ' + (r.backends_hit || 0) + ' backends · ' + (r.error_rate || 0).toFixed(1) + '% err';
+				return ''
+					+ '<div class="ei-row" onclick="openDrillDown(\'source\', \'' + escapeJSArg(r.source_ip) + '\')">'
+					+   '<div>'
+					+     '<div class="ei-primary">' + escapeHtml(r.source_ip) + (flag ? ' <span class="text-xs text-gray-400">' + escapeHtml(flag) + '</span>' : '') + '</div>'
+					+     '<div class="ei-secondary">' + escapeHtml(meta) + '</div>'
+					+   '</div>'
+					+   '<div class="ei-count">' + (r.error_count || 0).toLocaleString() + '</div>'
+					+ '</div>';
+			}).join('');
+		}
+
+		function renderEICountries(rows) {
+			if (rows.length === 0) return '<p class="text-xs text-gray-500 dark:text-gray-400">No country breakdown.</p>';
+			return rows.map(function(r) {
+				return ''
+					+ '<div class="ei-row" style="cursor: default;">'
+					+   '<div>'
+					+     '<div class="ei-primary">' + escapeHtml(r.country || 'Unknown') + ' <span class="text-xs text-gray-400">' + escapeHtml(r.country_code || '') + '</span></div>'
+					+     '<div class="ei-secondary">' + (r.unique_ips || 0) + ' IPs · ' + (r.error_rate || 0).toFixed(1) + '% err</div>'
+					+   '</div>'
+					+   '<div class="ei-count">' + (r.errors || 0).toLocaleString() + '</div>'
+					+ '</div>';
+			}).join('');
+		}
+
+		// ──────────────────────────────────────────────────────────────
+		// Drill-down drawer
+		// ──────────────────────────────────────────────────────────────
+
+		let drilldownCharts = {};
+
+		function destroyDrilldownCharts() {
+			Object.values(drilldownCharts).forEach(function(c) { try { c.destroy(); } catch(e){} });
+			drilldownCharts = {};
+		}
+
+		function openDrillDown(kind, name) {
+			const drawer = document.getElementById('drilldown-drawer');
+			const backdrop = document.getElementById('drilldown-backdrop');
+			drawer.classList.remove('hidden');
+			backdrop.classList.remove('hidden');
+			// Force reflow so the transition triggers.
+			void drawer.offsetWidth;
+			drawer.classList.add('open');
+			backdrop.classList.add('open');
+
+			document.getElementById('drilldown-eyebrow').textContent = kind === 'backend' ? 'Backend' : 'Source IP';
+			document.getElementById('drilldown-title').textContent = name;
+			document.getElementById('drilldown-body').innerHTML = '<p class="text-sm text-gray-500">Loading…</p>';
+
+			if (kind === 'backend') {
+				loadBackendDrillDown(name);
+			} else if (kind === 'source') {
+				loadSourceDrillDown(name);
+			}
+		}
+
+		function closeDrillDown() {
+			const drawer = document.getElementById('drilldown-drawer');
+			const backdrop = document.getElementById('drilldown-backdrop');
+			drawer.classList.remove('open');
+			backdrop.classList.remove('open');
+			setTimeout(function() {
+				drawer.classList.add('hidden');
+				backdrop.classList.add('hidden');
+				destroyDrilldownCharts();
+			}, 200);
+		}
+
+		document.addEventListener('keydown', function(e) {
+			if (e.key === 'Escape' && document.getElementById('drilldown-drawer').classList.contains('open')) {
+				closeDrillDown();
+			}
+		});
+
+		async function loadBackendDrillDown(backendName) {
+			const serverID = getServerID();
+			const range = hoursToRange(document.getElementById('hours-select').value);
+			const url = '/api/' + serverID + '/metrics/backend/' + encodeURIComponent(backendName) + '/details?range=' + encodeURIComponent(range);
+			try {
+				const res = await fetch(url);
+				if (!res.ok) throw new Error('HTTP ' + res.status);
+				const data = await res.json();
+				renderBackendDrillDown(data);
+				const link = document.getElementById('drilldown-logs-link');
+				link.href = '/logs?server=' + encodeURIComponent(serverID) + '&source=haproxy';
+				link.classList.remove('hidden');
+				loadLogErrors(serverID, backendName);
+			} catch (err) {
+				console.error('Drill-down failed', err);
+				document.getElementById('drilldown-body').innerHTML =
+					'<p class="text-sm text-red-500">Failed to load backend details: ' + escapeHtml(err.message) + '</p>';
+			}
+		}
+
+		async function loadSourceDrillDown(sourceIP) {
+			const serverID = getServerID();
+			const html = ''
+				+ '<div class="drilldown-section">'
+				+   '<h3>Source IP details</h3>'
+				+   '<p class="text-sm text-gray-700 dark:text-gray-300">Per-source breakdowns and GeoIP lookup live on the Traffic gear.</p>'
+				+   '<p class="mt-3"><a class="text-blue-600 dark:text-blue-400 underline" href="/traffic?server=' + encodeURIComponent(serverID) + '" target="_blank" rel="noopener">Open Traffic gear →</a></p>'
+				+ '</div>';
+			document.getElementById('drilldown-body').innerHTML = html;
+		}
+
+		function renderBackendDrillDown(data) {
+			const ts = data.timeseries || [];
+			let total5xx = 0, total4xx = 0, total2xx = 0, total3xx = 0, totalReq = 0;
+			let avgRT = 0, rtN = 0;
+			ts.forEach(function(b) {
+				total5xx += b.response_5xx || 0;
+				total4xx += b.response_4xx || 0;
+				total2xx += b.response_2xx || 0;
+				total3xx += b.response_3xx || 0;
+				totalReq += b.requests || 0;
+				if ((b.avg_response_ms || 0) > 0) { avgRT += b.avg_response_ms; rtN++; }
+			});
+			if (rtN > 0) avgRT = avgRT / rtN;
+			const totalResp = total2xx + total3xx + total4xx + total5xx;
+			const errRate = totalResp > 0 ? ((total4xx + total5xx) / totalResp * 100).toFixed(2) : '0.00';
+
+			const sources = data.top_sources || [];
+
+			const sourcesHTML = sources.length === 0
+				? '<p class="text-sm text-gray-500 dark:text-gray-400">No source data in window.</p>'
+				: '<div class="space-y-1">' + sources.map(function(s) {
+					const flag = s.country_code && s.country_code !== 'XX' ? s.country_code : '';
+					return ''
+						+ '<div class="flex items-center justify-between text-sm py-1.5 px-2 rounded hover:bg-gray-50 dark:hover:bg-slate-800">'
+						+   '<div>'
+						+     '<span class="font-medium">' + escapeHtml(s.source_ip) + '</span>'
+						+     (flag ? ' <span class="text-xs text-gray-400">' + escapeHtml(flag) + '</span>' : '')
+						+     '<span class="ml-2 text-xs text-gray-500">' + escapeHtml(s.country || 'Unknown') + '</span>'
+						+   '</div>'
+						+   '<div class="text-xs text-gray-700 dark:text-gray-300">'
+						+     (s.requests || 0).toLocaleString() + ' req · '
+						+     '<span class="text-red-500">' + (s.error_count || 0) + ' err</span>'
+						+   '</div>'
+						+ '</div>';
+				}).join('') + '</div>';
+
+			document.getElementById('drilldown-body').innerHTML = ''
+				+ '<div class="drilldown-section">'
+				+   '<h3>Summary</h3>'
+				+   '<div class="drilldown-kv">'
+				+     '<div><div class="k">Requests</div><div class="v">' + totalReq.toLocaleString() + '</div></div>'
+				+     '<div><div class="k">Error rate</div><div class="v ' + (parseFloat(errRate) > 5 ? 'text-red-500' : '') + '">' + errRate + '%</div></div>'
+				+     '<div><div class="k">5xx</div><div class="v ' + (total5xx > 0 ? 'text-red-500' : '') + '">' + total5xx.toLocaleString() + '</div></div>'
+				+     '<div><div class="k">4xx</div><div class="v ' + (total4xx > 0 ? 'text-yellow-500' : '') + '">' + total4xx.toLocaleString() + '</div></div>'
+				+     '<div><div class="k">Avg latency</div><div class="v">' + Math.round(avgRT) + ' ms</div></div>'
+				+   '</div>'
+				+ '</div>'
+				+ '<div class="drilldown-section">'
+				+   '<h3>Requests &amp; errors over time</h3>'
+				+   '<div class="drilldown-chart"><canvas id="drilldown-rate-chart"></canvas></div>'
+				+ '</div>'
+				+ '<div class="drilldown-section">'
+				+   '<h3>Status code mix</h3>'
+				+   '<div class="drilldown-chart" style="height: 140px;"><canvas id="drilldown-status-chart"></canvas></div>'
+				+ '</div>'
+				+ '<div class="drilldown-section">'
+				+   '<h3>Top sources hitting this backend</h3>'
+				+   sourcesHTML
+				+ '</div>'
+				+ '<div class="drilldown-section">'
+				+   '<div class="flex items-center justify-between">'
+				+     '<h3>Recent 5xx log lines</h3>'
+				+     '<span id="drilldown-logs-state" class="text-xs text-gray-400">Loading…</span>'
+				+   '</div>'
+				+   '<div id="drilldown-logs-body" class="space-y-1 mt-1"></div>'
+				+ '</div>';
+
+			renderDrilldownRateChart(ts);
+			renderDrilldownStatusChart({ r2xx: total2xx, r3xx: total3xx, r4xx: total4xx, r5xx: total5xx });
+		}
+
+		function renderDrilldownRateChart(ts) {
+			const ctx = document.getElementById('drilldown-rate-chart');
+			if (!ctx || ts.length === 0) return;
+			const labels = ts.map(function(b) { return formatTime(b.bucket_time); });
+			const reqs   = ts.map(function(b) { return b.requests || 0; });
+			const errs   = ts.map(function(b) { return (b.response_4xx || 0) + (b.response_5xx || 0); });
+			const colors = getChartColors();
+			drilldownCharts.rate = new Chart(ctx.getContext('2d'), {
+				type: 'line',
+				data: {
+					labels: labels,
+					datasets: [
+						{ label: 'Requests', data: reqs, borderColor: colors.primary, backgroundColor: 'rgba(59, 130, 246, 0.08)', fill: true, borderWidth: 1.4, pointRadius: 0, tension: 0.35, yAxisID: 'y' },
+						{ label: 'Errors',   data: errs, borderColor: colors.danger,  backgroundColor: 'rgba(239, 68, 68, 0.15)', fill: true, borderWidth: 1.4, pointRadius: 0, tension: 0.35, yAxisID: 'y1' }
+					]
+				},
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					plugins: { legend: { labels: { color: colors.text, boxWidth: 10, font: { size: 10 } } } },
+					scales: {
+						x:  { ticks: { color: colors.text, maxTicksLimit: 6, font: { size: 10 } }, grid: { color: colors.grid } },
+						y:  { position: 'left',  beginAtZero: true, ticks: { color: colors.text, font: { size: 10 } }, grid: { color: colors.grid } },
+						y1: { position: 'right', beginAtZero: true, ticks: { color: colors.danger, font: { size: 10 } }, grid: { drawOnChartArea: false } }
+					}
+				}
+			});
+		}
+
+		function renderDrilldownStatusChart(s) {
+			const ctx = document.getElementById('drilldown-status-chart');
+			if (!ctx) return;
+			const colors = getChartColors();
+			drilldownCharts.status = new Chart(ctx.getContext('2d'), {
+				type: 'doughnut',
+				data: {
+					labels: ['2xx', '3xx', '4xx', '5xx'],
+					datasets: [{
+						data: [s.r2xx || 0, s.r3xx || 0, s.r4xx || 0, s.r5xx || 0],
+						backgroundColor: [colors.secondary, colors.primary, colors.warning, colors.danger],
+						borderWidth: 0
+					}]
+				},
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					plugins: {
+						legend: { position: 'right', labels: { color: colors.text, boxWidth: 12, font: { size: 11 } } }
+					},
+					cutout: '60%'
+				}
+			});
+		}
+
+		async function loadLogErrors(serverID, backendName) {
+			const state = document.getElementById('drilldown-logs-state');
+			const body = document.getElementById('drilldown-logs-body');
+			if (!state || !body) return;
+			try {
+				const url = '/api/' + serverID + '/metrics/log-errors?status_min=500&lines=3000'
+					+ (backendName ? '&backend=' + encodeURIComponent(backendName) : '');
+				const res = await fetch(url);
+				if (!res.ok) throw new Error('HTTP ' + res.status);
+				const data = await res.json();
+				if (!data.available) {
+					state.textContent = 'logs unavailable';
+					body.innerHTML = '<p class="text-xs text-gray-500">' + escapeHtml(data.reason || 'Agent did not return log data.') + '</p>';
+					return;
+				}
+				const matches = data.matches || [];
+				state.textContent = matches.length + ' match' + (matches.length === 1 ? '' : 'es');
+				if (matches.length === 0) {
+					body.innerHTML = '<p class="text-xs text-gray-500">No 5xx log lines in the last few thousand entries.</p>';
+					return;
+				}
+				body.innerHTML = matches.slice(0, 50).map(function(m) {
+					const statusClass = (m.status_code >= 500) ? '' : ' s4';
+					return ''
+						+ '<div class="log-line">'
+						+   '<span class="lc-status' + statusClass + '">' + m.status_code + '</span> '
+						+   (m.method ? escapeHtml(m.method) + ' ' : '')
+						+   (m.path ? '<span class="lc-path">' + escapeHtml(m.path) + '</span> ' : '')
+						+   (m.source_ip ? '<span class="lc-ip">' + escapeHtml(m.source_ip) + '</span> ' : '')
+						+   (m.server ? '→ ' + escapeHtml(m.server) : '')
+						+ '</div>';
+				}).join('');
+			} catch (err) {
+				console.error('log-errors fetch failed', err);
+				state.textContent = 'load failed';
+				body.innerHTML = '<p class="text-xs text-red-500">Failed to load log lines.</p>';
+			}
+		}
+
+		// ──────────────────────────────────────────────────────────────
+		// Helpers
+		// ──────────────────────────────────────────────────────────────
+
+		function escapeHtml(s) {
+			if (s === null || s === undefined) return '';
+			const div = document.createElement('div');
+			div.textContent = String(s);
+			return div.innerHTML;
+		}
+
+		function escapeAttr(s) {
+			return escapeHtml(s).replace(/"/g, '&quot;');
+		}
+
+		// escapeJSArg escapes a string for safe inclusion as a single-quoted
+		// JS argument inside an HTML onclick attribute.
+		function escapeJSArg(s) {
+			return String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 		}
 
 		// Move page header content to main header

--- a/gearbox/internal/gears/metrics/README.md
+++ b/gearbox/internal/gears/metrics/README.md
@@ -1,14 +1,37 @@
 # Metrics Gear
 
-The Metrics gear provides historical metrics visualization and analysis for HAProxy monitoring.
+The Metrics gear surfaces historical metrics for HAProxy and the underlying
+host. It's the place users land when they want to answer *"how busy was the
+proxy, and what went wrong?"*
 
-## Features
+## Layout
 
-- Historical stats graphs
-- System metrics over time (CPU, memory, disk, network)
-- Backend performance trends
-- Configurable data retention
-- Time range selection for analysis
+The page has four stacked sections:
+
+1. **KPI summary band** — six compact stat cards across the top with an
+   inline sparkline and a delta vs. the previous window of equal length:
+   Requests / min, Avg Response, Error Rate %, 5xx Errors, Active Sessions,
+   Healthy Backends N/M. Cards colour themselves by health (green / amber /
+   red) and the delta arrow inverts so that "going up" is red for errors
+   and green for traffic. Hover any card for the explanation tooltip.
+2. **Charts grid** — seven time-series charts (Sessions, Server Health,
+   CPU Load, Memory, Network, Response Times, 5xx Errors). All charts use
+   index-mode crosshair tooltips so hovering any chart shows all series at
+   the same timestamp. Click any card's fullscreen icon to expand. The 5xx
+   Errors chart has a gradient fill — the colour intensity makes spikes
+   obvious at a glance.
+3. **Error Insights** — replaces the old "Recent Incidents" list. When the
+   window contains any 4xx/5xx responses, this panel shows three columns:
+   *Top backends by errors*, *Top source IPs*, and *Top countries*. Click
+   any backend or source row to open the drill-down drawer. If the window
+   has no errors, the panel collapses to a green "everything's quiet" tile.
+4. **Drill-down drawer** — slides in from the right when you click a row.
+   Shows a per-backend summary (requests, error rate, 5xx, 4xx, average
+   latency), two mini-charts (requests + errors over time, status code
+   doughnut), the top source IPs hitting that backend, and a list of
+   recent 5xx HAProxy log lines (pulled from the agent and filtered by
+   backend). A "View logs →" link jumps to the Logs gear with the HAProxy
+   source pre-selected. `Esc` or backdrop-click closes the drawer.
 
 ## Configuration
 
@@ -24,15 +47,19 @@ The Metrics gear provides historical metrics visualization and analysis for HAPr
 | `metrics:view`      | View metrics and history   |
 | `metrics:configure` | Configure metrics settings |
 
+The drill-down drawer's *Recent 5xx log lines* section additionally
+requires `logs:view`. If the user doesn't have that permission, the section
+shows a "logs unavailable" hint instead of failing.
+
 ## Routes
 
 | Method | Path       | Description               |
 |--------|------------|---------------------------|
 | GET    | `/history` | Main history/metrics page |
 
-## API Endpoints (Main Handler)
+## API endpoints (main handler)
 
-The following API endpoints are related to metrics but remain in the main handler:
+Existing endpoints kept for backwards compatibility:
 
 | Method | Path                                            | Description                   |
 |--------|-------------------------------------------------|-------------------------------|
@@ -42,19 +69,60 @@ The following API endpoints are related to metrics but remain in the main handle
 | GET    | `/api/{serverID}/metrics/storage-stats`         | Get storage statistics        |
 | POST   | `/api/{serverID}/metrics/clear`                 | Clear metrics data            |
 
+New in v2 ("insights" surface — see `api_metrics_insights.go`):
+
+| Method | Path                                                          | Description                                                                                  |
+|--------|---------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| GET    | `/api/{serverID}/metrics/summary?range=...`                   | KPI band: 6 cards, each with value, prior-window delta, sparkline                            |
+| GET    | `/api/{serverID}/metrics/error-breakdown?range=...`           | Top backends / source IPs / countries responsible for 4xx+5xx in the window                  |
+| GET    | `/api/{serverID}/metrics/backend/{name}/details?range=...`    | Per-backend time-series + top sources for the drill-down drawer                              |
+| GET    | `/api/{serverID}/metrics/log-errors?status_min=500&...`       | Recent HAProxy log lines with status >= `status_min`, parsed into source/backend/path/status |
+
+All four accept a `range` query param of `5m`, `30m`, `1h`, `6h`, `24h`,
+`3d`, or `7d` (default `24h`). `log-errors` also accepts `lines` (1–10000,
+default 2000) and an optional `backend` filter.
+
+## Data sources
+
+The new endpoints sit on top of existing tables — no new collection runs
+on the agent. Specifically:
+
+- KPI summary aggregates `stats_history` (per-snapshot HAProxy stats) and
+  `traffic_flows` (per-minute response-code buckets from the Traffic gear's
+  collector).
+- Error Insights and backend details query `traffic_flows` exclusively —
+  it stores actual per-bucket response counts rather than cumulative
+  counters, so error rates are accurate without delta math.
+- Log-errors hits the agent's `/api/v1/logs/haproxy` endpoint live, then
+  parses lines in the dashboard. The agent is unchanged.
+
 ## Architecture
 
-```txt
+```text
 internal/gears/metrics/
-├── gear.go      # Gear implementation
-├── handlers.go    # HTTP handlers
-├── icons.go       # Sidebar icon
-├── settings.go    # Settings page component
-└── README.md      # This file
+├── plugin.go             # Gear registration
+├── handlers.go           # HTTP handler (/history page)
+├── partials.templ        # CPU / memory / disk / etc. widget partials
+├── chart_partials.templ  # Reusable chart components for the home gear
+├── icons.go              # Sidebar icon
+├── settings.go           # Settings page component
+└── README.md             # This file
+
+internal/framework/handler/
+├── api_stats.go                       # Existing /history/* endpoints
+├── api_metrics_insights.go            # KPI / error breakdown / drill-down / log-errors
+└── api_metrics_insights_helpers.go    # KPI math, sparkline downsampling
+
+internal/framework/database/
+└── metrics_insights.go    # Top-backends / top-sources / time-series queries
+                           # (uses the existing traffic_flows table)
 ```
 
 ## Development
 
-### Building
-
 The gear is automatically included in the build via its `init()` function.
+After editing `history.templ`, run:
+
+```bash
+make templ-generate && make build
+```


### PR DESCRIPTION
## Summary

- Adds a 6-card KPI summary band (with sparklines + Δ vs prior window), an Error Insights panel (top backends / source IPs / countries by 4xx+5xx), and a slide-in drill-down drawer with per-backend mini-charts, top sources, and recent 5xx HAProxy log lines parsed live from the agent.
- All new endpoints sit on top of existing `stats_history` and `traffic_flows` tables — no new agent collection required.
- Crosshair tooltips and a gradient fill on the 5xx chart for the visual polish the issue asked for.
- Also includes a planning doc ([docs/research/metrics-source-agnostic.md](../tree/feature/metrics-improvement-pass-87/docs/research/metrics-source-agnostic.md)) outlining a 9-phase plan to make the gear source-agnostic so it works on plain Linux boxes and any detected web server / proxy. That doc is a follow-up — this PR doesn't implement it.

## What changed

**New backend (`gearbox/internal/framework/handler/`, `gearbox/internal/framework/database/`):**

- `GET /api/{id}/metrics/summary?range=…` — KPI cards
- `GET /api/{id}/metrics/error-breakdown?range=…` — top backends/sources/countries
- `GET /api/{id}/metrics/backend/{name}/details?range=…` — drill-down data
- `GET /api/{id}/metrics/log-errors?status_min=500&backend=…` — recent parsed HAProxy log lines
- DB queries in a new `metrics_insights.go` file
- 22 new unit tests for KPI math, sparkline downsampling, log-line parsing, and range parsing

**Dashboard UI (`history.templ`):**

- KPI band at top, replacing the previous "scroll down to see anything" layout
- Error Insights panel replacing "Recent Incidents" (incidents are still queryable; we just don't surface them here anymore)
- Drill-down drawer (slides in from right) with `Esc`/backdrop close
- Crosshair tooltips and gradient fill applied to existing charts via the shared option helpers

**Docs:**

- `gearbox/internal/gears/metrics/README.md` rewritten to describe the new layout, endpoints, and data sources
- `docs/research/metrics-source-agnostic.md` — the follow-up plan
- `docs/research/README.md` — links the new plan

## Issue answered

Closes #87.

The original issue asked three things, addressed as follows:

| Issue ask                                                | How it's addressed                                                                                                                                          |
|----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
| "Errors skyrocketing — but where?"                       | Error Insights panel shows top backends by 5xx + 4xx, ranked. Click a row → drawer with per-backend mini-charts + top source IPs + recent 5xx log lines.    |
| "Requests going up — who/what/where?"                    | KPI band shows requests/min with prior-window delta + sparkline. Drill-down drawer lists top source IPs hitting any backend.                                |
| "Traffic gear says 29% error rate to light-hugger — find it" | Clicking the relevant backend row in Error Insights opens the drawer with the live request-vs-error chart, status-code mix, top sources, and 5xx log lines. |

## Test plan

- [ ] `make templ-generate && make build` — clean build (verified locally)
- [ ] `go vet ./...` — clean (verified locally)
- [ ] `go test ./...` — full suite passes, including 22 new tests (verified locally)
- [ ] Visit `/history` on mjolnir with HAProxy data present — KPI band populates, Error Insights shows backends, click-through opens drawer with log lines
- [ ] Hover any chart — crosshair tooltip shows all series at the same x
- [ ] Click 5xx chart fullscreen icon — chart expands, gradient fill visible
- [ ] Drawer behaviour: Esc closes; backdrop click closes; close (×) button closes; opens cleanly on second/third use without leftover charts
- [ ] No regression on existing 7 charts or the time-range/resolution controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)