### PR TITLE
feat(#91): metrics gear — source-aware, no-HAProxy mode (phases 0-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ gearbox-agent/data/
 # Environment
 gearbox/.env
 gearbox-agent/.env
+.local.config
 *.local.json
 .mcp.json
 

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -688,6 +688,11 @@ func main() {
 			r.Get("/{boxID}/metrics/backend/{backendName}/details", h.APIMetricsBackendDetailsHandler)
 			r.Get("/{boxID}/metrics/log-errors", h.APIMetricsLogErrorsHandler)
 
+			// Per-box capability manifest — exposes which agent gears probed
+			// available so the metrics gear (and future source-aware UI) can
+			// hide cards/KPIs that don't apply to this host.
+			r.Get("/{boxID}/capabilities", h.APIBoxCapabilitiesHandler)
+
 			// Disabled entities management
 			r.Get("/{boxID}/disabled-entities", h.APIDisabledEntitiesHandler)
 			r.Post("/{boxID}/disable-entity", h.APIDisableEntityHandler)

--- a/gearbox/internal/framework/agent/capabilities_cache.go
+++ b/gearbox/internal/framework/agent/capabilities_cache.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"sync"
+	"time"
+)
+
+// BoxCapabilities is a dashboard-side view of one box's probe table.
+// Carries the CapabilitiesResponse from the agent plus when it was last
+// observed. Handlers consume this to gate UI on what the agent reports
+// the box can do — e.g. hide HAProxy charts when the haproxy gear isn't
+// available on this host.
+type BoxCapabilities struct {
+	Response  *CapabilitiesResponse
+	FetchedAt time.Time
+}
+
+// Has reports whether the agent surfaced the given gear at all, regardless
+// of probe verdict. Use when "the agent is recent enough to know about
+// this gear" is the question — older agents that pre-date a gear simply
+// won't have it in their probe table.
+func (b *BoxCapabilities) Has(gearName string) bool {
+	if b == nil || b.Response == nil {
+		return false
+	}
+	_, ok := b.Response.Gears[gearName]
+	return ok
+}
+
+// IsAvailable reports whether the gear probed Available on the agent.
+// Returns false when capabilities are nil/unknown; callers wanting
+// fail-open behaviour should check Has() separately.
+func (b *BoxCapabilities) IsAvailable(gearName string) bool {
+	if b == nil || b.Response == nil {
+		return false
+	}
+	e, ok := b.Response.Gears[gearName]
+	return ok && e.IsAvailable()
+}
+
+// Entry returns the agent's probe entry for the gear if it's present in
+// the response. The second return is false when the gear isn't surfaced
+// or capabilities are nil.
+func (b *BoxCapabilities) Entry(gearName string) (CapabilityEntry, bool) {
+	if b == nil || b.Response == nil {
+		return CapabilityEntry{}, false
+	}
+	e, ok := b.Response.Gears[gearName]
+	return e, ok
+}
+
+// CapabilitiesCache memoises agent capability fetches per box. Dashboard
+// pages call into this on every render that needs to decide what to
+// surface; without the cache, that's one synchronous round-trip per
+// render. TTL is short so a recently-restarted agent's new probe table
+// shows up without operator intervention; reconnect events should
+// invalidate explicitly via Invalidate() for an immediate refresh.
+//
+// Negative results (fetch errors, agent dead) are also cached for the
+// TTL window so a flaky or unreachable agent doesn't drag down every
+// page render with a fresh failed call.
+type CapabilitiesCache struct {
+	mu           sync.RWMutex
+	entries      map[string]*cachedCapabilities
+	ttl          time.Duration
+	fetchTimeout time.Duration
+}
+
+type cachedCapabilities struct {
+	caps      *BoxCapabilities // nil when the last fetch errored
+	err       error            // captured on failure for callers that want it
+	fetchedAt time.Time
+}
+
+// NewCapabilitiesCache creates a cache with the given TTL and per-fetch
+// timeout. The timeout must be short — capability fetches sit on the
+// critical path of page renders, so a dead agent must not stall the UI.
+// 3s matches the value the Gears settings page used pre-cache.
+func NewCapabilitiesCache(ttl, fetchTimeout time.Duration) *CapabilitiesCache {
+	return &CapabilitiesCache{
+		entries:      make(map[string]*cachedCapabilities),
+		ttl:          ttl,
+		fetchTimeout: fetchTimeout,
+	}
+}
+
+// Get returns the cached capabilities for boxID. If the entry is missing
+// or older than the TTL, the cache fetches fresh capabilities from
+// agentURL using the supplied API key. On fetch error, returns (nil, err);
+// the error is also cached for the TTL window. Callers should treat
+// (nil, err) as "unknown" and fail open — locking users out of pages
+// because the agent is briefly unreachable is worse than briefly showing
+// gears that may not be available.
+func (c *CapabilitiesCache) Get(boxID, agentURL, apiKey string) (*BoxCapabilities, error) {
+	if entry, ok := c.lookup(boxID); ok {
+		return entry.caps, entry.err
+	}
+
+	client := NewClientWithTimeout(agentURL, apiKey, c.fetchTimeout)
+	resp, err := client.GetCapabilities()
+
+	now := time.Now()
+	var caps *BoxCapabilities
+	if err == nil {
+		caps = &BoxCapabilities{Response: resp, FetchedAt: now}
+	}
+
+	c.mu.Lock()
+	c.entries[boxID] = &cachedCapabilities{caps: caps, err: err, fetchedAt: now}
+	c.mu.Unlock()
+
+	return caps, err
+}
+
+// lookup returns a non-stale entry under the read lock, or (nil, false)
+// if missing/expired. Split out so Get's refresh path can drop the read
+// lock before doing network I/O.
+func (c *CapabilitiesCache) lookup(boxID string) (*cachedCapabilities, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[boxID]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(entry.fetchedAt) >= c.ttl {
+		return nil, false
+	}
+	return entry, true
+}
+
+// Invalidate drops the cached entry for boxID, forcing a fresh fetch on
+// the next Get. Call this when the box reconnects so a restarted agent's
+// new probe table is picked up immediately rather than at the next TTL
+// boundary.
+func (c *CapabilitiesCache) Invalidate(boxID string) {
+	c.mu.Lock()
+	delete(c.entries, boxID)
+	c.mu.Unlock()
+}
+
+// InvalidateAll drops every cached entry. Useful when global config that
+// affects probing changes (rare) and in tests.
+func (c *CapabilitiesCache) InvalidateAll() {
+	c.mu.Lock()
+	c.entries = make(map[string]*cachedCapabilities)
+	c.mu.Unlock()
+}

--- a/gearbox/internal/framework/agent/capabilities_cache.go
+++ b/gearbox/internal/framework/agent/capabilities_cache.go
@@ -49,21 +49,38 @@ func (b *BoxCapabilities) Entry(gearName string) (CapabilityEntry, bool) {
 	return e, ok
 }
 
-// CapabilitiesCache memoises agent capability fetches per box. Dashboard
-// pages call into this on every render that needs to decide what to
-// surface; without the cache, that's one synchronous round-trip per
-// render. TTL is short so a recently-restarted agent's new probe table
-// shows up without operator intervention; reconnect events should
-// invalidate explicitly via Invalidate() for an immediate refresh.
+// CapabilitiesCache memoises agent capability fetches per (box, agent
+// URL) pair. Dashboard pages call into this on every render that needs
+// to decide what to surface; without the cache, that's one synchronous
+// round-trip per render. TTL is short so a recently-restarted agent's
+// new probe table shows up without operator intervention; reconnect
+// events should invalidate explicitly via Invalidate() for an immediate
+// refresh.
+//
+// The cache key includes the agent URL (not just the box ID) so that an
+// operator editing a box's Agent URL — or re-pointing the same box ID
+// at a different host — gets fresh capabilities on the next render
+// rather than stale data from the prior agent until the 5-minute TTL
+// expires. The API key is intentionally not part of the key (rotations
+// don't change which gears the host runs; if the new key is wrong the
+// fetch errors and the negative-cache entry expires normally).
 //
 // Negative results (fetch errors, agent dead) are also cached for the
 // TTL window so a flaky or unreachable agent doesn't drag down every
 // page render with a fresh failed call.
 type CapabilitiesCache struct {
 	mu           sync.RWMutex
-	entries      map[string]*cachedCapabilities
+	entries      map[cacheKey]*cachedCapabilities
 	ttl          time.Duration
 	fetchTimeout time.Duration
+}
+
+// cacheKey identifies one cached entry by (boxID, agentURL). Splitting
+// into a struct rather than concatenating strings sidesteps any chance
+// of separator collision in operator-supplied URLs.
+type cacheKey struct {
+	boxID    string
+	agentURL string
 }
 
 type cachedCapabilities struct {
@@ -78,21 +95,27 @@ type cachedCapabilities struct {
 // 3s matches the value the Gears settings page used pre-cache.
 func NewCapabilitiesCache(ttl, fetchTimeout time.Duration) *CapabilitiesCache {
 	return &CapabilitiesCache{
-		entries:      make(map[string]*cachedCapabilities),
+		entries:      make(map[cacheKey]*cachedCapabilities),
 		ttl:          ttl,
 		fetchTimeout: fetchTimeout,
 	}
 }
 
-// Get returns the cached capabilities for boxID. If the entry is missing
-// or older than the TTL, the cache fetches fresh capabilities from
-// agentURL using the supplied API key. On fetch error, returns (nil, err);
-// the error is also cached for the TTL window. Callers should treat
-// (nil, err) as "unknown" and fail open — locking users out of pages
-// because the agent is briefly unreachable is worse than briefly showing
-// gears that may not be available.
+// Get returns the cached capabilities for (boxID, agentURL). If the
+// entry is missing or older than the TTL, the cache fetches fresh
+// capabilities from agentURL using the supplied API key. On fetch error,
+// returns (nil, err); the error is also cached for the TTL window.
+// Callers should treat (nil, err) as "unknown" and fail open — locking
+// users out of pages because the agent is briefly unreachable is worse
+// than briefly showing gears that may not be available.
+//
+// Changing agentURL for the same boxID produces a different cache entry,
+// so config edits take effect on the next call rather than waiting out
+// the TTL. The previous entry expires naturally; no explicit cleanup
+// needed for the rare case of an operator-driven URL change.
 func (c *CapabilitiesCache) Get(boxID, agentURL, apiKey string) (*BoxCapabilities, error) {
-	if entry, ok := c.lookup(boxID); ok {
+	k := cacheKey{boxID: boxID, agentURL: agentURL}
+	if entry, ok := c.lookup(k); ok {
 		return entry.caps, entry.err
 	}
 
@@ -106,7 +129,7 @@ func (c *CapabilitiesCache) Get(boxID, agentURL, apiKey string) (*BoxCapabilitie
 	}
 
 	c.mu.Lock()
-	c.entries[boxID] = &cachedCapabilities{caps: caps, err: err, fetchedAt: now}
+	c.entries[k] = &cachedCapabilities{caps: caps, err: err, fetchedAt: now}
 	c.mu.Unlock()
 
 	return caps, err
@@ -115,10 +138,10 @@ func (c *CapabilitiesCache) Get(boxID, agentURL, apiKey string) (*BoxCapabilitie
 // lookup returns a non-stale entry under the read lock, or (nil, false)
 // if missing/expired. Split out so Get's refresh path can drop the read
 // lock before doing network I/O.
-func (c *CapabilitiesCache) lookup(boxID string) (*cachedCapabilities, bool) {
+func (c *CapabilitiesCache) lookup(k cacheKey) (*cachedCapabilities, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	entry, ok := c.entries[boxID]
+	entry, ok := c.entries[k]
 	if !ok {
 		return nil, false
 	}
@@ -128,20 +151,25 @@ func (c *CapabilitiesCache) lookup(boxID string) (*cachedCapabilities, bool) {
 	return entry, true
 }
 
-// Invalidate drops the cached entry for boxID, forcing a fresh fetch on
-// the next Get. Call this when the box reconnects so a restarted agent's
-// new probe table is picked up immediately rather than at the next TTL
+// Invalidate drops every cached entry for boxID, regardless of the agent
+// URL it was fetched against. Call this when the box reconnects or when
+// the box's config changes (URL or API key edited), so the next Get
+// refetches against the current settings rather than at the next TTL
 // boundary.
 func (c *CapabilitiesCache) Invalidate(boxID string) {
 	c.mu.Lock()
-	delete(c.entries, boxID)
-	c.mu.Unlock()
+	defer c.mu.Unlock()
+	for k := range c.entries {
+		if k.boxID == boxID {
+			delete(c.entries, k)
+		}
+	}
 }
 
 // InvalidateAll drops every cached entry. Useful when global config that
 // affects probing changes (rare) and in tests.
 func (c *CapabilitiesCache) InvalidateAll() {
 	c.mu.Lock()
-	c.entries = make(map[string]*cachedCapabilities)
+	c.entries = make(map[cacheKey]*cachedCapabilities)
 	c.mu.Unlock()
 }

--- a/gearbox/internal/framework/agent/capabilities_cache_test.go
+++ b/gearbox/internal/framework/agent/capabilities_cache_test.go
@@ -162,6 +162,78 @@ func TestBoxCapabilitiesAccessors(t *testing.T) {
 	}
 }
 
+func TestCapabilitiesCacheDifferentAgentURLBypassesCache(t *testing.T) {
+	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},
+	})
+	defer srv.Close()
+	srv2, hits2 := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "not_installed"}},
+	})
+	defer srv2.Close()
+
+	cache := NewCapabilitiesCache(5*time.Minute, 2*time.Second)
+
+	// Fetch against srv, then against srv2 with the same boxID. The
+	// second call must NOT serve cached data from srv — operator edits
+	// to the Agent URL should take effect on the next render.
+	caps1, err := cache.Get("box-1", srv.URL, "test-key")
+	if err != nil || !caps1.IsAvailable("haproxy") {
+		t.Fatalf("first Get: want available, got caps=%+v err=%v", caps1, err)
+	}
+	caps2, err := cache.Get("box-1", srv2.URL, "test-key")
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if caps2.IsAvailable("haproxy") {
+		t.Error("expected second Get to reflect srv2's not_installed verdict, got available (stale cache)")
+	}
+
+	if hits.Load() != 1 {
+		t.Errorf("srv: expected 1 hit, got %d", hits.Load())
+	}
+	if hits2.Load() != 1 {
+		t.Errorf("srv2: expected 1 hit, got %d", hits2.Load())
+	}
+}
+
+func TestCapabilitiesCacheInvalidateDropsAllAgentURLsForBox(t *testing.T) {
+	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},
+	})
+	defer srv.Close()
+	srv2, hits2 := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},
+	})
+	defer srv2.Close()
+
+	cache := NewCapabilitiesCache(5*time.Minute, 2*time.Second)
+	if _, err := cache.Get("box-1", srv.URL, "k"); err != nil {
+		t.Fatalf("seed srv: %v", err)
+	}
+	if _, err := cache.Get("box-1", srv2.URL, "k"); err != nil {
+		t.Fatalf("seed srv2: %v", err)
+	}
+
+	cache.Invalidate("box-1")
+
+	if _, err := cache.Get("box-1", srv.URL, "k"); err != nil {
+		t.Fatalf("post-invalidate srv: %v", err)
+	}
+	if _, err := cache.Get("box-1", srv2.URL, "k"); err != nil {
+		t.Fatalf("post-invalidate srv2: %v", err)
+	}
+
+	// Each backend should have been hit twice: once for the initial
+	// seed, once after invalidation dropped both entries for box-1.
+	if got := hits.Load(); got != 2 {
+		t.Errorf("srv hits = %d, want 2", got)
+	}
+	if got := hits2.Load(); got != 2 {
+		t.Errorf("srv2 hits = %d, want 2", got)
+	}
+}
+
 func TestCapabilitiesCacheInvalidateAll(t *testing.T) {
 	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
 		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},

