### PR TITLE
refactor: rename Metrics gear URL /history → /metrics + themed 404

### DIFF
--- a/docs/gears.md
+++ b/docs/gears.md
@@ -138,7 +138,7 @@ Client gears run in the **gearbox** web application (the monitoring client) and 
 - `traffic` - Traffic analysis and visualization page
 - `alerts` - Alert management page
 - `services` - Service status and control page
-- `metrics` - System metrics and history page
+- `metrics` - Time-series system + HAProxy metrics page (`/metrics`)
 
 ### Gear Scope: Box vs System
 

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -452,6 +452,12 @@ func main() {
 	r.Use(gbmiddleware.SecurityHeaders)
 	// Inject asset configuration for templates (CDN vs local assets)
 	r.Use(gbmiddleware.InjectAssetConfig(cfg.UseLocalAssets))
+
+	// Themed 404 for unmatched routes. The handler is intentionally
+	// static (inline HTML, no auth/DB/templ) so a typo'd URL can't be a
+	// side channel for fingerprinting session state. See the handler's
+	// own godoc for the rationale.
+	r.NotFound(handler.NotFoundHandler)
 	// Note: Timeout middleware is applied per-route group below
 	// SSE endpoints need to bypass the timeout middleware
 

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -627,7 +627,7 @@ func main() {
 
 		// Gear-registered routes
 		// Gears handle: / (haproxy overview), /status-grid (haproxy), /logs (logs),
-		// /services (services), /history (metrics), /certificates (certificates),
+		// /services (services), /metrics (metrics gear), /certificates (certificates),
 		// /traffic (traffic), /alerts (alerts)
 		gearManager.RegisterRoutes(r)
 
@@ -676,10 +676,13 @@ func main() {
 			r.Get("/{boxID}/charts/error-rates", h.APIChartsErrorRatesHandler)
 			r.Get("/{boxID}/logs/{logName}", h.APILogsHandler)
 			r.Get("/{boxID}/log-sources", h.APILogSourcesHandler) // Get enabled log sources
-			// History API endpoints
-			r.Get("/{boxID}/history/stats", h.APIStatsHistoryHandler)
-			r.Get("/{boxID}/history/metrics", h.APISystemMetricsHistoryHandler)
-			r.Get("/{boxID}/history/backend/{backendName}", h.APIBackendHistoryHandler)
+			// Metrics gear — time-series endpoints (HAProxy stats,
+			// system metrics, per-backend stats). These power the
+			// charts on the /metrics page; the /metrics/* "v2"
+			// endpoints just below power the KPI band + insights.
+			r.Get("/{boxID}/metrics/stats", h.APIMetricsStatsHandler)
+			r.Get("/{boxID}/metrics/system", h.APIMetricsSystemHandler)
+			r.Get("/{boxID}/metrics/backend/{backendName}", h.APIMetricsBackendHandler)
 			r.Get("/{boxID}/incidents", h.APIIncidentsHandler)
 
 			// Metrics gear v2 — insights & drill-down endpoints

--- a/gearbox/internal/framework/handler/api_stats.go
+++ b/gearbox/internal/framework/handler/api_stats.go
@@ -102,8 +102,12 @@ func (h *Handler) APISystemMetricsHandler(w http.ResponseWriter, r *http.Request
 	h.writeJSON(w, response)
 }
 
-// APIStatsHistoryHandler returns historical stats data.
-func (h *Handler) APIStatsHistoryHandler(w http.ResponseWriter, r *http.Request) {
+// APIMetricsStatsHandler returns time-series HAProxy stats for the
+// Metrics page's per-backend chart. Served at /api/{boxID}/metrics/stats.
+// The underlying DB method is still named GetStatsHistory because the
+// data it returns IS historical records; the URL renamed for clarity
+// with issue #97.
+func (h *Handler) APIMetricsStatsHandler(w http.ResponseWriter, r *http.Request) {
 	boxID := chi.URLParam(r, "boxID")
 	if boxID == "" {
 		http.Error(w, "Server ID required", http.StatusBadRequest)
@@ -142,8 +146,12 @@ func (h *Handler) APIStatsHistoryHandler(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-// APIBackendHistoryHandler returns historical data for a specific backend.
-func (h *Handler) APIBackendHistoryHandler(w http.ResponseWriter, r *http.Request) {
+// APIMetricsBackendHandler returns time-series stats for a specific
+// backend on the Metrics page. Served at
+// /api/{boxID}/metrics/backend/{backendName}. Coexists with the
+// /metrics/backend/{name}/details drill-down (which returns aggregate
+// insights rather than the time-series).
+func (h *Handler) APIMetricsBackendHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if user has permission to view metrics
 	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
 		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
@@ -191,8 +199,10 @@ func (h *Handler) APIBackendHistoryHandler(w http.ResponseWriter, r *http.Reques
 	})
 }
 
-// APISystemMetricsHistoryHandler returns historical system metrics.
-func (h *Handler) APISystemMetricsHistoryHandler(w http.ResponseWriter, r *http.Request) {
+// APIMetricsSystemHandler returns time-series host-level metrics for
+// the Metrics page (CPU, memory, disk, network). Served at
+// /api/{boxID}/metrics/system.
+func (h *Handler) APIMetricsSystemHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if user has permission to view metrics
 	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
 		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)

--- a/gearbox/internal/framework/handler/not_found.go
+++ b/gearbox/internal/framework/handler/not_found.go
@@ -1,0 +1,110 @@
+package handler
+
+import "net/http"
+
+// NotFoundHandler serves a static, self-contained 404 page for any URL
+// that doesn't match a registered route. Wired in main.go via
+// chi's r.NotFound().
+//
+// Deliberately bypasses every dashboard concern beyond the HTTP
+// envelope: no templ rendering, no auth middleware, no DB / agent
+// lookups, no user-context injection. A page-not-found response for a
+// randomly-typed URL must not be a side channel for fingerprinting
+// session state or for accidentally exposing data that a logged-out
+// caller shouldn't see. The HTML is a const so there's no filesystem
+// or template lookup at request time either.
+//
+// Visually the page matches the dashboard's palette (blue accent,
+// system fonts, prefers-color-scheme-aware) and includes a single
+// link back to "/". All styles are inline so the response works even
+// if the static-asset bundle didn't load.
+func NotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// 404s shouldn't be cached — the next deploy might add the route.
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte(notFoundHTML))
+}
+
+// notFoundHTML is the entire 404 response body. Kept as a const so the
+// handler has no runtime template or filesystem dependency — security
+// posture comment on NotFoundHandler explains why this matters.
+const notFoundHTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>404 — Page not found · Gearbox</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<style>
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 1.5rem;
+}
+@media (prefers-color-scheme: dark) {
+  body { background: #0f172a; color: #e2e8f0; }
+  .footer { color: #64748b; }
+}
+.card {
+  text-align: center;
+  max-width: 32rem;
+  padding: 2rem;
+}
+h1 {
+  font-size: 5rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+  letter-spacing: -0.025em;
+  color: #2563eb;
+  line-height: 1;
+}
+.lead {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 1rem;
+}
+p {
+  margin: 0.5rem 0;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+a.home {
+  display: inline-block;
+  margin-top: 1.5rem;
+  padding: 0.625rem 1.25rem;
+  background: #2563eb;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.9375rem;
+  transition: background-color 120ms ease;
+}
+a.home:hover, a.home:focus { background: #1d4ed8; }
+.footer {
+  margin-top: 2rem;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+</style>
+</head>
+<body>
+  <main class="card">
+    <h1>404</h1>
+    <p class="lead">Page not found</p>
+    <p>The URL you requested isn't registered on this dashboard.</p>
+    <a class="home" href="/">Back to dashboard</a>
+    <p class="footer">Gearbox</p>
+  </main>
+</body>
+</html>`

--- a/gearbox/internal/framework/handler/not_found_test.go
+++ b/gearbox/internal/framework/handler/not_found_test.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNotFoundHandlerStatusAndBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/anything-not-registered", nil)
+	w := httptest.NewRecorder()
+
+	NotFoundHandler(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want HTML", ct)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"<!doctype html>", "404", "Page not found", "Back to dashboard"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body should contain %q", want)
+		}
+	}
+}
+
+// TestNotFoundHandlerDoesNotEchoRequestData guards against accidentally
+// turning the 404 page into a reflection vector. The handler should
+// never embed any part of the request URL, headers, cookies, or body
+// into the response — the point of the static page is that a typo'd
+// URL produces a fully deterministic response.
+func TestNotFoundHandlerDoesNotEchoRequestData(t *testing.T) {
+	const probe = "GEARBOX-PROBE-MARKER-39df09a1"
+	req := httptest.NewRequest(http.MethodGet, "/"+probe, nil)
+	req.Header.Set("X-Probe", probe)
+	req.Header.Set("Cookie", "session="+probe)
+	req.Header.Set("Referer", "https://example.com/"+probe)
+	w := httptest.NewRecorder()
+
+	NotFoundHandler(w, req)
+
+	if strings.Contains(w.Body.String(), probe) {
+		t.Errorf("response body contains request-supplied marker %q — handler is reflecting request data", probe)
+	}
+}
+
+func TestNotFoundHandlerStableAcrossMethods(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/missing", nil)
+			w := httptest.NewRecorder()
+			NotFoundHandler(w, req)
+			if w.Code != http.StatusNotFound {
+				t.Errorf("%s: status = %d, want 404", method, w.Code)
+			}
+		})
+	}
+}

--- a/gearbox/internal/framework/handler/pages.go
+++ b/gearbox/internal/framework/handler/pages.go
@@ -15,7 +15,7 @@ import (
 // - OverviewPage -> plugins/haproxy
 // - StatusGridPage -> plugins/haproxy
 // - LogsPage -> plugins/logs
-// - HistoryPage -> plugins/metrics
+// - MetricsPage -> plugins/metrics
 // - ServicesPage -> plugins/services
 // - CertificatesPage -> plugins/certificates
 // - TrafficPage -> plugins/traffic

--- a/gearbox/internal/framework/models/permissions.go
+++ b/gearbox/internal/framework/models/permissions.go
@@ -335,7 +335,7 @@ func GetAvailablePermissionsForComponent(c Component) []Permission {
 		}
 	case ComponentMetrics:
 		return []Permission{
-			PermissionView,      // View metrics/history page and data
+			PermissionView,      // View the Metrics page and its data
 			PermissionConfigure, // Configure metrics storage settings
 		}
 	case ComponentGears:

--- a/gearbox/internal/framework/templates/layouts/base.templ
+++ b/gearbox/internal/framework/templates/layouts/base.templ
@@ -36,7 +36,7 @@ func gearLabelForPath(path string) string {
 		return ""
 	case path == "/haproxy" || strings.HasPrefix(path, "/haproxy/"):
 		return "HAProxy"
-	case path == "/history" || strings.HasPrefix(path, "/history/"):
+	case path == "/metrics" || strings.HasPrefix(path, "/metrics/"):
 		return "Metrics"
 	case path == "/logs" || strings.HasPrefix(path, "/logs/"):
 		return "Logs"
@@ -2175,7 +2175,7 @@ func integrationPath(name string) string {
 	case "haproxy":
 		return "/haproxy"
 	case "metrics":
-		return "/history"
+		return "/metrics"
 	case "logs":
 		return "/logs"
 	case "services":
@@ -2287,7 +2287,7 @@ templ OrderedIntegrationLinks(currentPath string) {
 			@SidebarLinkWithIntegration("/haproxy", "HAProxy", SidebarIconHAProxy(), currentPath, "haproxy")
 		}
 		if canViewIntegration(ctx, "metrics") {
-			@SidebarLinkWithIntegration("/history", "Metrics", SidebarIconMetrics(), currentPath, "metrics")
+			@SidebarLinkWithIntegration("/metrics", "Metrics", SidebarIconMetrics(), currentPath, "metrics")
 		}
 		if canViewIntegration(ctx, "logs") {
 			@SidebarLinkWithIntegration("/logs", "Logs", SidebarIconLogs(), currentPath, "logs")
@@ -2332,7 +2332,7 @@ templ renderIntegrationLink(name string, currentPath string) {
 		case "haproxy":
 			@SidebarLinkDraggable("/haproxy", "HAProxy", SidebarIconHAProxy(), currentPath, "haproxy")
 		case "metrics":
-			@SidebarLinkDraggable("/history", "Metrics", SidebarIconMetrics(), currentPath, "metrics")
+			@SidebarLinkDraggable("/metrics", "Metrics", SidebarIconMetrics(), currentPath, "metrics")
 		case "logs":
 			@SidebarLinkDraggable("/logs", "Logs", SidebarIconLogs(), currentPath, "logs")
 		case "services":

--- a/gearbox/internal/framework/templates/pages/details.templ
+++ b/gearbox/internal/framework/templates/pages/details.templ
@@ -714,7 +714,7 @@ templ BackendDetail(user *models.User, backendName string, stats *models.HAProxy
 					function loadBackendHistory() {
 						updateResolutionLabel();
 						var hours = document.getElementById('hours-select').value;
-						fetch('/api/' + backendServerID + '/history/backend/' + encodeURIComponent(backendNameVar) + '?hours=' + hours)
+						fetch('/api/' + backendServerID + '/metrics/backend/' + encodeURIComponent(backendNameVar) + '?hours=' + hours)
 							.then(function(response) { return response.json(); })
 							.then(function(result) {
 								cachedBackendData = result.data || [];

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -4,8 +4,8 @@ import "github.com/sarg3nt/gearbox/internal/framework/models"
 import "github.com/sarg3nt/gearbox/internal/framework/templates/layouts"
 import "github.com/sarg3nt/gearbox/internal/framework/templates/components"
 
-templ History(user *models.User, servers []models.BoxConfig) {
-	@layouts.Base("Metrics", user, "/history") {
+templ Metrics(user *models.User, servers []models.BoxConfig) {
+	@layouts.Base("Metrics", user, "/metrics") {
 		<!-- Hidden container for page header content. Title + box selector
 		     live in the global header breadcrumb + chip. -->
 		<div id="page-header-source" class="hidden">
@@ -843,12 +843,12 @@ templ History(user *models.User, servers []models.BoxConfig) {
 			await applyCapabilities(serverID);
 
 			try {
-				// Fetch stats history
-				const statsResponse = await fetch(`/api/${serverID}/history/stats?hours=${hours}`);
+				// Fetch HAProxy stats time series
+				const statsResponse = await fetch(`/api/${serverID}/metrics/stats?hours=${hours}`);
 				const statsData = await statsResponse.json();
 
-				// Fetch system metrics history
-				const metricsResponse = await fetch(`/api/${serverID}/history/metrics?hours=${hours}`);
+				// Fetch system-metrics time series
+				const metricsResponse = await fetch(`/api/${serverID}/metrics/system?hours=${hours}`);
 				const metricsData = await metricsResponse.json();
 
 				// Cache the data for fullscreen toggle

--- a/gearbox/internal/gears/metrics/README.md
+++ b/gearbox/internal/gears/metrics/README.md
@@ -93,7 +93,7 @@ The new endpoints sit on top of existing tables — no new collection runs
 on the agent. Specifically:
 
 - KPI summary aggregates `stats_history` (per-snapshot HAProxy stats — table
-  name unchanged from the pre-rename schema; the records IS historical) and
+  name unchanged from the pre-rename schema; the records are historical) and
   `traffic_flows` (per-minute response-code buckets from the Traffic gear's
   collector).
 - Error Insights and backend details query `traffic_flows` exclusively —

--- a/gearbox/internal/gears/metrics/README.md
+++ b/gearbox/internal/gears/metrics/README.md
@@ -1,8 +1,13 @@
 # Metrics Gear
 
-The Metrics gear surfaces historical metrics for HAProxy and the underlying
-host. It's the place users land when they want to answer *"how busy was the
-proxy, and what went wrong?"*
+The Metrics gear surfaces time-series metrics for HAProxy and the underlying
+host at the dashboard's `/metrics` URL. It's the place users land when they
+want to answer *"how busy was the proxy, and what went wrong?"*
+
+> The page used to live at `/history` and was internally referred to as the
+> "history" gear; issue #97 renamed it to `/metrics` to keep "history"
+> reserved for genuinely distinct concepts (OS-update apt/zypper history,
+> HAProxy config change history).
 
 ## Layout
 
@@ -44,7 +49,7 @@ The page has four stacked sections:
 
 | Permission          | Description                |
 |---------------------|----------------------------|
-| `metrics:view`      | View metrics and history   |
+| `metrics:view`      | View the Metrics page      |
 | `metrics:configure` | Configure metrics settings |
 
 The drill-down drawer's *Recent 5xx log lines* section additionally
@@ -53,21 +58,21 @@ shows a "logs unavailable" hint instead of failing.
 
 ## Routes
 
-| Method | Path       | Description               |
-|--------|------------|---------------------------|
-| GET    | `/history` | Main history/metrics page |
+| Method | Path       | Description       |
+|--------|------------|-------------------|
+| GET    | `/metrics` | Main Metrics page |
 
 ## API endpoints (main handler)
 
-Existing endpoints kept for backwards compatibility:
+Time-series endpoints (chart data):
 
-| Method | Path                                            | Description                   |
-|--------|-------------------------------------------------|-------------------------------|
-| GET    | `/api/{serverID}/history/stats`                 | Get historical HAProxy stats  |
-| GET    | `/api/{serverID}/history/metrics`               | Get historical system metrics |
-| GET    | `/api/{serverID}/history/backend/{backendName}` | Get backend-specific history  |
-| GET    | `/api/{serverID}/metrics/storage-stats`         | Get storage statistics        |
-| POST   | `/api/{serverID}/metrics/clear`                 | Clear metrics data            |
+| Method | Path                                            | Description                                   |
+|--------|-------------------------------------------------|-----------------------------------------------|
+| GET    | `/api/{serverID}/metrics/stats`                 | Time-series HAProxy stats (per-snapshot rows) |
+| GET    | `/api/{serverID}/metrics/system`                | Time-series host metrics (CPU/mem/disk/net)   |
+| GET    | `/api/{serverID}/metrics/backend/{backendName}` | Time-series per-backend stats                 |
+| GET    | `/api/{serverID}/metrics/storage-stats`         | Storage statistics                            |
+| POST   | `/api/{serverID}/metrics/clear`                 | Clear metrics data                            |
 
 New in v2 ("insights" surface — see `api_metrics_insights.go`):
 
@@ -87,7 +92,8 @@ default 2000) and an optional `backend` filter.
 The new endpoints sit on top of existing tables — no new collection runs
 on the agent. Specifically:
 
-- KPI summary aggregates `stats_history` (per-snapshot HAProxy stats) and
+- KPI summary aggregates `stats_history` (per-snapshot HAProxy stats — table
+  name unchanged from the pre-rename schema; the records IS historical) and
   `traffic_flows` (per-minute response-code buckets from the Traffic gear's
   collector).
 - Error Insights and backend details query `traffic_flows` exclusively —
@@ -100,8 +106,8 @@ on the agent. Specifically:
 
 ```text
 internal/gears/metrics/
-├── plugin.go             # Gear registration
-├── handlers.go           # HTTP handler (/history page)
+├── plugin.go             # Gear registration (/metrics route)
+├── handlers.go           # MetricsPage handler
 ├── partials.templ        # CPU / memory / disk / etc. widget partials
 ├── chart_partials.templ  # Reusable chart components for the home gear
 ├── icons.go              # Sidebar icon
@@ -109,7 +115,8 @@ internal/gears/metrics/
 └── README.md             # This file
 
 internal/framework/handler/
-├── api_stats.go                       # Existing /history/* endpoints
+├── api_stats.go                       # Time-series endpoints
+│                                      # (/api/{boxID}/metrics/{stats,system,backend/*})
 ├── api_metrics_insights.go            # KPI / error breakdown / drill-down / log-errors
 └── api_metrics_insights_helpers.go    # KPI math, sparkline downsampling
 
@@ -121,7 +128,7 @@ internal/framework/database/
 ## Development
 
 The gear is automatically included in the build via its `init()` function.
-After editing `history.templ`, run:
+After editing `metrics.templ`, run:
 
 ```bash
 make templ-generate && make build

--- a/gearbox/internal/gears/metrics/chart_partials.templ
+++ b/gearbox/internal/gears/metrics/chart_partials.templ
@@ -28,7 +28,7 @@ script initSessionsRequestsChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-sessions-requests-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/stats?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/stats?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];
@@ -84,7 +84,7 @@ script initServerHealthChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-server-health-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/stats?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/stats?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];
@@ -140,7 +140,7 @@ script initCPULoadChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-cpu-load-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/metrics?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/system?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];
@@ -197,7 +197,7 @@ script initMemoryUsageChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-memory-usage-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/metrics?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/system?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];
@@ -252,7 +252,7 @@ script initNetworkThroughputChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-network-throughput-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/metrics?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/system?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];
@@ -328,7 +328,7 @@ script initResponseTimesChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-response-times-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/stats?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/stats?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];
@@ -383,7 +383,7 @@ script initErrorRatesChart(boxID string, hours int, limit int) {
 		var canvasId = 'chart-error-rates-' + boxID;
 
 		function loadChart() {
-			fetch('/api/' + boxID + '/history/stats?hours=' + hours + '&limit=' + limit)
+			fetch('/api/' + boxID + '/metrics/stats?hours=' + hours + '&limit=' + limit)
 				.then(function(r) { return r.json(); })
 				.then(function(json) {
 					var data = json.data || [];

--- a/gearbox/internal/gears/metrics/handlers.go
+++ b/gearbox/internal/gears/metrics/handlers.go
@@ -19,8 +19,9 @@ func NewHandlers(deps gear.Dependencies) *Handlers {
 	return &Handlers{deps: deps}
 }
 
-// HistoryPage renders the history/metrics page.
-func (h *Handlers) HistoryPage(w http.ResponseWriter, r *http.Request) {
+// MetricsPage renders the Metrics gear's main page (charts, KPI band,
+// error insights). Served at /metrics on the dashboard.
+func (h *Handlers) MetricsPage(w http.ResponseWriter, r *http.Request) {
 	// Check permission
 	if !h.deps.Auth.HasPermission(r, "metrics", "view") {
 		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
@@ -43,10 +44,10 @@ func (h *Handlers) HistoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 	servers := serverAdapter.GetEnabledServersAsModels()
 
-	// Render the history page
-	component := pages.History(user, servers)
+	// Render the Metrics page
+	component := pages.Metrics(user, servers)
 	if err := component.Render(r.Context(), w); err != nil {
-		h.deps.Logger.Error("failed to render history page", "error", err)
+		h.deps.Logger.Error("failed to render metrics page", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}
 }

--- a/gearbox/internal/gears/metrics/plugin.go
+++ b/gearbox/internal/gears/metrics/plugin.go
@@ -1,5 +1,8 @@
-// Package metrics provides historical metrics and charts for HAProxy monitoring.
-// This plugin shows historical stats, system metrics, and graphs.
+// Package metrics provides the dashboard's Metrics gear: time-series
+// stats, system metrics, KPI band, and error insights, served at
+// /metrics. (Earlier revisions of this package called the page
+// "/history" — issue #97 renamed it; "history" now refers only to
+// distinct concepts like OS-update apt history.)
 package metrics
 
 import (
@@ -14,7 +17,7 @@ func init() {
 	gear.Register(&Gear{})
 }
 
-// Plugin implements the metrics/history functionality.
+// Gear implements the Metrics dashboard page.
 type Gear struct {
 	gear.BaseGear
 	handlers *Handlers
@@ -24,8 +27,8 @@ type Gear struct {
 func (p *Gear) Info() gear.Info {
 	return gear.Info{
 		Name:        "metrics",
-		DisplayName: "Metrics & History",
-		Description: "View historical stats, system metrics, and performance graphs",
+		DisplayName: "Metrics",
+		Description: "Time-series stats, system metrics, KPIs, and error insights",
 		Version:     "1.0.0",
 		Icon:        "chart-bar",
 		Category:    "monitoring",
@@ -45,20 +48,20 @@ func (p *Gear) Initialize(ctx context.Context, deps gear.Dependencies) error {
 }
 
 // RegisterRoutes registers HTTP routes for the metrics gear.
-// When mounted at /history, provides:
-//   - GET /history/ - Main history/metrics page
+// When mounted at /metrics, provides:
+//   - GET /metrics/ — main Metrics page
 //
-// Note: API endpoints (/api/{serverID}/history/*, /api/{serverID}/metrics-history,
-// /api/{serverID}/stats-history) remain in the main handler.
+// Per-box API endpoints live in the framework handler under
+// /api/{boxID}/metrics/* (see cmd/server/main.go).
 func (p *Gear) RegisterRoutes(r chi.Router) {
 	// Main page
-	r.Get("/", p.handlers.HistoryPage)
+	r.Get("/", p.handlers.MetricsPage)
 }
 
 // SidebarItem returns the sidebar configuration.
 func (p *Gear) SidebarItem() *gear.SidebarConfig {
 	return &gear.SidebarConfig{
-		Path:               "/history",
+		Path:               "/metrics",
 		Icon:               MetricsIcon(),
 		DefaultOrder:       30,
 		RequiresPermission: "metrics:view",

--- a/gearbox/static/js/gears/gears-page.js
+++ b/gearbox/static/js/gears/gears-page.js
@@ -136,7 +136,7 @@ if (!sidebar) return;
 
 // Map integration names to their sidebar link hrefs
 const gearHrefs = {
-	'metrics': '/history',
+	'metrics': '/metrics',
 	'logs': '/logs',
 	'services': '/services',
 	'certificates': '/certificates',
@@ -315,7 +315,7 @@ if (card) {
 	// Plugin name to URL path mapping
 	const gearPaths = {
 		'haproxy': '/haproxy',
-		'metrics': '/history',
+		'metrics': '/metrics',
 		'logs': '/logs',
 		'services': '/services',
 		'certificates': '/certificates',


### PR DESCRIPTION
## Summary

Two related changes that close out the "what does *history* mean in this codebase" question:

1. **Rename the Metrics gear URL** from `/history` to `/metrics` end-to-end (page route, API endpoints, handler functions, file name, templ component, sidebar, JS callers, docs).
2. **Add a themed static 404 page** wired into chi's `NotFound`. Anyone with a bookmark to the old `/history` URL will now land on a Gearbox-styled 404 instead of the browser's default — and the handler is intentionally static (no templ, no auth, no DB) so a typo'd URL can't be a side channel for fingerprinting session state.

## Why now

The Metrics gear was historically called "history" because the page shows time-series. That name leaked everywhere: the URL, the API endpoints, the templ file (`history.templ`), the handler functions (`HistoryPage`, `APIStatsHistoryHandler`, …), and assorted comments. With [#95](https://github.com/sarg3nt/gearbox/issues/95)'s "metric source" / "primary source" terminology landing, the dual naming has become genuinely confusing — particularly because there are *other* legitimate "history" concepts in the codebase (OS-update apt/zypper history, HAProxy config change history) that should keep their names.

Renaming the Metrics-gear identity isolates "history" to those genuinely-distinct concepts, so a future reader sees `history` and knows it means OS-update or config-change history, not the Metrics page.

## What's renamed

**Routes:**

- Page: `/history` → `/metrics`
- API: `/api/{boxID}/history/stats` → `/api/{boxID}/metrics/stats`
- API: `/api/{boxID}/history/metrics` → `/api/{boxID}/metrics/system`
- API: `/api/{boxID}/history/backend/{name}` → `/api/{boxID}/metrics/backend/{name}` (coexists with the existing `/metrics/backend/{name}/details` drill-down from [#87](https://github.com/sarg3nt/gearbox/issues/87))

**Go identifiers:**

- `HistoryPage` → `MetricsPage`
- `APIStatsHistoryHandler` → `APIMetricsStatsHandler`
- `APIBackendHistoryHandler` → `APIMetricsBackendHandler`
- `APISystemMetricsHistoryHandler` → `APIMetricsSystemHandler`
- `pages.History()` templ component → `pages.Metrics()`

**Files:**

- `templates/pages/history.templ` → `templates/pages/metrics.templ`

**Docs / comments / sidebar:**

- `metrics/README.md` routes table, architecture diagram, development snippet
- `cmd/server/main.go` route-group comment
- `handler/pages.go` migration-history comment
- `models/permissions.go` field comment
- `docs/gears.md` gear list
- `templates/layouts/base.templ` sidebar links (regular + draggable) + current-path match
- `static/js/gears/gears-page.js` URL map (both copies)
- 8 fetch URLs across `metrics.templ`, `details.templ`, `chart_partials.templ`

## Intentionally kept as "history"

These are legitimately distinct concepts; renaming would obscure their meaning:

- **DB tables** `stats_history`, `system_metrics_history`, `backend_history` — the rows ARE historical records. Renaming requires a migration with no user-visible benefit; the names accurately describe what they contain. The DB read methods (`GetStatsHistory`, etc.) keep their names for the same reason.
- **Snapshot interval / retention config** `HistoryIntervalSeconds`, `store_history`, `history_retention_days` — these control how the historical record is kept.
- **OS-update package-manager history** — apt/zypper/dnf/pacman/apk/yum history. `/api/v1/system/updates/history`, `parseAptHistoryLog`, `/var/log/apt/history.log`, `/os-updates/history` on the dashboard. Untouched.
- **HAProxy config change history** — `/{boxID}/haproxy/config/history`, `change_history.templ`, `APIHAProxyConfigHistory`. Untouched.

## Themed static 404

Wired via `r.NotFound(handler.NotFoundHandler)` on the root chi router so it inherits only the global middleware (security headers, asset config) and **not** the auth / session / DB middleware on the protected route groups.

Security posture (enforced by tests):

- No templ rendering, no auth lookup, no DB queries.
- HTML is a Go `const` — no filesystem or template lookup at request time.
- Inline CSS only — works even if the static-asset bundle didn't load.
- Does not echo any part of the request (URL, headers, cookies) into the response — guards against the page becoming a reflection vector. `TestNotFoundHandlerDoesNotEchoRequestData` probes for marker strings in the response body and fails if any leak.
- `Cache-Control: no-store` so a 404 doesn't outlive a deploy that later adds the missing route.

Visual: dashboard's blue accent (#2563eb), system fonts (no external font loading), `prefers-color-scheme`-aware.

## Agent module

No changes. The agent's `history` references are all OS-update package-manager history (apt/zypper/dnf/pacman/apk/yum), which is the legitimate concept. Verified by grep — nothing left that ties to the Metrics gear's identity.

## Test plan

- [x] `make test` — full gearbox suite green.
- [x] `make test` on gearbox-agent — 15 packages green (no changes; verifying nothing collateral).
- [x] `go vet ./...` clean.
- [x] 3 new tests for `NotFoundHandler` — status/body, no-reflection, stable across HTTP methods.
- [ ] Manual smoke: `/metrics` loads charts on `light-hugger`.
- [ ] Manual smoke: visiting `/history` (the old URL) lands on the themed 404 with a working "Back to dashboard" link.
- [ ] Manual smoke: typing a garbage URL like `/lolnope` lands on the themed 404.

## Follow-up

Separate branch in the next PR: fix the `scales.y.ticks.stepSize: 1 would result generating up to 8681 ticks. Limiting to 1000.` Chart.js warning spam. Pre-existing issue — three places force `stepSize: 1` where `precision: 0` would give the intended "integer ticks only" behaviour without making Chart.js generate thousands of tick marks when the data range is large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)