### PR TITLE
feat(#95): agent — metric-source primary selection + per-category overrides

### DIFF
--- a/gearbox-agent/README.md
+++ b/gearbox-agent/README.md
@@ -206,6 +206,26 @@ HAPROXY_STATS_USER=admin
 HAPROXY_STATS_PASSWORD=secret
 ```
 
+### Metric-source overrides
+
+Most hosts have one obvious producer per metric category. Where two coexist — for example HAProxy fronting nginx, with both genuinely serving HTTP — the agent auto-picks a primary using a built-in preference list and surfaces it in the capability manifest. Operators can override that pick when auto-detection chooses wrong on their host.
+
+Auto-detection is the default. The override env vars below exist for the rare edge cases.
+
+```bash
+# Force a specific gear as the primary for HTTP-request metrics
+# (request volume, response codes, response times, vhost breakdowns).
+# Valid values match gear identifiers in /api/v1/system/capabilities —
+# today only "haproxy" is implemented; more land with issue #95.
+GEARBOX_AGENT_HTTP_SOURCE=nginx
+```
+
+Override behaviour:
+
+- Names are case-insensitive and trimmed (`HAProxy` and `haproxy` both work).
+- An override pointing at a gear that didn't probe Available, or doesn't produce data for the category, logs a warning at startup and **falls back to auto-detect** — locking out HTTP metrics because the override's target isn't installed on this box would be worse than serving auto-picked data.
+- The selected primary plus the chosen reason and the alternatives that were also available appear in `/api/v1/system/capabilities` under `primary_sources` so dashboards and humans can confirm the resolution.
+
 ## Authentication
 
 ### API Key

--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -383,6 +383,7 @@ func main() {
 		HAProxyStatsPassword: cfg.HAProxyStatsPassword,
 		HAProxyConfigPath:    cfg.HAProxyConfigFile,
 		CertbotTimer:         cfg.CertbotTimer,
+		SourceOverrides:      buildSourceOverrides(cfg),
 	}
 
 	// Create plugin manager
@@ -564,4 +565,17 @@ func main() {
 	}
 
 	logger.Info("Server stopped")
+}
+
+// buildSourceOverrides packs the per-category override env vars from
+// the agent's Config into the category-keyed map that Dependencies
+// (and the manager's primary-source resolver) consume. Empty values
+// are omitted so the map only contains explicit operator picks —
+// callers downstream treat absence as "auto-detect".
+func buildSourceOverrides(cfg *config.Config) map[gear.MetricCategory]string {
+	out := make(map[gear.MetricCategory]string)
+	if cfg.HTTPSource != "" {
+		out[gear.CategoryHTTPRequests] = cfg.HTTPSource
+	}
+	return out
 }

--- a/gearbox-agent/internal/framework/config/config.go
+++ b/gearbox-agent/internal/framework/config/config.go
@@ -66,6 +66,21 @@ type Config struct {
 	// endpoint + schema list to unauthenticated callers in production. See
 	// 2026-05 security audit P3-2.
 	SwaggerEnabled bool
+
+	// Metric-source overrides. Each one points a single metric category
+	// at a specific gear, bypassing auto-detection. Empty = pure
+	// auto-detection (built-in preference order). Lowercased at load
+	// time; the manager validates that each named gear is actually
+	// available before honouring the override (falls back to auto and
+	// warns otherwise).
+	//
+	// Background: most hosts have one obvious producer per metric
+	// category. When two coexist (e.g. HAProxy + nginx both serving
+	// HTTP), the agent picks one as primary; this override lets the
+	// operator force the choice for boxes where the built-in
+	// preference picks wrong. See [docs/source-detection.md] /
+	// issue #95.
+	HTTPSource string // GEARBOX_AGENT_HTTP_SOURCE — primary for CategoryHTTPRequests
 }
 
 // DefaultConfig returns the default configuration.
@@ -161,7 +176,20 @@ func Load() (*Config, error) {
 	// Swagger UI off by default; opt in for dev / API debugging.
 	cfg.SwaggerEnabled = os.Getenv("HAPROXY_AGENT_SWAGGER_ENABLED") == "true"
 
+	// Metric-source overrides. Lowercased + trimmed so 'HAProxy ' and
+	// 'haproxy' both match the gear's Info().Name. Empty = auto-detect.
+	cfg.HTTPSource = normaliseSourceOverride(os.Getenv("GEARBOX_AGENT_HTTP_SOURCE"))
+
 	return cfg, nil
+}
+
+// normaliseSourceOverride trims + lowercases an operator-supplied gear
+// name so case / whitespace differences ('HAProxy ' vs 'haproxy') don't
+// cause silent misses against Info().Name. Returns "" for an empty or
+// whitespace-only input, which downstream callers treat as "no
+// override, auto-detect".
+func normaliseSourceOverride(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
 }
 
 // Validate validates the configuration.

--- a/gearbox-agent/internal/framework/config/config_test.go
+++ b/gearbox-agent/internal/framework/config/config_test.go
@@ -395,16 +395,10 @@ func TestNormaliseSourceOverride(t *testing.T) {
 }
 
 func TestLoad_HTTPSourceOverride(t *testing.T) {
-	saved := os.Getenv("GEARBOX_AGENT_HTTP_SOURCE")
-	t.Cleanup(func() {
-		if saved != "" {
-			os.Setenv("GEARBOX_AGENT_HTTP_SOURCE", saved)
-		} else {
-			os.Unsetenv("GEARBOX_AGENT_HTTP_SOURCE")
-		}
-	})
-
-	os.Setenv("GEARBOX_AGENT_HTTP_SOURCE", " Nginx ")
+	// t.Setenv handles save/restore automatically and prevents
+	// parallel-test interference; the old os.Setenv + t.Cleanup pattern
+	// would leak the env var if the test panicked before Cleanup ran.
+	t.Setenv("GEARBOX_AGENT_HTTP_SOURCE", " Nginx ")
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -415,13 +409,12 @@ func TestLoad_HTTPSourceOverride(t *testing.T) {
 }
 
 func TestLoad_HTTPSourceDefaultsEmpty(t *testing.T) {
-	saved := os.Getenv("GEARBOX_AGENT_HTTP_SOURCE")
+	// Unset within the test; t.Setenv with an empty string only marks
+	// the env var for restoration but doesn't unset it, so explicit
+	// Unsetenv is the right tool when the test specifically needs the
+	// var absent.
+	t.Setenv("GEARBOX_AGENT_HTTP_SOURCE", "") // record original for restore
 	os.Unsetenv("GEARBOX_AGENT_HTTP_SOURCE")
-	t.Cleanup(func() {
-		if saved != "" {
-			os.Setenv("GEARBOX_AGENT_HTTP_SOURCE", saved)
-		}
-	})
 
 	cfg, err := Load()
 	if err != nil {

--- a/gearbox-agent/internal/framework/config/config_test.go
+++ b/gearbox-agent/internal/framework/config/config_test.go
@@ -375,3 +375,59 @@ func TestGetEnvDurationSecondsOrDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestNormaliseSourceOverride(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"haproxy", "haproxy"},
+		{"HAProxy", "haproxy"},
+		{" HAPROXY ", "haproxy"},
+		{"  Nginx  ", "nginx"},
+	}
+	for _, tc := range cases {
+		if got := normaliseSourceOverride(tc.in); got != tc.want {
+			t.Errorf("normaliseSourceOverride(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLoad_HTTPSourceOverride(t *testing.T) {
+	saved := os.Getenv("GEARBOX_AGENT_HTTP_SOURCE")
+	t.Cleanup(func() {
+		if saved != "" {
+			os.Setenv("GEARBOX_AGENT_HTTP_SOURCE", saved)
+		} else {
+			os.Unsetenv("GEARBOX_AGENT_HTTP_SOURCE")
+		}
+	})
+
+	os.Setenv("GEARBOX_AGENT_HTTP_SOURCE", " Nginx ")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.HTTPSource != "nginx" {
+		t.Errorf("HTTPSource = %q, want %q (trimmed + lowercased)", cfg.HTTPSource, "nginx")
+	}
+}
+
+func TestLoad_HTTPSourceDefaultsEmpty(t *testing.T) {
+	saved := os.Getenv("GEARBOX_AGENT_HTTP_SOURCE")
+	os.Unsetenv("GEARBOX_AGENT_HTTP_SOURCE")
+	t.Cleanup(func() {
+		if saved != "" {
+			os.Setenv("GEARBOX_AGENT_HTTP_SOURCE", saved)
+		}
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.HTTPSource != "" {
+		t.Errorf("HTTPSource = %q, want empty (auto-detect)", cfg.HTTPSource)
+	}
+}

--- a/gearbox-agent/internal/framework/gear/dependencies.go
+++ b/gearbox-agent/internal/framework/gear/dependencies.go
@@ -45,6 +45,14 @@ type Dependencies struct {
 
 	// CertbotTimer is the name of the certbot systemd timer.
 	CertbotTimer string
+
+	// SourceOverrides maps metric categories to an operator-chosen
+	// primary gear name, bypassing auto-detection for that category.
+	// Empty map (or missing key) means auto-detect. Sourced from
+	// per-category env vars at startup (GEARBOX_AGENT_HTTP_SOURCE for
+	// CategoryHTTPRequests, etc.). Names are pre-lowercased to match
+	// Info().Name lookups in the manager.
+	SourceOverrides map[MetricCategory]string
 }
 
 // Common event types used across plugins.

--- a/gearbox-agent/internal/framework/gear/manager.go
+++ b/gearbox-agent/internal/framework/gear/manager.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -65,7 +66,9 @@ func NewManager(deps Dependencies, logger *slog.Logger) *Manager {
 // ProbeAll runs each gear's Probe (if implemented) and records the verdict.
 // Gears that don't implement ProbeableGear are treated as always-available.
 // After all gears are probed, a summary table is written to the configured
-// table writer (defaults to os.Stderr → systemd journal) and a structured
+// table writer (defaults to os.Stderr → systemd journal), the primary
+// metric source per category is resolved (logging override warnings for
+// any operator-supplied overrides that don't resolve), and a structured
 // completion line is logged via slog.
 //
 // Must be called before InitializeAll. The verdict drives whether each
@@ -84,6 +87,32 @@ func (m *Manager) ProbeAll(ctx context.Context) {
 	}
 
 	m.logProbeTable()
+	m.logPrimarySources()
+}
+
+// logPrimarySources resolves and logs the primary metric source per
+// category. Runs at startup (from ProbeAll) so override warnings appear
+// in the journal alongside the probe table, and operators can confirm at
+// a glance which source the dashboard will treat as authoritative.
+// Categories with no available producer are silently skipped — they're
+// just absent from this host, no log noise warranted.
+func (m *Manager) logPrimarySources() {
+	picks := m.ResolvePrimarySources()
+	if len(picks) == 0 {
+		return
+	}
+	for _, cat := range AllMetricCategories() {
+		sel, ok := picks[cat]
+		if !ok {
+			continue
+		}
+		m.logger.Info("primary metric source resolved",
+			"category", cat,
+			"source", sel.Source,
+			"reason", sel.Reason,
+			"alternatives", sel.Alternatives,
+		)
+	}
 }
 
 // probeOrDefault calls a gear's Probe if it implements ProbeableGear, or
@@ -477,6 +506,205 @@ type CapabilityEntry struct {
 // CapabilitiesResponse is the envelope for GET /api/v1/system/capabilities.
 type CapabilitiesResponse struct {
 	Gears map[string]CapabilityEntry `json:"gears"`
+
+	// PrimarySources keys each MetricCategory to the gear that's been
+	// chosen as the authoritative producer on this host. Categories
+	// with no available producer are omitted entirely (rather than
+	// surfacing as an empty SourceSelection) so the dashboard can
+	// distinguish "no category" from "category exists but unselected".
+	PrimarySources map[MetricCategory]SourceSelection `json:"primary_sources,omitempty"`
+}
+
+// preferenceOrder ranks gears for each metric category when multiple
+// produce the same data and the operator hasn't set an override. First
+// match wins. The order encodes opinions about what's most likely to be
+// the user's "real" source on a homelab-flavoured deploy:
+//
+//   - HAProxy comes first because in this project HAProxy is the L7
+//     entry point and its stats see the union of every backend's
+//     traffic; other web servers tend to be backends behind it. A box
+//     with both an HAProxy frontend AND a backend nginx benefits from
+//     the proxy view first.
+//   - nginx > Apache > Caddy > Traefik is rough order-of-prevalence
+//     across the homelab fleet. Operators on a Traefik-primary host
+//     will simply set GEARBOX_AGENT_HTTP_SOURCE=traefik; this list
+//     just makes the no-config case do something reasonable rather
+//     than picking arbitrarily.
+//
+// Entries that aren't yet implemented as gears are harmless — the
+// resolver only considers gears that probed Available.
+var preferenceOrder = map[MetricCategory][]string{
+	CategoryHTTPRequests: {"haproxy", "nginx", "apache", "caddy", "traefik"},
+}
+
+// ResolvePrimarySources picks the primary metric source for each
+// defined MetricCategory based on the probe table, the built-in
+// preference order, and any operator overrides in deps.SourceOverrides.
+// The returned map omits any category for which no available producer
+// exists — callers should treat missing keys as "no primary".
+//
+// Resolution rules per category:
+//  1. If deps.SourceOverrides[category] names a gear that probed
+//     Available AND is a registered producer (implements
+//     MetricSourceGear and declares the category), use it. The
+//     SourceSelection.Reason names the env var so operators can
+//     verify the override took effect.
+//  2. Otherwise walk preferenceOrder[category] and pick the first
+//     gear that probed Available + is a registered producer.
+//  3. If neither path finds anything, the category is omitted.
+//
+// Overrides that name an unknown gear, a not-Available gear, or a gear
+// that doesn't produce data for this category log a warning at startup
+// and fall through to auto-detection — operators templating env files
+// across heterogeneous fleets shouldn't lose metrics because one host
+// doesn't have the override's target installed.
+func (m *Manager) ResolvePrimarySources() map[MetricCategory]SourceSelection {
+	probed := m.ProbeResults()
+
+	// Build category-to-producers from the registered gears that
+	// implement MetricSourceGear. Producers are filtered to only those
+	// that probed Available — a not-installed nginx isn't a candidate.
+	producers := make(map[MetricCategory][]string)
+	registeredFor := make(map[MetricCategory]map[string]struct{})
+	for _, p := range All() {
+		name := p.Info().Name
+		src, ok := p.(MetricSourceGear)
+		if !ok {
+			continue
+		}
+		for _, cat := range src.MetricCategories() {
+			if registeredFor[cat] == nil {
+				registeredFor[cat] = make(map[string]struct{})
+			}
+			registeredFor[cat][name] = struct{}{}
+			if r, ok := probed[name]; ok && r.IsAvailable() {
+				producers[cat] = append(producers[cat], name)
+			}
+		}
+	}
+
+	out := make(map[MetricCategory]SourceSelection)
+	for _, cat := range AllMetricCategories() {
+		available := producers[cat]
+		if len(available) == 0 {
+			// No producer — omit the category entirely. The dashboard
+			// reads missing key as "no primary for this category".
+			continue
+		}
+
+		// Order alternatives by the built-in preference so the
+		// dashboard's "switch source" UI presents a stable list.
+		ordered := orderByPreference(available, preferenceOrder[cat])
+
+		// Operator override: must be available AND a registered
+		// producer. Fall through with a warning otherwise.
+		override := strings.ToLower(strings.TrimSpace(deps_override(m.deps, cat)))
+		if override != "" {
+			if _, isProducer := registeredFor[cat][override]; !isProducer {
+				m.logger.Warn("source override names a gear that doesn't produce this metric category; falling back to auto-detect",
+					"category", cat,
+					"override", override,
+					"env_var", overrideEnvVarFor(cat))
+			} else if !containsString(ordered, override) {
+				m.logger.Warn("source override names an unavailable gear; falling back to auto-detect",
+					"category", cat,
+					"override", override,
+					"env_var", overrideEnvVarFor(cat))
+			} else {
+				out[cat] = SourceSelection{
+					Category:     cat,
+					Source:       override,
+					Reason:       "operator override via " + overrideEnvVarFor(cat),
+					Alternatives: withoutString(ordered, override),
+				}
+				continue
+			}
+		}
+
+		// Auto-detect from preference order.
+		out[cat] = SourceSelection{
+			Category:     cat,
+			Source:       ordered[0],
+			Reason:       "auto-detected from preference order",
+			Alternatives: ordered[1:],
+		}
+	}
+
+	return out
+}
+
+// deps_override fetches the operator's override for a category from
+// Dependencies. Standalone (not a method) so tests that build
+// Dependencies directly stay readable.
+func deps_override(d Dependencies, cat MetricCategory) string {
+	if d.SourceOverrides == nil {
+		return ""
+	}
+	return d.SourceOverrides[cat]
+}
+
+// overrideEnvVarFor names the env var that controls a category. Kept
+// in one place so warning messages and docs stay aligned with what
+// operators actually set in their env files.
+func overrideEnvVarFor(cat MetricCategory) string {
+	switch cat {
+	case CategoryHTTPRequests:
+		return "GEARBOX_AGENT_HTTP_SOURCE"
+	default:
+		return "(unknown category)"
+	}
+}
+
+// orderByPreference returns the subset of `available` ordered by where
+// each entry appears in `preferred`. Entries in `available` that
+// aren't in `preferred` get appended at the end (sorted alphabetically
+// so the result is deterministic across runs). Lets newer producers
+// that haven't been ranked yet still surface as alternatives without
+// editing preferenceOrder.
+func orderByPreference(available, preferred []string) []string {
+	have := make(map[string]struct{}, len(available))
+	for _, n := range available {
+		have[n] = struct{}{}
+	}
+
+	out := make([]string, 0, len(available))
+	used := make(map[string]struct{}, len(available))
+	for _, n := range preferred {
+		if _, ok := have[n]; ok {
+			out = append(out, n)
+			used[n] = struct{}{}
+		}
+	}
+	// Tack on any available producer not in the preference list,
+	// alphabetised for determinism.
+	var extras []string
+	for _, n := range available {
+		if _, ok := used[n]; !ok {
+			extras = append(extras, n)
+		}
+	}
+	sort.Strings(extras)
+	out = append(out, extras...)
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func withoutString(in []string, drop string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s != drop {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // RegisterSystemRoutes registers cross-cutting agent endpoints that aren't
@@ -488,12 +716,17 @@ func (m *Manager) RegisterSystemRoutes(r chi.Router) {
 }
 
 // handleCapabilities renders the probe table — every registered gear, its
-// verdict, reason, and any detected capability key-values. The dashboard
-// uses this to hide gears that can't run on a given box (issue #71 item 2).
+// verdict, reason, and any detected capability key-values — plus the
+// resolved primary metric source per category. The dashboard uses this
+// to hide gears that can't run on a given box (issue #71 item 2) and to
+// pick which source's data to render for each category (issue #91).
 func (m *Manager) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	plugins := All()
 	results := m.ProbeResults()
-	out := CapabilitiesResponse{Gears: make(map[string]CapabilityEntry, len(plugins))}
+	out := CapabilitiesResponse{
+		Gears:          make(map[string]CapabilityEntry, len(plugins)),
+		PrimarySources: m.ResolvePrimarySources(),
+	}
 	for _, p := range plugins {
 		name := p.Info().Name
 		out.Gears[name] = CapabilityEntry(results[name])

--- a/gearbox-agent/internal/framework/gear/manager.go
+++ b/gearbox-agent/internal/framework/gear/manager.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -96,7 +97,13 @@ func (m *Manager) ProbeAll(ctx context.Context) {
 // a glance which source the dashboard will treat as authoritative.
 // Categories with no available producer are silently skipped — they're
 // just absent from this host, no log noise warranted.
+//
+// Override-validation warnings are emitted here (once per agent start)
+// rather than from inside ResolvePrimarySources, so the API endpoint
+// that calls Resolve on every request doesn't replay the same warning
+// on every dashboard poll.
 func (m *Manager) logPrimarySources() {
+	m.ValidatePrimarySourceOverrides()
 	picks := m.ResolvePrimarySources()
 	if len(picks) == 0 {
 		return
@@ -537,6 +544,16 @@ var preferenceOrder = map[MetricCategory][]string{
 	CategoryHTTPRequests: {"haproxy", "nginx", "apache", "caddy", "traefik"},
 }
 
+// categoryEnvVar names the env var that controls each metric category's
+// primary-source override. Kept as a map (rather than a switch) so
+// adding a new category requires only an entry here — and the
+// exhaustiveness test in source_test.go fails until that entry exists,
+// preventing the "(unknown category)" placeholder from ever appearing
+// in operator-facing warnings or SourceSelection.Reason strings.
+var categoryEnvVar = map[MetricCategory]string{
+	CategoryHTTPRequests: "GEARBOX_AGENT_HTTP_SOURCE",
+}
+
 // ResolvePrimarySources picks the primary metric source for each
 // defined MetricCategory based on the probe table, the built-in
 // preference order, and any operator overrides in deps.SourceOverrides.
@@ -554,11 +571,56 @@ var preferenceOrder = map[MetricCategory][]string{
 //  3. If neither path finds anything, the category is omitted.
 //
 // Overrides that name an unknown gear, a not-Available gear, or a gear
-// that doesn't produce data for this category log a warning at startup
-// and fall through to auto-detection — operators templating env files
-// across heterogeneous fleets shouldn't lose metrics because one host
-// doesn't have the override's target installed.
+// that doesn't produce data for this category fall through to auto-
+// detection — operators templating env files across heterogeneous
+// fleets shouldn't lose metrics because one host doesn't have the
+// override's target installed. Warnings about mis-targeted overrides
+// are emitted **once at startup** by ValidatePrimarySourceOverrides,
+// not here, so the API endpoint that calls Resolve on every request
+// doesn't turn dashboard polling into log spam.
+//
+// The function is side-effect-free apart from reading the probe table,
+// safe to call concurrently from the capabilities API handler.
 func (m *Manager) ResolvePrimarySources() map[MetricCategory]SourceSelection {
+	picks, _ := m.resolvePrimarySources()
+	return picks
+}
+
+// ValidatePrimarySourceOverrides re-runs the resolver and logs a
+// warning for each operator override that doesn't apply on this host
+// — unknown gear, not-Available gear, or gear that doesn't produce
+// the category in question. Called once from ProbeAll so operators
+// see actionable warnings in journalctl at startup without the
+// /api/v1/system/capabilities endpoint replaying them on every poll.
+//
+// Returns the number of override entries that failed validation,
+// purely so tests can assert without parsing log output. Production
+// callers can ignore the return value.
+func (m *Manager) ValidatePrimarySourceOverrides() int {
+	_, invalid := m.resolvePrimarySources()
+	for _, inv := range invalid {
+		m.logger.Warn(inv.message,
+			"category", inv.category,
+			"override", inv.override,
+			"env_var", categoryEnvVar[inv.category])
+	}
+	return len(invalid)
+}
+
+// overrideValidationFailure captures one mis-targeted override so
+// ValidatePrimarySourceOverrides can log it from a single place
+// (consistent slog key-set) and tests can count failures.
+type overrideValidationFailure struct {
+	category MetricCategory
+	override string
+	message  string
+}
+
+// resolvePrimarySources does the actual work shared between Resolve
+// (silent) and Validate (logs warnings). Returns the picks plus any
+// override failures the caller may want to surface. Unexported so the
+// validation-vs-resolution split stays an implementation detail.
+func (m *Manager) resolvePrimarySources() (map[MetricCategory]SourceSelection, []overrideValidationFailure) {
 	probed := m.ProbeResults()
 
 	// Build category-to-producers from the registered gears that
@@ -584,6 +646,7 @@ func (m *Manager) ResolvePrimarySources() map[MetricCategory]SourceSelection {
 	}
 
 	out := make(map[MetricCategory]SourceSelection)
+	var failures []overrideValidationFailure
 	for _, cat := range AllMetricCategories() {
 		available := producers[cat]
 		if len(available) == 0 {
@@ -597,62 +660,60 @@ func (m *Manager) ResolvePrimarySources() map[MetricCategory]SourceSelection {
 		ordered := orderByPreference(available, preferenceOrder[cat])
 
 		// Operator override: must be available AND a registered
-		// producer. Fall through with a warning otherwise.
-		override := strings.ToLower(strings.TrimSpace(deps_override(m.deps, cat)))
+		// producer. Capture validation failures for the caller to log,
+		// but fall through to auto-detect either way.
+		override := strings.ToLower(strings.TrimSpace(overrideForCategory(m.deps, cat)))
 		if override != "" {
 			if _, isProducer := registeredFor[cat][override]; !isProducer {
-				m.logger.Warn("source override names a gear that doesn't produce this metric category; falling back to auto-detect",
-					"category", cat,
-					"override", override,
-					"env_var", overrideEnvVarFor(cat))
-			} else if !containsString(ordered, override) {
-				m.logger.Warn("source override names an unavailable gear; falling back to auto-detect",
-					"category", cat,
-					"override", override,
-					"env_var", overrideEnvVarFor(cat))
+				failures = append(failures, overrideValidationFailure{
+					category: cat,
+					override: override,
+					message:  "source override names a gear that doesn't produce this metric category; falling back to auto-detect",
+				})
+			} else if !slices.Contains(ordered, override) {
+				failures = append(failures, overrideValidationFailure{
+					category: cat,
+					override: override,
+					message:  "source override names an unavailable gear; falling back to auto-detect",
+				})
 			} else {
+				// Defensive Clone+DeleteFunc — the Alternatives slice
+				// returned to callers must not share backing storage
+				// with `ordered`, which a future change to this
+				// function could mutate.
+				alts := slices.Clone(ordered)
+				alts = slices.DeleteFunc(alts, func(s string) bool { return s == override })
 				out[cat] = SourceSelection{
 					Category:     cat,
 					Source:       override,
-					Reason:       "operator override via " + overrideEnvVarFor(cat),
-					Alternatives: withoutString(ordered, override),
+					Reason:       "operator override via " + categoryEnvVar[cat],
+					Alternatives: alts,
 				}
 				continue
 			}
 		}
 
-		// Auto-detect from preference order.
+		// Auto-detect from preference order. Clone the alternatives
+		// slice for the same defensive reason as the override branch.
 		out[cat] = SourceSelection{
 			Category:     cat,
 			Source:       ordered[0],
 			Reason:       "auto-detected from preference order",
-			Alternatives: ordered[1:],
+			Alternatives: slices.Clone(ordered[1:]),
 		}
 	}
 
-	return out
+	return out, failures
 }
 
-// deps_override fetches the operator's override for a category from
-// Dependencies. Standalone (not a method) so tests that build
+// overrideForCategory fetches the operator's override for a category
+// from Dependencies. Standalone (not a method) so tests that build
 // Dependencies directly stay readable.
-func deps_override(d Dependencies, cat MetricCategory) string {
+func overrideForCategory(d Dependencies, cat MetricCategory) string {
 	if d.SourceOverrides == nil {
 		return ""
 	}
 	return d.SourceOverrides[cat]
-}
-
-// overrideEnvVarFor names the env var that controls a category. Kept
-// in one place so warning messages and docs stay aligned with what
-// operators actually set in their env files.
-func overrideEnvVarFor(cat MetricCategory) string {
-	switch cat {
-	case CategoryHTTPRequests:
-		return "GEARBOX_AGENT_HTTP_SOURCE"
-	default:
-		return "(unknown category)"
-	}
 }
 
 // orderByPreference returns the subset of `available` ordered by where
@@ -685,25 +746,6 @@ func orderByPreference(available, preferred []string) []string {
 	}
 	sort.Strings(extras)
 	out = append(out, extras...)
-	return out
-}
-
-func containsString(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
-func withoutString(in []string, drop string) []string {
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if s != drop {
-			out = append(out, s)
-		}
-	}
 	return out
 }
 

--- a/gearbox-agent/internal/framework/gear/source.go
+++ b/gearbox-agent/internal/framework/gear/source.go
@@ -1,0 +1,84 @@
+package gear
+
+// MetricCategory groups metric data by what it describes so the agent
+// can pick a single "primary" producer per category when multiple
+// sources could supply the same thing on one host.
+//
+// Most metric data is single-source on any given box. The category
+// abstraction matters for HTTP request statistics (and a couple of
+// other future cases) where two or more proxies / web servers might
+// each be capable of producing requests/sec, response codes, and the
+// like — for instance a host running HAProxy in front of nginx, where
+// both genuinely see traffic. Without a primary-source concept the
+// dashboard would double-count or have to ask the user which numbers
+// to trust.
+//
+// Selection of the primary is auto-detection first: the manager walks
+// preferenceOrder for the category and picks the first gear that
+// probed Available. Operators override via per-category env vars
+// (GEARBOX_AGENT_HTTP_SOURCE, etc.) when auto-detection picks wrong on
+// their host — an extreme edge case but the one the override exists
+// for.
+type MetricCategory string
+
+const (
+	// CategoryHTTPRequests covers request volume, response codes,
+	// response times, and per-vhost/backend breakdowns. Today only
+	// HAProxy produces these; nginx/Apache/Caddy/Traefik join the
+	// category as their detection lands (issue #95).
+	CategoryHTTPRequests MetricCategory = "http_requests"
+)
+
+// AllMetricCategories lists every defined category in a stable order.
+// Used by the manager to iterate when resolving primary sources and by
+// tests that need to enumerate the set.
+func AllMetricCategories() []MetricCategory {
+	return []MetricCategory{
+		CategoryHTTPRequests,
+	}
+}
+
+// SourceSelection records the resolution of one metric category: which
+// gear is primary, how the selection was made, and what alternatives
+// were also available. Surfaced in the capability manifest so the
+// dashboard can render which source's metrics it's about to display
+// (and a "switch to X instead" hint when alternatives exist).
+type SourceSelection struct {
+	// Category is the metric category this selection applies to.
+	Category MetricCategory `json:"category"`
+
+	// Source is the gear name (matching Info().Name) that was picked
+	// as primary. Empty means no available producer for this category
+	// on this host — the field is then omitted from the manifest.
+	Source string `json:"source,omitempty"`
+
+	// Reason is operator-readable: "auto-detected from preference
+	// order", "operator override via GEARBOX_AGENT_HTTP_SOURCE",
+	// "operator override fell back to auto-detect — chosen gear is
+	// not available", etc. Surfaces in the manifest so an operator
+	// who sets an override can confirm at a glance that it took
+	// effect.
+	Reason string `json:"reason,omitempty"`
+
+	// Alternatives lists the other gears that probed Available and
+	// could have produced metrics for this category. Useful for the
+	// dashboard's "you have N sources for this; click to switch"
+	// affordance, and for operators trying to choose an override.
+	// Stable order (preferenceOrder for this category).
+	Alternatives []string `json:"alternatives,omitempty"`
+}
+
+// MetricSourceGear is implemented by gears that produce metrics for one
+// or more MetricCategory values. The manager builds the
+// category-to-producers map from these declarations and uses it to
+// resolve primary sources. Gears that don't implement this interface
+// don't participate in source selection — they're still in the
+// manifest, but no category points at them.
+type MetricSourceGear interface {
+	Gear
+
+	// MetricCategories returns the categories this gear produces
+	// data for. Returning an empty slice is allowed but pointless —
+	// such a gear should simply not implement the interface.
+	MetricCategories() []MetricCategory
+}

--- a/gearbox-agent/internal/framework/gear/source_test.go
+++ b/gearbox-agent/internal/framework/gear/source_test.go
@@ -1,0 +1,241 @@
+package gear
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// newTestManagerWithDeps mirrors newTestManager but lets the test seed
+// Dependencies — needed to exercise the operator-override paths on
+// ResolvePrimarySources (SourceOverrides).
+func newTestManagerWithDeps(t *testing.T, deps Dependencies) (*Manager, *bytes.Buffer) {
+	t.Helper()
+	m := NewManager(deps, nil)
+	buf := &bytes.Buffer{}
+	m.tableWriter = buf
+	return m, buf
+}
+
+// mockSourceGear is a gear that declares one or more MetricCategory
+// values, suitable for exercising ResolvePrimarySources. Embeds
+// mockProbeGear so it inherits the lifecycle counters and Probe
+// behaviour the existing tests already rely on.
+type mockSourceGear struct {
+	mockProbeGear
+	categories []MetricCategory
+}
+
+func (m *mockSourceGear) MetricCategories() []MetricCategory {
+	return m.categories
+}
+
+func newSourceGear(name string, status ProbeStatus, cats ...MetricCategory) *mockSourceGear {
+	pr := ProbeResult{Status: status, Reason: ""}
+	g := &mockSourceGear{
+		mockProbeGear: mockProbeGear{
+			info:        Info{Name: name},
+			probeResult: pr,
+		},
+		categories: cats,
+	}
+	return g
+}
+
+func TestResolvePrimarySources_AutoDetectPicksFirstAvailableFromPreference(t *testing.T) {
+	// HAProxy first in preferenceOrder, nginx second; both Available.
+	// Expect HAProxy to win and nginx to be listed as an alternative.
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	ngx := newSourceGear("nginx", ProbeStatusAvailable, CategoryHTTPRequests)
+	withTestRegistry(t, hap, ngx)
+
+	m, _ := newTestManager(t)
+	m.ProbeAll(context.Background())
+
+	picks := m.ResolvePrimarySources()
+	sel, ok := picks[CategoryHTTPRequests]
+	if !ok {
+		t.Fatal("CategoryHTTPRequests should have a primary")
+	}
+	if sel.Source != "haproxy" {
+		t.Errorf("source = %q, want haproxy (first in preferenceOrder)", sel.Source)
+	}
+	if !strings.Contains(sel.Reason, "auto-detected") {
+		t.Errorf("reason should mention auto-detect, got %q", sel.Reason)
+	}
+	if len(sel.Alternatives) != 1 || sel.Alternatives[0] != "nginx" {
+		t.Errorf("alternatives = %v, want [nginx]", sel.Alternatives)
+	}
+}
+
+func TestResolvePrimarySources_OverrideWinsOverPreferenceOrder(t *testing.T) {
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	ngx := newSourceGear("nginx", ProbeStatusAvailable, CategoryHTTPRequests)
+	withTestRegistry(t, hap, ngx)
+
+	deps := Dependencies{
+		SourceOverrides: map[MetricCategory]string{
+			CategoryHTTPRequests: "nginx",
+		},
+	}
+	m, _ := newTestManagerWithDeps(t, deps)
+	m.ProbeAll(context.Background())
+
+	sel := m.ResolvePrimarySources()[CategoryHTTPRequests]
+	if sel.Source != "nginx" {
+		t.Errorf("override should pick nginx, got %q", sel.Source)
+	}
+	if !strings.Contains(sel.Reason, "operator override") {
+		t.Errorf("reason should mention override, got %q", sel.Reason)
+	}
+	if !strings.Contains(sel.Reason, "GEARBOX_AGENT_HTTP_SOURCE") {
+		t.Errorf("reason should name the env var, got %q", sel.Reason)
+	}
+	// Alternatives should list what would have been picked otherwise,
+	// minus the chosen source. HAProxy comes first in preferenceOrder.
+	if len(sel.Alternatives) != 1 || sel.Alternatives[0] != "haproxy" {
+		t.Errorf("alternatives = %v, want [haproxy]", sel.Alternatives)
+	}
+}
+
+func TestResolvePrimarySources_OverrideFallsBackWhenTargetNotAvailable(t *testing.T) {
+	// Override names nginx, but nginx didn't probe Available — fall
+	// back to auto-detect (HAProxy wins) and log a warning rather than
+	// dropping HTTP metrics entirely.
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	ngx := newSourceGear("nginx", ProbeStatusNotInstalled, CategoryHTTPRequests)
+	withTestRegistry(t, hap, ngx)
+
+	deps := Dependencies{
+		SourceOverrides: map[MetricCategory]string{
+			CategoryHTTPRequests: "nginx",
+		},
+	}
+	m, _ := newTestManagerWithDeps(t, deps)
+	m.ProbeAll(context.Background())
+
+	sel := m.ResolvePrimarySources()[CategoryHTTPRequests]
+	if sel.Source != "haproxy" {
+		t.Errorf("override target unavailable → should fall back to haproxy, got %q", sel.Source)
+	}
+	if !strings.Contains(sel.Reason, "auto-detected") {
+		t.Errorf("fallback should be marked auto-detected, got %q", sel.Reason)
+	}
+}
+
+func TestResolvePrimarySources_OverrideFallsBackWhenTargetUnknown(t *testing.T) {
+	// Override names a gear that isn't registered as a producer for
+	// this category at all (e.g. nginx not yet implemented, operator
+	// templating an env file for a future deploy). Same fallback +
+	// warning behaviour as unavailable.
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	withTestRegistry(t, hap)
+
+	deps := Dependencies{
+		SourceOverrides: map[MetricCategory]string{
+			CategoryHTTPRequests: "imaginary-server",
+		},
+	}
+	m, _ := newTestManagerWithDeps(t, deps)
+	m.ProbeAll(context.Background())
+
+	sel := m.ResolvePrimarySources()[CategoryHTTPRequests]
+	if sel.Source != "haproxy" {
+		t.Errorf("unknown override → should fall back to haproxy, got %q", sel.Source)
+	}
+}
+
+func TestResolvePrimarySources_NoAvailableProducerOmitsCategory(t *testing.T) {
+	// Only producer for HTTP is HAProxy, but it probed NotInstalled.
+	// Category should be omitted from the result, not appear with an
+	// empty Source — callers distinguish "no primary" via key absence.
+	hap := newSourceGear("haproxy", ProbeStatusNotInstalled, CategoryHTTPRequests)
+	withTestRegistry(t, hap)
+
+	m, _ := newTestManager(t)
+	m.ProbeAll(context.Background())
+
+	if _, ok := m.ResolvePrimarySources()[CategoryHTTPRequests]; ok {
+		t.Error("CategoryHTTPRequests should be omitted when no producer is Available")
+	}
+}
+
+func TestResolvePrimarySources_OverrideForCategoryNoProducerOmitsCategory(t *testing.T) {
+	// No producer registered for this category at all. Override is
+	// meaningless and should not cause a synthetic entry.
+	withTestRegistry(t)
+
+	deps := Dependencies{
+		SourceOverrides: map[MetricCategory]string{
+			CategoryHTTPRequests: "nginx",
+		},
+	}
+	m, _ := newTestManagerWithDeps(t, deps)
+	m.ProbeAll(context.Background())
+
+	if _, ok := m.ResolvePrimarySources()[CategoryHTTPRequests]; ok {
+		t.Error("no registered producers → category should be omitted regardless of override")
+	}
+}
+
+func TestResolvePrimarySources_UnrankedProducerStillSurfacesAsAlternative(t *testing.T) {
+	// A producer that isn't in preferenceOrder for this category
+	// should still show up in alternatives so the dashboard's "switch
+	// source" UI can offer it. Alphabetical tiebreak among unranked
+	// producers.
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	weird := newSourceGear("zebra-proxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	withTestRegistry(t, hap, weird)
+
+	m, _ := newTestManager(t)
+	m.ProbeAll(context.Background())
+
+	sel := m.ResolvePrimarySources()[CategoryHTTPRequests]
+	if sel.Source != "haproxy" {
+		t.Fatalf("primary should be haproxy, got %q", sel.Source)
+	}
+	if len(sel.Alternatives) != 1 || sel.Alternatives[0] != "zebra-proxy" {
+		t.Errorf("alternatives = %v, want [zebra-proxy]", sel.Alternatives)
+	}
+}
+
+func TestCapabilitiesEndpointIncludesPrimarySources(t *testing.T) {
+	// End-to-end: /api/v1/system/capabilities response includes the
+	// resolved primary_sources alongside the existing gears table.
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	withTestRegistry(t, hap)
+
+	m, _ := newTestManager(t)
+	m.ProbeAll(context.Background())
+
+	r := chi.NewRouter()
+	m.RegisterSystemRoutes(r)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/capabilities", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp CapabilitiesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp.Gears["haproxy"]; !ok {
+		t.Error("response should include haproxy in Gears")
+	}
+	sel, ok := resp.PrimarySources[CategoryHTTPRequests]
+	if !ok {
+		t.Fatal("primary_sources should include CategoryHTTPRequests")
+	}
+	if sel.Source != "haproxy" {
+		t.Errorf("primary source = %q, want haproxy", sel.Source)
+	}
+}

--- a/gearbox-agent/internal/framework/gear/source_test.go
+++ b/gearbox-agent/internal/framework/gear/source_test.go
@@ -48,6 +48,54 @@ func newSourceGear(name string, status ProbeStatus, cats ...MetricCategory) *moc
 	return g
 }
 
+// TestEveryCategoryHasOverrideEnvVar guards against adding a new
+// MetricCategory and forgetting to map it to an env var. Without this
+// test the missing entry only surfaces as the literal string
+// "(unknown category)" leaking into operator-facing log messages and
+// SourceSelection.Reason values — exactly the placeholder Copilot
+// flagged on PR #96 review. Driving the map from this test means a
+// new category that's added to AllMetricCategories() and skipped in
+// categoryEnvVar fails CI immediately.
+func TestEveryCategoryHasOverrideEnvVar(t *testing.T) {
+	for _, cat := range AllMetricCategories() {
+		envVar, ok := categoryEnvVar[cat]
+		if !ok {
+			t.Errorf("MetricCategory %q is missing an entry in categoryEnvVar — add one to manager.go", cat)
+			continue
+		}
+		if envVar == "" {
+			t.Errorf("categoryEnvVar[%q] is empty — set the env-var name", cat)
+		}
+		if !strings.HasPrefix(envVar, "GEARBOX_AGENT_") {
+			t.Errorf("categoryEnvVar[%q] = %q; agent-wide overrides should use the GEARBOX_AGENT_ prefix", cat, envVar)
+		}
+	}
+}
+
+// TestValidatePrimarySourceOverridesCountsMisses guards the split
+// between Resolve (silent) and Validate (logs warnings). The endpoint
+// handler calls Resolve on every dashboard poll, so warnings must
+// stay in the Validate path that only runs at startup.
+func TestValidatePrimarySourceOverridesCountsMisses(t *testing.T) {
+	hap := newSourceGear("haproxy", ProbeStatusAvailable, CategoryHTTPRequests)
+	withTestRegistry(t, hap)
+
+	deps := Dependencies{
+		SourceOverrides: map[MetricCategory]string{
+			CategoryHTTPRequests: "imaginary-server",
+		},
+	}
+	m, _ := newTestManagerWithDeps(t, deps)
+	m.ProbeAll(context.Background())
+
+	// ProbeAll already invoked Validate (via logPrimarySources).
+	// A second explicit call should still report the same failure
+	// without changing Resolve's output — Validate is idempotent.
+	if got := m.ValidatePrimarySourceOverrides(); got != 1 {
+		t.Errorf("Validate count = %d, want 1 (one mis-targeted override)", got)
+	}
+}
+
 func TestResolvePrimarySources_AutoDetectPicksFirstAvailableFromPreference(t *testing.T) {
 	// HAProxy first in preferenceOrder, nginx second; both Available.
 	// Expect HAProxy to win and nginx to be listed as an alternative.

--- a/gearbox-agent/internal/gears/haproxy/plugin.go
+++ b/gearbox-agent/internal/gears/haproxy/plugin.go
@@ -122,6 +122,19 @@ func (p *Gear) RegisterRoutes(r chi.Router) {
 	r.Get("/api/v1/haproxy/validate", p.handleConfigValidation)
 }
 
+// MetricCategories declares the metric categories this gear produces
+// data for. The agent's manager uses this to build the
+// category-to-producers table that drives primary-source selection.
+// HAProxy stats provide request-level data (requests/sec, response
+// codes, response times, per-backend breakdowns) — the
+// CategoryHTTPRequests slot. When other HTTP-source gears land
+// (nginx, Apache, Caddy, Traefik), they'll join the same category
+// and the operator can pick between them via
+// GEARBOX_AGENT_HTTP_SOURCE.
+func (p *Gear) MetricCategories() []gear.MetricCategory {
+	return []gear.MetricCategory{gear.CategoryHTTPRequests}
+}
+
 // Collectors returns the periodic collectors for this gear.
 func (p *Gear) Collectors() []gear.Collector {
 	if p.statsClient == nil {


### PR DESCRIPTION
## Summary

First foundational PR for [#95](https://github.com/sarg3nt/gearbox/issues/95) (Phase 3 of [#91](https://github.com/sarg3nt/gearbox/issues/91)). Establishes the **"who's the primary metric source on this host"** mechanism so future PRs can drop in nginx / Apache / Caddy / Traefik detectors without re-architecting how the dashboard picks whose numbers to render.

## The problem this addresses

Most hosts have one obvious producer per metric category (HTTP requests, response codes, etc.). Where two coexist — e.g. HAProxy fronting nginx, both genuinely serving traffic — the agent has no way today to say "use HAProxy's numbers, not nginx's." Without a primary-source concept, a host with multiple HTTP sources would either double-count or force the user to decide ad-hoc which numbers to trust.

The override env var fills the extreme-edge-case gap: when auto-detection picks wrong on a specific box, operators force the choice for that box without per-fleet config sprawl.

## Design

**Categories:** `MetricCategory` is a grouping of metric data multiple sources could produce. One category defined today (`CategoryHTTPRequests`); more land with future phases (`backend_health`, `container_metrics`, etc.).

**Producer registration:** Gears that produce metrics implement an opt-in `MetricSourceGear` interface declaring which categories they cover. HAProxy declares `CategoryHTTPRequests`. Future gears will declare their own.

**Auto-detection:** A built-in `preferenceOrder` per category encodes a homelab-flavoured opinion — HAProxy first (the L7 entry point in this project), then nginx > Apache > Caddy > Traefik (rough order-of-prevalence). The resolver walks the order and picks the first gear that probed Available.

**Override:** Per-category env var. Today: `GEARBOX_AGENT_HTTP_SOURCE=nginx`. When set, the named gear wins — provided it actually probed Available and is registered for the category. If not, the agent logs a warning and falls back to auto-detection (losing HTTP metrics because an override's target isn't installed would be worse than serving auto-picked data).

**Exposure:** `/api/v1/system/capabilities` grows a `primary_sources` field keyed by category. Each entry has `source`, `reason` (auto-detect vs override), and `alternatives` (the other available producers for the category, in preference order). Categories with no available producer are omitted entirely — callers distinguish "no primary" via key absence.

**Startup log:** One line per resolved category in the journal so operators can confirm overrides without hitting the API.

## Files

| File | Purpose |
|------|---------|
| `gear/source.go` (new) | `MetricCategory` type, `CategoryHTTPRequests` constant, `MetricSourceGear` interface, `SourceSelection` struct. |
| `gear/source_test.go` (new) | 8 resolver tests + capabilities-endpoint integration test. |
| `gear/manager.go` | `ResolvePrimarySources()`, `preferenceOrder` map, override validation, `primary_sources` in the manifest, startup logging. |
| `gear/dependencies.go` | `SourceOverrides map[MetricCategory]string`. |
| `config/config.go` | `HTTPSource string` field; `normaliseSourceOverride` trims + lowercases. |
| `config/config_test.go` | Parser + env-var integration tests. |
| `gears/haproxy/plugin.go` | Declares `MetricCategories() → [CategoryHTTPRequests]`. |
| `cmd/gearbox-agent/main.go` | `buildSourceOverrides(cfg)` packs the per-category env-var fields into the Dependencies map. |
| `README.md` | New "Metric-source overrides" section. |

## Test plan

- [x] `go test ./...` — 15 packages pass on `gearbox-agent`.
- [x] New unit tests cover:
  - Auto-detect picks first Available from preference order.
  - Override wins over preference; reason names env var.
  - Override target unavailable → falls back to auto + warning.
  - Override target unknown / not a producer for the category → same.
  - No available producers → category omitted from result.
  - Unranked producer still surfaces as alternative (alphabetised).
  - End-to-end `/api/v1/system/capabilities` includes `primary_sources`.
  - Env-var parsing trims + lowercases; default is empty.
- [x] `go vet ./...` clean.
- [ ] Manual smoke on `light-hugger` (HAProxy host): the manifest's `primary_sources.http_requests.source` reads `"haproxy"` with reason `"auto-detected from preference order"` and empty `alternatives` (since only HAProxy is detected today). Override via env var still no-ops gracefully since nginx isn't installed.

## Backwards compatibility

Purely additive — no breaking changes.

- Existing `CapabilitiesResponse.Gears` table unchanged. Older dashboards that ignore `primary_sources` get the same data they did before.
- Older agents talking to a Phase-3-aware dashboard: manifest just lacks `primary_sources`. Dashboard already treats missing fields as "use existing defaults" (PR #93 fail-open behaviour). No regression.
- No env-var renames, no removed config, no API breakage.

## What this PR is NOT

Per the issue #95 PR breakdown, this is **PR A** — the foundation. Out of scope:

- nginx / Apache / Caddy / Traefik / Docker detection gears (PRs B–E of #95).
- Additional metric categories — `backend_health`, `container_metrics` — added when their second producer lands.
- Dashboard consumption of `primary_sources` — gets surfaced in metrics-page UI in a separate PR once a real second source exists for HTTP.

## Design note vs. issue #95 wording

Issue #95 mentioned `GEARBOX_AGENT_DISABLE_SOURCES` for blocking detected sources wholesale. After clarification, the actual need is **primary-source selection** — picking which detected source wins for each metric category. This PR implements that. The block/allowlist concept can land separately if and when it becomes useful; it's a different control surface and shouldn't be conflated.

I'll update the body of issue #95 to reflect this clarification once the PR lands.

## References

- Parent issue: [#95](https://github.com/sarg3nt/gearbox/issues/95) (Phase 3 — service detection).
- Grandparent: [#91](https://github.com/sarg3nt/gearbox/issues/91) (source-agnostic Metrics gear).
- Prior PR: [#93](https://github.com/sarg3nt/gearbox/pull/93) (Phases 0–2 dashboard).
- Architecture doc: [`docs/research/metrics-source-agnostic.md`](../blob/main/gearbox/docs/research/metrics-source-agnostic.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)