--- a/gearbox/internal/framework/agent/capabilities_cache_test.go
+++ b/gearbox/internal/framework/agent/capabilities_cache_test.go
@@ -1,0 +1,192 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newCapabilitiesServer is a small httptest server that returns a
+// CapabilitiesResponse and tracks how many times it was called.
+func newCapabilitiesServer(t *testing.T, response CapabilitiesResponse) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.URL.Path != "/api/v1/system/capabilities" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	return srv, &hits
+}
+
+func TestCapabilitiesCacheCachesWithinTTL(t *testing.T) {
+	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{
+			"haproxy": {Status: "available"},
+		},
+	})
+	defer srv.Close()
+
+	cache := NewCapabilitiesCache(5*time.Minute, 2*time.Second)
+
+	for i := 0; i < 3; i++ {
+		caps, err := cache.Get("box-1", srv.URL, "test-key")
+		if err != nil {
+			t.Fatalf("Get %d: %v", i, err)
+		}
+		if !caps.IsAvailable("haproxy") {
+			t.Fatalf("Get %d: haproxy should be available", i)
+		}
+	}
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 upstream hit, got %d", got)
+	}
+}
+
+func TestCapabilitiesCacheRefreshesAfterTTL(t *testing.T) {
+	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},
+	})
+	defer srv.Close()
+
+	// Sub-millisecond TTL: every Get triggers a refresh.
+	cache := NewCapabilitiesCache(1*time.Nanosecond, 2*time.Second)
+
+	for i := 0; i < 3; i++ {
+		if _, err := cache.Get("box-1", srv.URL, "test-key"); err != nil {
+			t.Fatalf("Get %d: %v", i, err)
+		}
+	}
+
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected 3 upstream hits (each past TTL), got %d", got)
+	}
+}
+
+func TestCapabilitiesCacheInvalidateForcesRefresh(t *testing.T) {
+	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},
+	})
+	defer srv.Close()
+
+	cache := NewCapabilitiesCache(5*time.Minute, 2*time.Second)
+
+	if _, err := cache.Get("box-1", srv.URL, "test-key"); err != nil {
+		t.Fatalf("initial Get: %v", err)
+	}
+	cache.Invalidate("box-1")
+	if _, err := cache.Get("box-1", srv.URL, "test-key"); err != nil {
+		t.Fatalf("post-invalidate Get: %v", err)
+	}
+
+	if got := hits.Load(); got != 2 {
+		t.Errorf("expected 2 upstream hits (invalidate + refresh), got %d", got)
+	}
+}
+
+func TestCapabilitiesCacheNegativeCaching(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		http.Error(w, "agent unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cache := NewCapabilitiesCache(5*time.Minute, 2*time.Second)
+
+	for i := 0; i < 3; i++ {
+		caps, err := cache.Get("box-1", srv.URL, "test-key")
+		if err == nil {
+			t.Fatalf("Get %d: expected error from failing agent", i)
+		}
+		if caps != nil {
+			t.Fatalf("Get %d: expected nil caps on error, got %+v", i, caps)
+		}
+	}
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 upstream hit (negative cache), got %d", got)
+	}
+}
+
+func TestBoxCapabilitiesNilSafe(t *testing.T) {
+	var b *BoxCapabilities
+	if b.Has("haproxy") {
+		t.Error("nil Has should return false")
+	}
+	if b.IsAvailable("haproxy") {
+		t.Error("nil IsAvailable should return false")
+	}
+	if _, ok := b.Entry("haproxy"); ok {
+		t.Error("nil Entry should return false")
+	}
+}
+
+func TestBoxCapabilitiesAccessors(t *testing.T) {
+	b := &BoxCapabilities{
+		Response: &CapabilitiesResponse{
+			Gears: map[string]CapabilityEntry{
+				"haproxy": {Status: "available"},
+				"metrics": {Status: "not_installed"},
+			},
+		},
+		FetchedAt: time.Now(),
+	}
+
+	if !b.Has("haproxy") {
+		t.Error("Has(haproxy) should be true")
+	}
+	if b.Has("nginx") {
+		t.Error("Has(nginx) should be false (not in response)")
+	}
+	if !b.IsAvailable("haproxy") {
+		t.Error("IsAvailable(haproxy) should be true")
+	}
+	if b.IsAvailable("metrics") {
+		t.Error("IsAvailable(metrics) should be false (not_installed)")
+	}
+	if b.IsAvailable("nginx") {
+		t.Error("IsAvailable(nginx) should be false (absent)")
+	}
+
+	entry, ok := b.Entry("metrics")
+	if !ok || entry.Status != "not_installed" {
+		t.Errorf("Entry(metrics) = %+v, ok=%v; want not_installed", entry, ok)
+	}
+}
+
+func TestCapabilitiesCacheInvalidateAll(t *testing.T) {
+	srv, hits := newCapabilitiesServer(t, CapabilitiesResponse{
+		Gears: map[string]CapabilityEntry{"haproxy": {Status: "available"}},
+	})
+	defer srv.Close()
+
+	cache := NewCapabilitiesCache(5*time.Minute, 2*time.Second)
+
+	if _, err := cache.Get("box-1", srv.URL, "test-key"); err != nil {
+		t.Fatalf("box-1 Get: %v", err)
+	}
+	if _, err := cache.Get("box-2", srv.URL, "test-key"); err != nil {
+		t.Fatalf("box-2 Get: %v", err)
+	}
+
+	cache.InvalidateAll()
+
+	if _, err := cache.Get("box-1", srv.URL, "test-key"); err != nil {
+		t.Fatalf("post-invalidate box-1: %v", err)
+	}
+	if _, err := cache.Get("box-2", srv.URL, "test-key"); err != nil {
+		t.Fatalf("post-invalidate box-2: %v", err)
+	}
+
+	if got := hits.Load(); got != 4 {
+		t.Errorf("expected 4 hits (2 initial + 2 post-invalidate), got %d", got)
+	}
+}

--- a/gearbox/internal/framework/handler/api_capabilities.go
+++ b/gearbox/internal/framework/handler/api_capabilities.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
 )
 
 // APICapabilitiesResponse is the JSON envelope returned by
@@ -43,10 +44,20 @@ type APICapabilityEntry struct {
 // metrics gear's frontend (and any future source-aware UI) to hide
 // cards / KPIs for sources the box can't produce.
 //
+// Gated on ComponentMetrics + PermissionView. The manifest enumerates
+// detected services on the host, which is enough information for
+// fingerprinting in a multi-tenant deploy — a user who can't see
+// metrics has no business knowing whether the host runs nginx vs
+// Apache vs Caddy. Mirrors APIMetricsSummaryHandler's gate.
+//
 // Returns 503 when the box isn't agent-backed or capabilities can't
 // be fetched — callers should fail open (show the full UI) on errors
 // so a flaky agent doesn't lock the user out.
 func (h *Handler) APIBoxCapabilitiesHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
 	boxID := chi.URLParam(r, "boxID")
 	if boxID == "" {
 		http.Error(w, "Server ID required", http.StatusBadRequest)

--- a/gearbox/internal/framework/handler/api_capabilities.go
+++ b/gearbox/internal/framework/handler/api_capabilities.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// APICapabilitiesResponse is the JSON envelope returned by
+// GET /api/{boxID}/capabilities. The dashboard's metrics gear (and
+// future source-aware gears) call this on render to decide which
+// cards / KPIs / panels to surface for the active box. Fields mirror
+// the agent's CapabilitiesResponse with one wrapping layer so the
+// envelope can grow (e.g. dashboard-side derived flags) without
+// changing the agent contract.
+type APICapabilitiesResponse struct {
+	// Gears keys agent gear names ("haproxy", "metrics", "logs", …)
+	// to their probe verdicts. Missing keys mean the agent didn't
+	// surface that gear at all — older agents or gears not yet
+	// probe-aware. Callers should treat missing as "unknown" rather
+	// than "not available".
+	Gears map[string]APICapabilityEntry `json:"gears"`
+
+	// FetchedAt is when the dashboard last saw fresh capabilities from
+	// the agent. Allows callers to reason about staleness; the
+	// dashboard refreshes on agent reconnect events plus a short TTL.
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+// APICapabilityEntry is one row of the probe table. Mirrors the
+// agent-side CapabilityEntry without exposing the agent's internal
+// ProbeStatus type alias.
+type APICapabilityEntry struct {
+	Status       string            `json:"status"`
+	Reason       string            `json:"reason,omitempty"`
+	Capabilities map[string]string `json:"capabilities,omitempty"`
+}
+
+// APIBoxCapabilitiesHandler handles GET /api/{boxID}/capabilities and
+// returns the cached agent probe table for the box. Used by the
+// metrics gear's frontend (and any future source-aware UI) to hide
+// cards / KPIs for sources the box can't produce.
+//
+// Returns 503 when the box isn't agent-backed or capabilities can't
+// be fetched — callers should fail open (show the full UI) on errors
+// so a flaky agent doesn't lock the user out.
+func (h *Handler) APIBoxCapabilitiesHandler(w http.ResponseWriter, r *http.Request) {
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	caps, ok := h.getBoxCapabilities(boxID)
+	if !ok || caps == nil || caps.Response == nil {
+		http.Error(w, "Capabilities unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	out := APICapabilitiesResponse{
+		Gears:     make(map[string]APICapabilityEntry, len(caps.Response.Gears)),
+		FetchedAt: caps.FetchedAt,
+	}
+	for name, entry := range caps.Response.Gears {
+		out.Gears[name] = APICapabilityEntry{
+			Status:       entry.Status,
+			Reason:       entry.Reason,
+			Capabilities: entry.Capabilities,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		h.logger.Error("encode capabilities response failed", "box_id", boxID, "error", err)
+	}
+}

--- a/gearbox/internal/framework/handler/api_metrics_insights.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights.go
@@ -57,6 +57,8 @@ type kpiCard struct {
 	Sparkline   []float64 `json:"sparkline"`     // 30 points spanning the current window
 	IsCount     bool      `json:"is_count"`      // hint to UI: render as integer count
 	Description string    `json:"description"`   // tooltip body
+	Source      string    `json:"source"`        // metric source: "haproxy", "host", … (drives the UI badge)
+	SourceLabel string    `json:"source_label"`  // human-readable form ("HAProxy", "Host") for the badge
 }
 
 // APIMetricsSummaryHandler returns the KPI band data for the top of the
@@ -79,17 +81,63 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 	since, until, label := metricsRangeToTimes(r.URL.Query().Get("range"))
 	prevSince := since.Add(-until.Sub(since))
 
+	// Capability-aware gating: only emit HAProxy KPI cards when the agent
+	// surfaces an available haproxy gear. Hosts without HAProxy still get
+	// host-level cards below. Missing/unknown capabilities fail open
+	// (haproxyAvailable = true) so a flaky agent doesn't strip the band
+	// down to nothing.
+	haproxyAvailable := true
+	if caps, ok := h.getBoxCapabilities(boxID); ok && caps != nil {
+		if entry, present := caps.Entry("haproxy"); present {
+			haproxyAvailable = entry.IsAvailable()
+		}
+	}
+
+	cards := []kpiCard{}
+
+	if haproxyAvailable {
+		haproxyCards, err := h.haproxyKPICards(boxID, since, until, prevSince)
+		if err != nil {
+			h.logger.Error("metrics summary: haproxy KPIs", "error", err)
+			http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
+			return
+		}
+		cards = append(cards, haproxyCards...)
+	}
+
+	hostCards, err := h.hostKPICards(boxID, since, until, prevSince)
+	if err != nil {
+		h.logger.Error("metrics summary: host KPIs", "error", err)
+		// Host KPIs are best-effort: an empty system_metrics_history table
+		// shouldn't blow up the band when HAProxy data is fine. Log and
+		// return whatever HAProxy gave us.
+	} else {
+		cards = append(cards, hostCards...)
+	}
+
+	h.writeJSON(w, map[string]interface{}{
+		"server_id":         boxID,
+		"range":             label,
+		"window_start":      since,
+		"window_end":        until,
+		"prev_window_start": prevSince,
+		"haproxy_available": haproxyAvailable,
+		"cards":             cards,
+	})
+}
+
+// haproxyKPICards returns the HAProxy-sourced KPI cards (requests/min,
+// response time, error rate, 5xx count, active sessions, backend health).
+// Computed from the dashboard's stats_history table — the source-of-truth
+// is HAProxy's own admin socket / stats URL via the agent.
+func (h *Handler) haproxyKPICards(boxID string, since, until, prevSince time.Time) ([]kpiCard, error) {
 	curr, err := h.db.GetStatsHistory(boxID, since, 5000)
 	if err != nil {
-		h.logger.Error("metrics summary: stats history", "error", err)
-		http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
-		return
+		return nil, err
 	}
 	prevRaw, err := h.db.GetStatsHistory(boxID, prevSince, 5000)
 	if err != nil {
-		h.logger.Error("metrics summary: prev stats history", "error", err)
-		http.Error(w, "Failed to load stats history", http.StatusInternalServerError)
-		return
+		return nil, err
 	}
 	// GetStatsHistory takes a lower bound only, so prevRaw spans both the
 	// previous AND current windows. Trim to entries strictly before `since`
@@ -120,7 +168,9 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		DeltaPct:    pctDelta(currReqRate, prevReqRate),
 		Status:      "good",
 		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalRequests) }, 30),
-		Description: "Total HTTP requests served per minute, averaged across the window.",
+		Description: "Total HTTP requests served per minute, averaged across the window. Reported by HAProxy stats.",
+		Source:      sourceHAProxy,
+		SourceLabel: sourceLabelHAProxy,
 	})
 
 	currRT := avgPositiveStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.AvgResponseTime) })
@@ -142,7 +192,9 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		DeltaPct:    pctDelta(currRT, prevRT),
 		Status:      rtStatus,
 		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.AvgResponseTime) }, 30),
-		Description: "Mean backend response time across all backends.",
+		Description: "Mean backend response time across all backends. Reported by HAProxy stats.",
+		Source:      sourceHAProxy,
+		SourceLabel: sourceLabelHAProxy,
 	})
 
 	curr5xx, curr4xx, currTotalResp := h.errorTotals(boxID, since, until)
@@ -167,6 +219,8 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		Status:      errStatus,
 		Sparkline:   h.errorRateSparkline(boxID, since, until, 30),
 		Description: "Percentage of requests with 4xx or 5xx status. Click the Error Insights panel below to see which backend / source is responsible.",
+		Source:      sourceHAProxy,
+		SourceLabel: sourceLabelHAProxy,
 	})
 
 	cards = append(cards, kpiCard{
@@ -180,7 +234,9 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		DeltaPct:    pctDelta(float64(curr5xx), float64(prev5xx)),
 		Status:      statusFromCount(curr5xx, 5, 50),
 		Sparkline:   h.errorCountSparkline(boxID, since, until, 30),
-		Description: "Total HTTP 5xx server errors in this window.",
+		Description: "Total HTTP 5xx server errors in this window. Reported by HAProxy stats.",
+		Source:      sourceHAProxy,
+		SourceLabel: sourceLabelHAProxy,
 	})
 
 	currSess := lastStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalSessions) })
@@ -196,7 +252,9 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		DeltaPct:    pctDelta(currSess, prevSess),
 		Status:      "good",
 		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.TotalSessions) }, 30),
-		Description: "Current concurrent sessions across all backends.",
+		Description: "Current concurrent sessions across all backends. Reported by HAProxy stats.",
+		Source:      sourceHAProxy,
+		SourceLabel: sourceLabelHAProxy,
 	})
 
 	currHealthy := lastStat(curr, func(s database.StatsSnapshot) float64 { return float64(s.HealthyServers) })
@@ -221,18 +279,119 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 		IsCount:     true,
 		Status:      healthStatus,
 		Sparkline:   statSparkline(curr, func(s database.StatsSnapshot) float64 { return float64(s.HealthyServers) }, 30),
-		Description: "Live healthy backend servers out of total configured.",
+		Description: "Live healthy backend servers out of total configured. Reported by HAProxy stats.",
+		Source:      sourceHAProxy,
+		SourceLabel: sourceLabelHAProxy,
 	})
 
-	h.writeJSON(w, map[string]interface{}{
-		"server_id":     boxID,
-		"range":         label,
-		"window_start":  since,
-		"window_end":    until,
-		"prev_window_start": prevSince,
-		"cards":         cards,
-	})
+	return cards, nil
 }
+
+// hostKPICards returns the host-level KPI cards (memory, disk, load,
+// network). Computed from the dashboard's system_metrics_history table.
+// Host metrics are produced by the agent on every box, regardless of
+// whether HAProxy or any other proxy is installed — so these cards always
+// render when data is available. CPU%, uptime, and failed-systemd
+// counters aren't persisted in system_metrics_history today; they'll
+// follow when the collector starts saving them.
+func (h *Handler) hostKPICards(boxID string, since, until, prevSince time.Time) ([]kpiCard, error) {
+	curr, err := h.db.GetSystemMetricsHistory(boxID, since, 5000)
+	if err != nil {
+		return nil, err
+	}
+	prevRaw, err := h.db.GetSystemMetricsHistory(boxID, prevSince, 5000)
+	if err != nil {
+		return nil, err
+	}
+	prev := prevRaw[:0]
+	for _, s := range prevRaw {
+		if s.CollectedAt.Before(since) {
+			prev = append(prev, s)
+		}
+	}
+
+	cards := []kpiCard{}
+
+	// Memory %
+	currMem := avgPositiveSysField(curr, func(s database.SystemMetricsSnapshot) float64 { return s.MemoryUsagePercent })
+	prevMem := avgPositiveSysField(prev, func(s database.SystemMetricsSnapshot) float64 { return s.MemoryUsagePercent })
+	memStatus := "good"
+	if currMem >= 80 {
+		memStatus = "warn"
+	}
+	if currMem >= 95 {
+		memStatus = "bad"
+	}
+	cards = append(cards, kpiCard{
+		Key:         "memory",
+		Label:       "Memory",
+		Value:       currMem,
+		Unit:        "%",
+		Decimals:    1,
+		PrevValue:   prevMem,
+		DeltaPct:    pctDelta(currMem, prevMem),
+		Status:      memStatus,
+		Sparkline:   sysSparkline(curr, func(s database.SystemMetricsSnapshot) float64 { return s.MemoryUsagePercent }, 30),
+		Description: "Average memory usage in this window. Reported by the agent's host collector.",
+		Source:      sourceHost,
+		SourceLabel: sourceLabelHost,
+	})
+
+	// Disk %
+	currDisk := avgPositiveSysField(curr, func(s database.SystemMetricsSnapshot) float64 { return s.DiskUsagePercent })
+	prevDisk := avgPositiveSysField(prev, func(s database.SystemMetricsSnapshot) float64 { return s.DiskUsagePercent })
+	diskStatus := "good"
+	if currDisk >= 80 {
+		diskStatus = "warn"
+	}
+	if currDisk >= 95 {
+		diskStatus = "bad"
+	}
+	cards = append(cards, kpiCard{
+		Key:         "disk",
+		Label:       "Disk",
+		Value:       currDisk,
+		Unit:        "%",
+		Decimals:    1,
+		PrevValue:   prevDisk,
+		DeltaPct:    pctDelta(currDisk, prevDisk),
+		Status:      diskStatus,
+		Sparkline:   sysSparkline(curr, func(s database.SystemMetricsSnapshot) float64 { return s.DiskUsagePercent }, 30),
+		Description: "Average disk usage on the root filesystem. Reported by the agent's host collector.",
+		Source:      sourceHost,
+		SourceLabel: sourceLabelHost,
+	})
+
+	// Load average (1 min)
+	currLoad := avgPositiveSysField(curr, func(s database.SystemMetricsSnapshot) float64 { return s.LoadAverage1 })
+	prevLoad := avgPositiveSysField(prev, func(s database.SystemMetricsSnapshot) float64 { return s.LoadAverage1 })
+	cards = append(cards, kpiCard{
+		Key:         "load_1m",
+		Label:       "Load (1m)",
+		Value:       currLoad,
+		Unit:        "",
+		Decimals:    2,
+		PrevValue:   prevLoad,
+		DeltaPct:    pctDelta(currLoad, prevLoad),
+		Status:      "good",
+		Sparkline:   sysSparkline(curr, func(s database.SystemMetricsSnapshot) float64 { return s.LoadAverage1 }, 30),
+		Description: "1-minute load average across the window. Reported by the agent's host collector.",
+		Source:      sourceHost,
+		SourceLabel: sourceLabelHost,
+	})
+
+	return cards, nil
+}
+
+// Source identifiers + display labels. Defined as constants so handlers
+// and templates stay aligned and a typo doesn't silently drop a card from
+// the filtered view.
+const (
+	sourceHAProxy      = "haproxy"
+	sourceLabelHAProxy = "HAProxy"
+	sourceHost         = "host"
+	sourceLabelHost    = "Host"
+)
 
 // APIMetricsErrorBreakdownHandler powers the "Error Insights" panel: a
 // three-column view of top-N backends, source IPs, and countries

--- a/gearbox/internal/framework/handler/api_metrics_insights.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights.go
@@ -88,7 +88,7 @@ func (h *Handler) APIMetricsSummaryHandler(w http.ResponseWriter, r *http.Reques
 	// down to nothing.
 	haproxyAvailable := true
 	if caps, ok := h.getBoxCapabilities(boxID); ok && caps != nil {
-		if entry, present := caps.Entry("haproxy"); present {
+		if entry, present := caps.Entry(sourceHAProxy); present {
 			haproxyAvailable = entry.IsAvailable()
 		}
 	}

--- a/gearbox/internal/framework/handler/api_metrics_insights_helpers.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights_helpers.go
@@ -163,3 +163,53 @@ func statusFromCount(count int64, warnAt, badAt int64) string {
 	}
 	return "good"
 }
+
+// sysField mirrors snapshotField for SystemMetricsSnapshot rows, so the
+// host KPI cards can reuse the same aggregate/sparkline shape as the
+// HAProxy cards without templated generics.
+type sysField func(s database.SystemMetricsSnapshot) float64
+
+// avgPositiveSysField is the SystemMetricsSnapshot counterpart of
+// avgPositiveStat — averages f over rows where f(s) > 0 so empty buckets
+// don't pull down legitimate readings.
+func avgPositiveSysField(curr []database.SystemMetricsSnapshot, f sysField) float64 {
+	var sum float64
+	var n int
+	for i := range curr {
+		v := f(curr[i])
+		if v > 0 {
+			sum += v
+			n++
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+// sysSparkline downsamples a SystemMetricsSnapshot slice to ~points values
+// for KPI-card sparklines. Mirrors statSparkline so host and HAProxy
+// cards render identically.
+func sysSparkline(curr []database.SystemMetricsSnapshot, f sysField, points int) []float64 {
+	if len(curr) == 0 {
+		return []float64{}
+	}
+	if len(curr) <= points {
+		out := make([]float64, len(curr))
+		for i := range curr {
+			out[i] = f(curr[i])
+		}
+		return out
+	}
+	out := make([]float64, 0, points)
+	step := float64(len(curr)) / float64(points)
+	for i := 0; i < points; i++ {
+		idx := int(float64(i) * step)
+		if idx >= len(curr) {
+			idx = len(curr) - 1
+		}
+		out = append(out, f(curr[idx]))
+	}
+	return out
+}

--- a/gearbox/internal/framework/handler/api_metrics_insights_test.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights_test.go
@@ -134,6 +134,46 @@ func TestAvgPositiveStatSkipsZeros(t *testing.T) {
 	}
 }
 
+func TestAvgPositiveSysFieldSkipsZeros(t *testing.T) {
+	rows := []database.SystemMetricsSnapshot{
+		{MemoryUsagePercent: 40},
+		{MemoryUsagePercent: 0}, // empty bucket — should be skipped
+		{MemoryUsagePercent: 60},
+	}
+	got := avgPositiveSysField(rows, func(s database.SystemMetricsSnapshot) float64 { return s.MemoryUsagePercent })
+	if got != 50 {
+		t.Errorf("expected avg of (40, 60) = 50, got %v", got)
+	}
+}
+
+func TestSysSparklineDownsamples(t *testing.T) {
+	rows := make([]database.SystemMetricsSnapshot, 100)
+	for i := range rows {
+		rows[i].MemoryUsagePercent = float64(i)
+	}
+	out := sysSparkline(rows, func(s database.SystemMetricsSnapshot) float64 { return s.MemoryUsagePercent }, 30)
+	if len(out) != 30 {
+		t.Errorf("expected 30 sparkline points, got %d", len(out))
+	}
+	if out[0] != 0 {
+		t.Errorf("first point should be 0, got %v", out[0])
+	}
+	if out[29] < 90 {
+		t.Errorf("last point should be near series end, got %v", out[29])
+	}
+}
+
+func TestSysSparklineShortSeriesPassThrough(t *testing.T) {
+	rows := []database.SystemMetricsSnapshot{
+		{MemoryUsagePercent: 10},
+		{MemoryUsagePercent: 20},
+	}
+	out := sysSparkline(rows, func(s database.SystemMetricsSnapshot) float64 { return s.MemoryUsagePercent }, 30)
+	if len(out) != 2 {
+		t.Errorf("expected pass-through of 2 points, got %d", len(out))
+	}
+}
+
 func TestParseHAProxyLogLine_5xx(t *testing.T) {
 	// Representative HAProxy HTTP log line with a 502 response.
 	raw := `Apr 14 02:13:45 lighthugger haproxy[1234]: 203.0.113.42:51234 [14/Apr/2026:02:13:45.123] https-in~ app-backend/server1 0/0/1/0/1 502 1234 - - ---- 5/5/0/0/0 0/0 "GET /api/widgets HTTP/1.1"`

--- a/gearbox/internal/framework/handler/gears.go
+++ b/gearbox/internal/framework/handler/gears.go
@@ -105,19 +105,13 @@ const capabilitiesFetchTimeout = 3 * time.Second
 // agent is unreachable or running a version without the capabilities
 // endpoint, we surface the full gear list so users aren't locked out of
 // configuring boxes mid-upgrade. Non-mapped gears are always retained.
+//
+// Uses Handler.capabilities so repeated renders within the cache TTL share
+// one upstream fetch instead of one round-trip per render.
 func (h *Handler) filterGearsByAgentCapabilities(boxID string, gears []database.Gear) []database.Gear {
-	serverConfig, exists := h.getServerConfig(boxID)
-	if !exists || !serverConfig.UsesAgentAPI() {
-		return gears
-	}
-
-	// Short timeout — this call sits on the critical path of every Gears
-	// page render, so a 30s default would freeze the UI when the box is
-	// down. Fail-open if it times out.
-	client := agent.NewClientWithTimeout(serverConfig.AgentURL, serverConfig.APIKey, capabilitiesFetchTimeout)
-	caps, err := client.GetCapabilities()
-	if err != nil {
-		h.logger.Debug("capabilities fetch failed; showing all gears", "box_id", boxID, "error", err)
+	caps, ok := h.getBoxCapabilities(boxID)
+	if !ok {
+		// Either not agent-backed, or fetch failed. Fail-open.
 		return gears
 	}
 
@@ -128,7 +122,7 @@ func (h *Handler) filterGearsByAgentCapabilities(boxID string, gears []database.
 			out = append(out, g)
 			continue
 		}
-		entry, present := caps.Gears[agentName]
+		entry, present := caps.Entry(agentName)
 		if !present {
 			// Agent didn't report this gear at all — keep it (older agent
 			// or gear not yet probe-aware).

--- a/gearbox/internal/framework/handler/handler.go
+++ b/gearbox/internal/framework/handler/handler.go
@@ -7,14 +7,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+	"github.com/sarg3nt/gearbox/internal/framework/auth"
 	"github.com/sarg3nt/gearbox/internal/framework/collector"
 	"github.com/sarg3nt/gearbox/internal/framework/database"
-	"github.com/sarg3nt/gearbox/internal/framework/auth"
 	"github.com/sarg3nt/gearbox/internal/framework/events"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
 	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
 	"github.com/sarg3nt/gearbox/internal/framework/services/email"
 	"github.com/sarg3nt/gearbox/internal/framework/services/geoip"
-	"github.com/sarg3nt/gearbox/internal/framework/models"
 )
 
 // Handler holds dependencies for HTTP handlers.
@@ -31,6 +32,12 @@ type Handler struct {
 	eventHub         *events.Hub
 	wsManager        *collector.WebSocketManager
 	geoipClient      *geoip.Client
+
+	// capabilities caches per-box probe tables so gear-page handlers don't
+	// fire a fresh agent call on every render. TTL is short enough that a
+	// restarted agent's new probe table shows up within minutes; reconnect
+	// events explicitly invalidate for an immediate refresh.
+	capabilities *agent.CapabilitiesCache
 
 	// Config redactor for hiding sensitive values (e.g., stats auth passwords)
 	configRedactor *ConfigRedactor
@@ -83,9 +90,46 @@ func NewHandler(
 		encryptor:       encryptor,
 		registry:        registry,
 		geoipClient:     geoip.NewClient(),
+		capabilities:    agent.NewCapabilitiesCache(capabilityCacheTTL, capabilitiesFetchTimeout),
 		configRedactor:  NewConfigRedactor(),
 		prevSourceData:  make(map[string]*trafficSourceSnapshot),
 		prevBackendData: make(map[string]*trafficBackendSnapshot),
+	}
+}
+
+// capabilityCacheTTL is the freshness window for cached agent probe tables.
+// Short enough that a restarted agent's new probe table shows up without
+// operator intervention; long enough that the dashboard doesn't fire a
+// fresh agent call on every page render. Reconnect events invalidate
+// explicitly via Handler.invalidateBoxCapabilities for faster refresh.
+const capabilityCacheTTL = 5 * time.Minute
+
+// getBoxCapabilities returns the cached capabilities for boxID, or fetches
+// fresh ones if missing/stale. Returns (nil, false) when the box isn't
+// configured or doesn't use the agent API. Errors are logged at debug —
+// callers should fail open (show the full UI) when capabilities are
+// unknown, the same way filterGearsByAgentCapabilities does.
+func (h *Handler) getBoxCapabilities(boxID string) (*agent.BoxCapabilities, bool) {
+	serverConfig, exists := h.getServerConfig(boxID)
+	if !exists || !serverConfig.UsesAgentAPI() {
+		return nil, false
+	}
+	caps, err := h.capabilities.Get(boxID, serverConfig.AgentURL, serverConfig.APIKey)
+	if err != nil {
+		h.logger.Debug("capabilities fetch failed",
+			"box_id", boxID, "error", err)
+		return nil, false
+	}
+	return caps, caps != nil
+}
+
+// invalidateBoxCapabilities drops the cached probe table for boxID so the
+// next getBoxCapabilities call refetches. Wired to server.connected events
+// by handler.go's main wiring so a restarted agent's new probe table is
+// reflected immediately rather than at the next TTL boundary.
+func (h *Handler) invalidateBoxCapabilities(boxID string) {
+	if h.capabilities != nil {
+		h.capabilities.Invalidate(boxID)
 	}
 }
 
@@ -104,9 +148,34 @@ func (h *Handler) SetWebAuthnManager(mgr *auth.WebAuthnManager) {
 	h.webAuthnMgr = mgr
 }
 
-// SetEventHub sets the event hub for real-time updates.
+// SetEventHub sets the event hub for real-time updates and starts a
+// background subscriber that invalidates the per-box capabilities cache
+// whenever an agent (re)connects. This gives operators an immediate
+// refresh after restarting an agent — without it, a restarted agent's
+// new probe table would only surface at the next TTL boundary.
 func (h *Handler) SetEventHub(hub *events.Hub) {
 	h.eventHub = hub
+	if hub != nil {
+		go h.watchAgentReconnects(hub)
+	}
+}
+
+// watchAgentReconnects subscribes to server.connected events and drops
+// the cached capabilities for that box. Runs for the lifetime of the
+// process; exits when the hub closes the subscription channel during
+// shutdown.
+func (h *Handler) watchAgentReconnects(hub *events.Hub) {
+	sub := hub.Subscribe("capabilities-cache-invalidator", "")
+	defer hub.Unsubscribe(sub)
+	for evt := range sub.Events {
+		if evt.Type != events.EventTypeServerConnected {
+			continue
+		}
+		if evt.ServerID == "" {
+			continue
+		}
+		h.invalidateBoxCapabilities(evt.ServerID)
+	}
 }
 
 // SetWebSocketManager sets the WebSocket manager for Agent connections.

--- a/gearbox/internal/framework/handler/haproxy_config.go
+++ b/gearbox/internal/framework/handler/haproxy_config.go
@@ -248,6 +248,12 @@ func (h *Handler) HAProxyBoxUpdatePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The Agent URL or API key may have changed; drop any cached
+	// capabilities so the next render fetches against the new endpoint
+	// rather than serving stale data from the previous agent until the
+	// TTL expires.
+	h.invalidateBoxCapabilities(server.BoxID)
+
 	// Log audit
 	h.logAudit(r, user.ID, "haproxy_box_update", fmt.Sprintf("Updated HAProxy box: %s (%s)", server.Name, server.BoxID))
 
@@ -310,6 +316,11 @@ func (h *Handler) HAProxyBoxDeletePost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to delete server", http.StatusInternalServerError)
 		return
 	}
+
+	// Drop cached capabilities — even if the same box ID is recreated
+	// later, it's likely a different host and we shouldn't serve the
+	// previous probe table.
+	h.invalidateBoxCapabilities(server.BoxID)
 
 	// Log audit
 	h.logAudit(r, user.ID, "haproxy_box_delete", fmt.Sprintf("Deleted HAProxy box: %s (%s)", server.Name, server.BoxID))

--- a/gearbox/internal/framework/templates/pages/history.templ
+++ b/gearbox/internal/framework/templates/pages/history.templ
@@ -68,6 +68,14 @@ templ History(user *models.User, servers []models.BoxConfig) {
 		if len(servers) == 0 {
 			@components.InfoAlert("No servers configured.")
 		} else {
+			<!-- No-HAProxy banner — shown when the active box's agent
+			     reports no HAProxy gear. JS toggles visibility based on
+			     /api/{boxID}/capabilities. -->
+			<div id="no-haproxy-banner" class="hidden mb-4 rounded-lg border border-blue-200 dark:border-blue-900/40 bg-blue-50 dark:bg-blue-900/20 px-4 py-3 text-sm text-blue-900 dark:text-blue-100">
+				<strong class="font-semibold">No HAProxy detected on this host.</strong>
+				Showing host-level metrics only. Install HAProxy or enable the agent's HAProxy gear to see proxy metrics.
+			</div>
+
 			<!-- KPI summary band — populated by loadKPISummary().
 			     Each card shows a current value, delta vs the previous
 			     window of equal length, and an inline sparkline. -->
@@ -86,9 +94,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				<!-- Charts Grid - 4 columns on 2xl, 3 on xl, 2 on lg, 1 on smaller -->
 				<div id="charts-grid" class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
 					<!-- Sessions & Requests -->
-					<div id="card-sessions" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-sessions" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">Sessions & Requests</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Sessions & Requests</h4>
 							<button onclick="toggleFullscreen('card-sessions')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -101,9 +109,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 					</div>
 
 					<!-- Server Health -->
-					<div id="card-health" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-health" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">Server Health</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Server Health</h4>
 							<button onclick="toggleFullscreen('card-health')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -116,9 +124,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 					</div>
 
 					<!-- CPU Load -->
-					<div id="card-cpu" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-cpu" data-source="host" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">CPU Load</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> CPU Load</h4>
 							<button onclick="toggleFullscreen('card-cpu')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -131,9 +139,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 					</div>
 
 					<!-- Memory Usage -->
-					<div id="card-memory" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-memory" data-source="host" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">Memory Usage</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Memory Usage</h4>
 							<button onclick="toggleFullscreen('card-memory')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -146,9 +154,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 					</div>
 
 					<!-- Network Traffic -->
-					<div id="card-network" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-network" data-source="host" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">Network Throughput</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Network Throughput</h4>
 							<button onclick="toggleFullscreen('card-network')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -161,9 +169,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 					</div>
 
 					<!-- Response Times -->
-					<div id="card-response-time" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-response-time" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">Response Times</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Response Times</h4>
 							<button onclick="toggleFullscreen('card-response-time')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -176,9 +184,9 @@ templ History(user *models.User, servers []models.BoxConfig) {
 					</div>
 
 					<!-- Error Rates -->
-					<div id="card-errors" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+					<div id="card-errors" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300">Error Rates (5xx)</h4>
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Error Rates (5xx)</h4>
 							<button onclick="toggleFullscreen('card-errors')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -198,12 +206,12 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			     countries. Each row is clickable and opens the drill-down
 			     drawer. The panel renders nothing when there are no errors
 			     in the window — silence is the desired state. -->
-			<div id="error-insights-section" class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6">
+			<div id="error-insights-section" data-source="haproxy" class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6">
 				<div class="flex items-center justify-between mb-4">
 					<div>
-						<h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100">Error Insights</h3>
+						<h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100">HAProxy Error Insights</h3>
 						<p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-							Where the 4xx/5xx responses in this window are coming from. Click any row to drill in.
+							Where the 4xx/5xx responses in this window are coming from, as reported by HAProxy logs. Click any row to drill in.
 						</p>
 					</div>
 					<button
@@ -351,6 +359,36 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			height: 24px;
 			pointer-events: none;
 		}
+		/* Source attribution. Used on chart-card titles and KPI cards so the
+		   reader can tell at a glance which collector produced the metric. */
+		.source-tag {
+			display: inline-block;
+			font-size: 0.7rem;
+			font-weight: 600;
+			letter-spacing: 0.02em;
+			text-transform: uppercase;
+			padding: 0.05rem 0.4rem;
+			margin-right: 0.4rem;
+			border-radius: 9999px;
+			background: #eef2ff;
+			color: #4338ca;
+			vertical-align: 0.15em;
+		}
+		.dark .source-tag { background: rgba(99, 102, 241, 0.15); color: #a5b4fc; }
+		.kpi-source-badge {
+			position: absolute;
+			top: 0.5rem;
+			right: 0.5rem;
+			font-size: 0.6rem;
+			font-weight: 600;
+			letter-spacing: 0.02em;
+			text-transform: uppercase;
+			padding: 0.05rem 0.4rem;
+			border-radius: 9999px;
+			background: #eef2ff;
+			color: #4338ca;
+		}
+		.dark .kpi-source-badge { background: rgba(99, 102, 241, 0.15); color: #a5b4fc; }
 
 		/* Error Insights tables */
 		.ei-col h4 {
@@ -794,6 +832,12 @@ templ History(user *models.User, servers []models.BoxConfig) {
 				return;
 			}
 
+			// Capability gating runs before chart rendering so HAProxy
+			// sections are hidden up-front rather than flickering in then
+			// out. Failures here fail open — the rest of the page still
+			// renders the same as before.
+			await applyCapabilities(serverID);
+
 			try {
 				// Fetch stats history
 				const statsResponse = await fetch(`/api/${serverID}/history/stats?hours=${hours}`);
@@ -820,6 +864,38 @@ templ History(user *models.User, servers []models.BoxConfig) {
 
 			} catch (error) {
 				console.error('Failed to load history data:', error);
+			}
+		}
+
+		// applyCapabilities fetches the per-box probe table and toggles
+		// HAProxy-specific UI based on whether the haproxy gear is
+		// available. Host-sourced cards always remain visible. Errors
+		// fail open: the dashboard reverts to "HAProxy assumed present"
+		// rather than locking the user out of cards they may need.
+		async function applyCapabilities(serverID) {
+			let haproxyAvailable = true;
+			try {
+				const res = await fetch('/api/' + serverID + '/capabilities');
+				if (res.ok) {
+					const data = await res.json();
+					const entry = data && data.gears && data.gears.haproxy;
+					if (entry) {
+						haproxyAvailable = entry.status === 'available';
+					}
+				}
+			} catch (err) {
+				console.debug('capabilities fetch failed; assuming haproxy present', err);
+			}
+
+			// Toggle every element tagged data-source="haproxy". Includes
+			// the chart cards plus the Error Insights panel.
+			document.querySelectorAll('[data-source="haproxy"]').forEach(function(el) {
+				el.classList.toggle('hidden', !haproxyAvailable);
+			});
+
+			const banner = document.getElementById('no-haproxy-banner');
+			if (banner) {
+				banner.classList.toggle('hidden', haproxyAvailable);
 			}
 		}
 
@@ -1414,8 +1490,15 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			band.innerHTML = cards.map(function(c) {
 				const valueText = formatKPIValue(c);
 				const deltaHTML = formatKPIDelta(c);
+				// Source badge tells the reader which collector produced the
+				// number. Server emits source/source_label on every card;
+				// legacy responses without these fields render no badge.
+				const sourceBadge = c.source_label
+					? '<span class="kpi-source-badge" title="Reported by ' + escapeAttr(c.source_label) + '">' + escapeHtml(c.source_label) + '</span>'
+					: '';
 				return ''
-					+ '<div class="kpi-card status-' + (c.status || 'good') + '" title="' + escapeAttr(c.description || '') + '">'
+					+ '<div class="kpi-card status-' + (c.status || 'good') + '" data-source="' + escapeAttr(c.source || '') + '" title="' + escapeAttr(c.description || '') + '">'
+					+   sourceBadge
 					+   '<div class="kpi-label">' + escapeHtml(c.label) + '</div>'
 					+   '<div class="kpi-value">' + valueText + '</div>'
 					+   '<div class="kpi-delta-row mt-1">' + deltaHTML + '</div>'

--- a/gearbox/internal/framework/templates/pages/history.templ
+++ b/gearbox/internal/framework/templates/pages/history.templ
@@ -68,12 +68,16 @@ templ History(user *models.User, servers []models.BoxConfig) {
 		if len(servers) == 0 {
 			@components.InfoAlert("No servers configured.")
 		} else {
-			<!-- No-HAProxy banner — shown when the active box's agent
-			     reports no HAProxy gear. JS toggles visibility based on
-			     /api/{boxID}/capabilities. -->
+			<!-- HAProxy-unavailable banner — shown when the active box's
+			     agent reports the HAProxy gear is anything other than
+			     'available'. JS in applyCapabilities() picks message
+			     text from the capability entry's status + reason so the
+			     copy matches reality: a missing binary (not_installed)
+			     gets different guidance than an unreachable socket
+			     (inaccessible) or an operator-disabled gear (disabled). -->
 			<div id="no-haproxy-banner" class="hidden mb-4 rounded-lg border border-blue-200 dark:border-blue-900/40 bg-blue-50 dark:bg-blue-900/20 px-4 py-3 text-sm text-blue-900 dark:text-blue-100">
-				<strong class="font-semibold">No HAProxy detected on this host.</strong>
-				Showing host-level metrics only. Install HAProxy or enable the agent's HAProxy gear to see proxy metrics.
+				<strong id="no-haproxy-banner-title" class="font-semibold">HAProxy metrics unavailable on this host.</strong>
+				<span id="no-haproxy-banner-detail">Showing host-level metrics only.</span>
 			</div>
 
 			<!-- KPI summary band — populated by loadKPISummary().
@@ -874,13 +878,14 @@ templ History(user *models.User, servers []models.BoxConfig) {
 		// rather than locking the user out of cards they may need.
 		async function applyCapabilities(serverID) {
 			let haproxyAvailable = true;
+			let haproxyEntry = null;
 			try {
 				const res = await fetch('/api/' + serverID + '/capabilities');
 				if (res.ok) {
 					const data = await res.json();
-					const entry = data && data.gears && data.gears.haproxy;
-					if (entry) {
-						haproxyAvailable = entry.status === 'available';
+					haproxyEntry = data && data.gears && data.gears.haproxy;
+					if (haproxyEntry) {
+						haproxyAvailable = haproxyEntry.status === 'available';
 					}
 				}
 			} catch (err) {
@@ -896,7 +901,50 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			const banner = document.getElementById('no-haproxy-banner');
 			if (banner) {
 				banner.classList.toggle('hidden', haproxyAvailable);
+				if (!haproxyAvailable) {
+					updateNoHAProxyBanner(haproxyEntry);
+				}
 			}
+		}
+
+		// updateNoHAProxyBanner picks user-facing copy that matches the
+		// actual probe verdict — not_installed / inaccessible / disabled
+		// each get different guidance, and the agent's `reason` field is
+		// surfaced verbatim when present so operators see the exact
+		// detection failure.
+		function updateNoHAProxyBanner(entry) {
+			const titleEl = document.getElementById('no-haproxy-banner-title');
+			const detailEl = document.getElementById('no-haproxy-banner-detail');
+			if (!titleEl || !detailEl) return;
+
+			let title = 'HAProxy metrics unavailable on this host.';
+			let detail = 'Showing host-level metrics only.';
+
+			const status = entry && entry.status;
+			const reason = (entry && entry.reason) ? String(entry.reason) : '';
+
+			switch (status) {
+				case 'not_installed':
+					title = 'No HAProxy detected on this host.';
+					detail = 'Install HAProxy or enable the agent\'s HAProxy gear to see proxy metrics. Showing host-level metrics only.';
+					break;
+				case 'inaccessible':
+					title = 'HAProxy is installed but the agent can\'t reach its stats.';
+					detail = (reason ? reason + ' ' : '') + 'Showing host-level metrics only.';
+					break;
+				case 'disabled':
+					title = 'HAProxy gear disabled in agent configuration.';
+					detail = (reason ? reason + ' ' : '') + 'Showing host-level metrics only.';
+					break;
+				default:
+					// status === undefined (agent didn't surface haproxy at
+					// all — older agent or fetch failed). Keep the generic
+					// copy and don't pretend we know more than we do.
+					break;
+			}
+
+			titleEl.textContent = title;
+			detailEl.textContent = ' ' + detail;
 		}
 
 		// hoursToRange maps the hours-select dropdown value (e.g. "0.083",


### PR DESCRIPTION
## Summary

Lay the foundation for a source-agnostic Metrics gear by introducing the **MetricSource** concept end-to-end. The page now declares which collector produces each number ("HAProxy: Sessions & Requests", "Host: CPU Load", …) and gracefully degrades on boxes without HAProxy.

This PR lands phases 0-2 of [#91](https://github.com/sarg3nt/gearbox/issues/91). Each phase is independently valuable; together they ship the foundation every later phase (nginx, Apache, Caddy, Docker) builds on.

## Phase 0 — Capability manifest plumbing (dashboard side)

- New `agent.CapabilitiesCache` (5-min TTL, 3s fetch timeout, negative caching) memoises per-box probe tables so gear-page handlers don't fire a fresh agent call on every render.
- Handler-level `getBoxCapabilities()` + `BoxCapabilities` accessor with `Has` / `IsAvailable` / `Entry` helpers.
- Reconnect-driven invalidation: handler subscribes to `EventTypeServerConnected` and drops the cache for that box so a restarted agent's new probe table is reflected immediately rather than at the next TTL boundary.
- New `GET /api/{boxID}/capabilities` endpoint surfaces the cached manifest to the auth-scoped frontend.
- `filterGearsByAgentCapabilities` (issue #71) refactored onto the cache — removes one synchronous agent call per Gears-page render.

> Note: the agent's `/api/v1/system/capabilities` endpoint already shipped under #71. This PR adds the dashboard-side caching + accessor + endpoint the Phase 0 spec calls for.

## Phase 1 — Source attribution in the UI

- Chart card titles carry source-prefix badges ("HAProxy: …" or "Host: …") so the reader can tell which collector produced the metric at a glance.
- KPI cards render a small source badge in the upper-right corner; server emits `source` + `source_label` on every card.
- "Error Insights" → "HAProxy Error Insights" with explicit copy.

## Phase 2 — Graceful no-HAProxy mode

- `/api/{boxID}/metrics/summary` checks the haproxy capability and only emits HAProxy KPI cards when the gear is available; host KPIs (Memory %, Disk %, Load 1m) are always emitted from `system_metrics_history`.
- Frontend `applyCapabilities()` hides `[data-source="haproxy"]` chart cards + Error Insights when haproxy isn't available; shows an empty-state banner pointing to install / enable.
- **Fail-open everywhere** — capability fetches that error don't strip the page; the dashboard reverts to "HAProxy assumed present" rather than locking the user out of cards they may need.

## What's intentionally not in this PR

- **CPU%, uptime, failed-systemd KPIs** — the collector doesn't persist these in `system_metrics_history` today. They'll follow when the collector starts saving them.
- **Service detection (nginx, Apache, Caddy, Traefik)** — Phase 3 of the issue. Agent-side work; intentionally separate so this PR stays focused.
- **Per-source charts (nginx metrics, Caddy metrics, etc.)** — Phases 4+ of the issue.
- **Cross-source aggregates** — Phase 8.

## Test plan

- [x] `make test` — 9 packages pass on `gearbox`; no regressions on `gearbox-agent`.
- [x] New unit tests:
  - `CapabilitiesCache` — TTL caching, refresh past TTL, `Invalidate`, `InvalidateAll`, negative caching, nil-safety on `BoxCapabilities` accessors.
  - `avgPositiveSysField` + `sysSparkline` — host-KPI counterparts of the existing stat helpers.
- [x] `go vet ./...` clean across both modules.
- [ ] Manual smoke: `/history` on `light-hugger` (HAProxy box) shows HAProxy + Host KPIs and chart titles read "HAProxy: …" / "Host: …".
- [ ] Manual smoke: `/history` on a box without HAProxy (mjolnir?) shows the no-HAProxy banner, hides HAProxy cards and Error Insights, and renders just the Host KPI cards + Host chart cards.
- [ ] Manual smoke: reconnecting an agent updates capabilities within seconds (not 5 min).

## References

- Closes the Phase 0-2 portion of #91 (issue tracks the full roadmap through Phase 8).
- Follow-up PR: agent-side discovery (nginx/Apache/Caddy/Traefik) — Phase 3.
- Architecture / phasing doc: [`docs/research/metrics-source-agnostic.md`](docs/research/metrics-source-agnostic.md).