### PR TITLE
feat(#91): dashboard — multi-source metrics page (nginx/Apache/Caddy/Traefik)

### DIFF
--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -697,6 +697,13 @@ func main() {
 			r.Get("/{boxID}/metrics/backend/{backendName}/details", h.APIMetricsBackendDetailsHandler)
 			r.Get("/{boxID}/metrics/log-errors", h.APIMetricsLogErrorsHandler)
 
+			// Per-source metrics endpoints (issue #91 phases 4/5/7).
+			// {source} ∈ {nginx, apache, caddy, traefik} for summary;
+			// the log-errors variant also accepts "haproxy" because
+			// Phase 5 unifies log parsing across every source.
+			r.Get("/{boxID}/metrics/source/{source}/summary", h.APIMetricsSourceSummaryHandler)
+			r.Get("/{boxID}/metrics/source/{source}/log-errors", h.APIMetricsSourceLogErrorsHandler)
+
 			// Per-box capability manifest — exposes which agent gears probed
 			// available so the metrics gear (and future source-aware UI) can
 			// hide cards/KPIs that don't apply to this host.

--- a/gearbox/internal/framework/agent/client.go
+++ b/gearbox/internal/framework/agent/client.go
@@ -276,8 +276,6 @@ func (c *Client) doRequestWithBody(method, path string, reqBody interface{}) ([]
 	return c.doRequestWithBodyAndQuery(method, path, reqBody, nil)
 }
 
-
-
 // doRequestWithBodyAndQuery performs an HTTP request with a JSON body and query parameters.
 func (c *Client) doRequestWithBodyAndQuery(method, path string, reqBody interface{}, query url.Values) ([]byte, error) {
 	fullURL := c.baseURL + path
@@ -1903,14 +1901,17 @@ type AccessLogResponse struct {
 }
 
 // GetAccessLogRecent fetches recent parsed log records from the
-// agent's access-log endpoint. statusMin defaults to 500 server-
-// side when 0 is passed (agent's own convention); limit and lines
-// are clamped server-side to [1, 10000]. Returns the envelope as-is
-// so the handler can decide whether to surface available=false
-// content versus a 4xx.
+// agent's access-log endpoint. statusMin = 0 is a valid value
+// meaning "disable filtering" — the agent treats it that way (see
+// gearbox-agent's access-log handler). To distinguish "caller
+// supplied 0 explicitly" from "caller wants the agent default of
+// 500" we treat any non-negative value as caller-supplied and pass
+// it through; a negative value (e.g. -1) is the way to fall back
+// to the agent default. limit > 0 follows the same explicit/default
+// split — 0 is server-default, positive is explicit.
 func (c *Client) GetAccessLogRecent(source string, statusMin, limit int) (*AccessLogResponse, error) {
 	q := url.Values{}
-	if statusMin > 0 {
+	if statusMin >= 0 {
 		q.Set("status_min", fmt.Sprintf("%d", statusMin))
 	}
 	if limit > 0 {

--- a/gearbox/internal/framework/agent/client.go
+++ b/gearbox/internal/framework/agent/client.go
@@ -1822,3 +1822,107 @@ func (c *Client) ConfigureUnattended(enabled, autoReboot bool) (*UnattendedConfi
 
 	return &resp, nil
 }
+
+// ==============================================================
+// Source-aware metrics endpoints (issue #91 phases 4 + 5 + 7).
+//
+// These mirror the agent's /api/v1/{nginx,apache,caddy,traefik}/stats
+// + /api/v1/access-log/{source}/recent shape. The dashboard collector
+// calls GetSourceStats once per available source per scrape; the
+// metrics-page handler calls GetAccessLogRecent when the Error
+// Insights panel asks for a different source. The agent endpoints
+// landed in PR #100 / #101; see gearbox-agent/docs/source-detection.md
+// for the per-source surface they expose.
+// ==============================================================
+
+// SourceStats is the un-typed JSON payload the agent's /api/v1/{src}/stats
+// endpoints return. Each source's Stats struct shape differs (nginx has
+// active/reading/writing/waiting; Traefik has per-status-class counters;
+// etc.), so the client surface keeps the payload as a flexible map and
+// lets the collector normalise it into the database's SourceStatsSnapshot
+// shape. This avoids re-declaring four near-identical Go types whose only
+// real purpose is JSON unmarshaling.
+type SourceStats map[string]any
+
+// GetSourceStats fetches the latest stats snapshot for one source
+// (nginx / apache / caddy / traefik). Returns 503 from the agent
+// when the gear hasn't completed its first scrape yet; we surface
+// that as an error so the collector can log + skip without
+// persisting a misleading zero row.
+//
+// `source` must be one of the four supported identifiers; the
+// agent will return 404 for anything else and we surface that too.
+func (c *Client) GetSourceStats(source string) (SourceStats, error) {
+	body, err := c.doRequest("GET", "/api/v1/"+source+"/stats", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out SourceStats
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("failed to parse %s stats response: %w", source, err)
+	}
+	return out, nil
+}
+
+// AccessLogRecord mirrors the agent's accesslog.Record shape — the
+// dashboard renders these directly in the Error Insights panel, so
+// the JSON keys here have to track the agent's. Keep alphabetical
+// by field name within each grouping so adding a new field is a
+// trivial inspection.
+type AccessLogRecord struct {
+	Profile      string  `json:"profile"`
+	Timestamp    string  `json:"timestamp,omitempty"`
+	TimestampRaw string  `json:"timestamp_raw,omitempty"`
+	SourceIP     string  `json:"source_ip,omitempty"`
+	Method       string  `json:"method,omitempty"`
+	Path         string  `json:"path,omitempty"`
+	Host         string  `json:"host,omitempty"`
+	StatusCode   int     `json:"status_code"`
+	BytesSent    int64   `json:"bytes_sent,omitempty"`
+	DurationMs   float64 `json:"duration_ms,omitempty"`
+	Backend      string  `json:"backend,omitempty"`
+	Server       string  `json:"server,omitempty"`
+	UserAgent    string  `json:"user_agent,omitempty"`
+	Referer      string  `json:"referer,omitempty"`
+	Raw          string  `json:"raw"`
+}
+
+// AccessLogResponse is the envelope the agent's
+// /api/v1/access-log/{source}/recent endpoint returns. Available=false
+// + a Reason populated means the host has no readable log for this
+// source — the dashboard renders that as a "logs unavailable" hint
+// rather than an empty panel.
+type AccessLogResponse struct {
+	Source     string            `json:"source"`
+	Profile    string            `json:"profile"`
+	Path       string            `json:"path,omitempty"`
+	Available  bool              `json:"available"`
+	Reason     string            `json:"reason,omitempty"`
+	MatchCount int               `json:"match_count"`
+	Records    []AccessLogRecord `json:"records"`
+}
+
+// GetAccessLogRecent fetches recent parsed log records from the
+// agent's access-log endpoint. statusMin defaults to 500 server-
+// side when 0 is passed (agent's own convention); limit and lines
+// are clamped server-side to [1, 10000]. Returns the envelope as-is
+// so the handler can decide whether to surface available=false
+// content versus a 4xx.
+func (c *Client) GetAccessLogRecent(source string, statusMin, limit int) (*AccessLogResponse, error) {
+	q := url.Values{}
+	if statusMin > 0 {
+		q.Set("status_min", fmt.Sprintf("%d", statusMin))
+	}
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	body, err := c.doRequest("GET", "/api/v1/access-log/"+source+"/recent", q)
+	if err != nil {
+		return nil, err
+	}
+	var resp AccessLogResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse access-log response: %w", err)
+	}
+	return &resp, nil
+}

--- a/gearbox/internal/framework/collector/manager.go
+++ b/gearbox/internal/framework/collector/manager.go
@@ -39,7 +39,8 @@ type Manager struct {
 	metadataCollector MetadataCollectorInterface
 	systemCollector   SystemCollectorInterface
 	logCollector      LogCollectorInterface
-	agentClient       *agent.Client // Direct access to agent client for security operations
+	sourceCollector   *SourceStatsCollector // per-source nginx/apache/caddy/traefik
+	agentClient       *agent.Client         // Direct access to agent client for security operations
 	logger            *slog.Logger
 	db                *database.DB
 	stopCh            chan struct{}
@@ -60,6 +61,7 @@ func NewManager(
 	metadataCollector := NewAgentMetadataCollector(agentClient)
 	systemCollector := NewAgentSystemCollector(agentClient)
 	logCollector := NewAgentLogCollector(agentClient)
+	sourceCollector := NewSourceStatsCollector(serverID, agentClient, db, logger)
 
 	return &Manager{
 		serverID:          serverID,
@@ -68,6 +70,7 @@ func NewManager(
 		metadataCollector: metadataCollector,
 		systemCollector:   systemCollector,
 		logCollector:      logCollector,
+		sourceCollector:   sourceCollector,
 		agentClient:       agentClient,
 		logger:            logger,
 		db:                db,
@@ -244,6 +247,14 @@ func (m *Manager) persistHistory() {
 				"server_id", m.serverID,
 				"error", err)
 		}
+	}
+
+	// Scrape and save per-source metrics (nginx, apache, caddy,
+	// traefik). The collector silently skips sources whose gears
+	// haven't probed Available on this host, so this is a no-op on
+	// hosts that only run HAProxy.
+	if m.sourceCollector != nil {
+		m.sourceCollector.Run()
 	}
 }
 

--- a/gearbox/internal/framework/collector/source_stats.go
+++ b/gearbox/internal/framework/collector/source_stats.go
@@ -1,0 +1,253 @@
+// Package collector — per-source metric scraping for the Metrics
+// gear's multi-source pivot (issue #91 phases 4 / 7).
+//
+// The dashboard polls each of the four non-HAProxy agent endpoints
+// (/api/v1/{nginx,apache,caddy,traefik}/stats) on the same cadence
+// as the HAProxy stats collector. Each scrape's normalised result
+// lands in the source_stats table the database layer added; the
+// metrics-page handlers read it back from there.
+//
+// We always poll every source rather than gating on the capability
+// cache: a fresh agent that hasn't completed its first probe yet,
+// or a brief network hiccup against the capability endpoint, would
+// drop scrapes if the collector consulted the cache. Agent endpoints
+// return 503 for sources whose gear hasn't successfully scraped yet
+// and 404 for unsupported sources — both cases are silently skipped
+// here so the collector stays robust.
+package collector
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+)
+
+// supportedSources lists the source identifiers the dashboard
+// collector polls every cycle. Order doesn't matter for correctness
+// (each scrape persists its own row); kept alphabetical for
+// readability when iterating in the manager and the JS layer's
+// matching list.
+var supportedSources = []string{"apache", "caddy", "nginx", "traefik"}
+
+// SupportedSources exports the canonical list so other packages
+// (handlers, tests) don't redeclare it.
+func SupportedSources() []string {
+	out := make([]string, len(supportedSources))
+	copy(out, supportedSources)
+	return out
+}
+
+// SourceStatsCollector polls one agent's per-source /stats endpoints
+// and persists the normalised results to source_stats. One instance
+// per manager; the manager's persistHistory tick drives Run().
+type SourceStatsCollector struct {
+	serverID string
+	client   *agent.Client
+	db       *database.DB
+	logger   *slog.Logger
+}
+
+// NewSourceStatsCollector wires a collector to one box's agent
+// client and the shared database. Returns nil-safe — a nil db just
+// means scrapes are no-ops, which keeps the manager wiring simple
+// during tests that don't care about persistence.
+func NewSourceStatsCollector(serverID string, client *agent.Client, db *database.DB, logger *slog.Logger) *SourceStatsCollector {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SourceStatsCollector{
+		serverID: serverID,
+		client:   client,
+		db:       db,
+		logger:   logger.With("collector", "source_stats"),
+	}
+}
+
+// Run scrapes every supported source once and persists what landed.
+// Called from the manager's persistHistory loop on the same cadence
+// the HAProxy stats snapshot is saved. Each source is fully
+// independent — one source's failure doesn't skip the next.
+func (s *SourceStatsCollector) Run() {
+	if s.db == nil {
+		return
+	}
+	for _, src := range supportedSources {
+		s.collectOne(src)
+	}
+}
+
+// collectOne scrapes one source and persists the normalised result.
+// Silently skips on the common "source not present on this host"
+// shapes (agent returns 503 = no data yet, 404 = source unsupported)
+// so a homelab box that runs only HAProxy doesn't fill the journal
+// with one warning per source per tick.
+func (s *SourceStatsCollector) collectOne(source string) {
+	raw, err := s.client.GetSourceStats(source)
+	if err != nil {
+		if isExpectedSourceMiss(err) {
+			return
+		}
+		s.logger.Warn("source stats scrape failed",
+			"server_id", s.serverID,
+			"source", source,
+			"error", err)
+		return
+	}
+	snap := normaliseSourceStats(s.serverID, source, raw)
+	if snap == nil {
+		// Shouldn't happen — every source has a normaliser — but
+		// defensively skip rather than persist a half-shaped row.
+		return
+	}
+	if err := s.db.SaveSourceStats(snap); err != nil {
+		s.logger.Error("source stats save failed",
+			"server_id", s.serverID,
+			"source", source,
+			"error", err)
+	}
+}
+
+// isExpectedSourceMiss reports whether the agent error matches one
+// of the "this source isn't installed/ready on this host" shapes we
+// want to swallow silently. We match on the HTTP status fragment in
+// the agent client's error format ("status 503: …", "status 404:
+// …") because the client doesn't expose typed errors; doing it here
+// keeps the collector quiet without the client needing a refactor.
+func isExpectedSourceMiss(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "status 503") || strings.Contains(msg, "status 404") {
+		return true
+	}
+	// Older agents (pre-#100) won't have the endpoint at all —
+	// surfaces as a 404 from the chi router. Same swallow.
+	return errors.Is(err, errNotImplementedOnAgent)
+}
+
+// errNotImplementedOnAgent is a sentinel future code can wrap into
+// returned errors when the agent rejects a probe path because the
+// gear hasn't shipped on its build yet. Today nothing returns it;
+// declared here so callers reading the swallow logic above can see
+// the shape of "expected miss" reasoning at a glance.
+var errNotImplementedOnAgent = errors.New("endpoint not implemented on agent")
+
+// normaliseSourceStats maps one source's agent-side JSON shape into
+// the common SourceStatsSnapshot the database stores. Each source
+// emits different field names; we surface the rollups
+// (requests_total, response_* where available, active connections),
+// and the rest lands in Extra for the per-source chart card to
+// consume.
+//
+// Numeric coercion uses asInt64 / asFloat — JSON numbers come
+// through encoding/json as float64, and integer fields like
+// `requests_total` round-trip cleanly because the agent never emits
+// values approaching float64's 2^53 integer ceiling.
+func normaliseSourceStats(serverID, source string, raw agent.SourceStats) *database.SourceStatsSnapshot {
+	if raw == nil {
+		return nil
+	}
+	snap := &database.SourceStatsSnapshot{
+		ServerID:    serverID,
+		Source:      source,
+		CollectedAt: parseCollectedAt(raw["collected_at"]),
+		Extra:       map[string]any{},
+	}
+
+	switch source {
+	case "nginx":
+		snap.RequestsTotal = asInt64(raw["requests"])
+		snap.ActiveConnections = asInt64(raw["active"])
+		// Per-state connection split into Extra so the dashboard
+		// can render the reading/writing/waiting stacked chart.
+		for _, k := range []string{"reading", "writing", "waiting", "accepts", "handled"} {
+			if v, ok := raw[k]; ok {
+				snap.Extra[k] = v
+			}
+		}
+
+	case "apache":
+		snap.RequestsTotal = asInt64(raw["total_accesses"])
+		// Busy workers ≈ "active connections" for chart parity
+		// with nginx; the idle counter goes to Extra alongside
+		// the other Apache-specific fields.
+		snap.ActiveConnections = asInt64(raw["busy_workers"])
+		for _, k := range []string{
+			"idle_workers", "cpu_load", "uptime_seconds",
+			"req_per_sec", "bytes_per_sec", "bytes_per_req", "total_kbytes",
+		} {
+			if v, ok := raw[k]; ok {
+				snap.Extra[k] = v
+			}
+		}
+
+	case "caddy":
+		snap.RequestsTotal = asInt64(raw["requests_total"])
+		// Caddy doesn't emit per-status-class by default; the
+		// rich aggregate of "requests that errored" lands in
+		// Extra so the dashboard can render a single error
+		// counter alongside requests_total.
+		if v, ok := raw["request_errors_total"]; ok {
+			snap.Extra["request_errors_total"] = v
+		}
+
+	case "traefik":
+		snap.RequestsTotal = asInt64(raw["requests_total"])
+		snap.Response2xx = asInt64(raw["response_2xx"])
+		snap.Response3xx = asInt64(raw["response_3xx"])
+		snap.Response4xx = asInt64(raw["response_4xx"])
+		snap.Response5xx = asInt64(raw["response_5xx"])
+		if v, ok := raw["response_1xx"]; ok {
+			snap.Extra["response_1xx"] = v
+		}
+		if v, ok := raw["entrypoints"]; ok {
+			snap.Extra["entrypoints"] = v
+		}
+
+	default:
+		// Unknown source — store the raw payload in Extra so the
+		// dashboard can at least render the bytes for diagnosis.
+		// Defensive only; supportedSources gates the caller.
+		snap.Extra["raw"] = raw
+	}
+
+	if len(snap.Extra) == 0 {
+		snap.Extra = nil
+	}
+	return snap
+}
+
+// parseCollectedAt converts the agent's RFC3339 collected_at string
+// into a time.Time. Falls back to time.Now (UTC) when the field is
+// missing or unparseable so the row still lands; better to have a
+// slightly-off timestamp than to drop the snapshot entirely.
+func parseCollectedAt(v any) time.Time {
+	if s, ok := v.(string); ok && s != "" {
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Now().UTC()
+}
+
+// asInt64 coerces a JSON-decoded number (float64) to int64 with
+// truncation toward zero. Returns 0 for nil, strings, or anything
+// else — keeps the normaliser tolerant of agent changes (a new
+// field added as a string instead of a number doesn't crash; it
+// just lands as zero until we update the mapping).
+func asInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	}
+	return 0
+}

--- a/gearbox/internal/framework/collector/source_stats.go
+++ b/gearbox/internal/framework/collector/source_stats.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"errors"
 	"log/slog"
-	"strings"
+	"net/http"
 	"time"
 
 	"github.com/sarg3nt/gearbox/internal/framework/agent"
@@ -113,29 +113,27 @@ func (s *SourceStatsCollector) collectOne(source string) {
 
 // isExpectedSourceMiss reports whether the agent error matches one
 // of the "this source isn't installed/ready on this host" shapes we
-// want to swallow silently. We match on the HTTP status fragment in
-// the agent client's error format ("status 503: …", "status 404:
-// …") because the client doesn't expose typed errors; doing it here
-// keeps the collector quiet without the client needing a refactor.
+// want to swallow silently. The agent client returns *agent.APIError
+// for any non-2xx response with the HTTP status code on a typed
+// field — we inspect that directly rather than substring-matching
+// the Message text, which would have been brittle (and previously
+// broken — the Message is just the parsed response body, not a
+// "status NNN" string).
+//
+// 503 = source-not-installed-or-not-yet-scraped (the per-source
+// /stats handler returns 503 before its first successful collection),
+// 404 = pre-#100 agent that doesn't have the endpoint at all.
 func isExpectedSourceMiss(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	if strings.Contains(msg, "status 503") || strings.Contains(msg, "status 404") {
-		return true
+	var apiErr *agent.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound ||
+			apiErr.StatusCode == http.StatusServiceUnavailable
 	}
-	// Older agents (pre-#100) won't have the endpoint at all —
-	// surfaces as a 404 from the chi router. Same swallow.
-	return errors.Is(err, errNotImplementedOnAgent)
+	return false
 }
-
-// errNotImplementedOnAgent is a sentinel future code can wrap into
-// returned errors when the agent rejects a probe path because the
-// gear hasn't shipped on its build yet. Today nothing returns it;
-// declared here so callers reading the swallow logic above can see
-// the shape of "expected miss" reasoning at a glance.
-var errNotImplementedOnAgent = errors.New("endpoint not implemented on agent")
 
 // normaliseSourceStats maps one source's agent-side JSON shape into
 // the common SourceStatsSnapshot the database stores. Each source

--- a/gearbox/internal/framework/collector/source_stats_test.go
+++ b/gearbox/internal/framework/collector/source_stats_test.go
@@ -133,19 +133,26 @@ func TestNormaliseSourceStatsTolerantOfMissingFields(t *testing.T) {
 }
 
 func TestIsExpectedSourceMiss(t *testing.T) {
+	// The agent client returns *agent.APIError for any non-2xx
+	// response — we match on the typed field, not the message text.
+	// 404 and 503 are the "source not present / not ready" shapes
+	// we swallow; everything else surfaces as a warning.
 	cases := []struct {
+		name string
 		err  error
 		want bool
 	}{
-		{nil, false},
-		{errors.New("status 503: no data"), true},
-		{errors.New("status 404: not found"), true},
-		{errors.New("status 500: something broke"), false},
-		{errors.New("connection refused"), false},
+		{"nil", nil, false},
+		{"503 (not yet collected)", &agent.APIError{StatusCode: 503, Message: "stats not yet collected"}, true},
+		{"404 (endpoint missing on older agent)", &agent.APIError{StatusCode: 404, Message: "not found"}, true},
+		{"500 (real failure)", &agent.APIError{StatusCode: 500, Message: "boom"}, false},
+		{"plain error (transport)", errors.New("connection refused"), false},
 	}
 	for _, tc := range cases {
-		if got := isExpectedSourceMiss(tc.err); got != tc.want {
-			t.Errorf("isExpectedSourceMiss(%v) = %v, want %v", tc.err, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isExpectedSourceMiss(tc.err); got != tc.want {
+				t.Errorf("isExpectedSourceMiss(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/gearbox/internal/framework/collector/source_stats_test.go
+++ b/gearbox/internal/framework/collector/source_stats_test.go
@@ -1,0 +1,151 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+)
+
+func TestNormaliseSourceStatsNginx(t *testing.T) {
+	// JSON-decoded floats: encoding/json gives every numeric value
+	// as float64 regardless of the wire shape, so we have to
+	// reproduce that here for the test to match production.
+	raw := agent.SourceStats{
+		"active":       float64(291),
+		"reading":      float64(6),
+		"writing":      float64(179),
+		"waiting":      float64(106),
+		"accepts":      float64(16630948),
+		"handled":      float64(16630948),
+		"requests":     float64(31070465),
+		"collected_at": "2026-05-15T04:00:00Z",
+	}
+	got := normaliseSourceStats("server-1", "nginx", raw)
+	if got == nil {
+		t.Fatal("expected snapshot")
+	}
+	if got.RequestsTotal != 31070465 {
+		t.Errorf("RequestsTotal = %d, want 31070465 (nginx 'requests' counter)", got.RequestsTotal)
+	}
+	if got.ActiveConnections != 291 {
+		t.Errorf("ActiveConnections = %d, want 291 (nginx 'active')", got.ActiveConnections)
+	}
+	// reading/writing/waiting/accepts/handled must land in Extra
+	// for the dashboard's stacked-connection chart.
+	for _, k := range []string{"reading", "writing", "waiting", "accepts", "handled"} {
+		if _, ok := got.Extra[k]; !ok {
+			t.Errorf("Extra[%q] missing", k)
+		}
+	}
+	if got.CollectedAt.UTC().Format(time.RFC3339) != "2026-05-15T04:00:00Z" {
+		t.Errorf("CollectedAt = %v, want round-trip of agent timestamp", got.CollectedAt)
+	}
+}
+
+func TestNormaliseSourceStatsApacheUsesBusyWorkersAsActive(t *testing.T) {
+	// Apache doesn't have a direct "active connections" — busy
+	// workers is the closest analogue for the dashboard's parity
+	// chart against nginx. Idle workers + CPU load + uptime move
+	// to Extra so the per-source card can render them too.
+	raw := agent.SourceStats{
+		"total_accesses": float64(1234),
+		"busy_workers":   float64(5),
+		"idle_workers":   float64(95),
+		"cpu_load":       float64(0.5),
+		"uptime_seconds": float64(1000),
+		"collected_at":   "2026-05-15T04:00:00Z",
+	}
+	got := normaliseSourceStats("s", "apache", raw)
+	if got.RequestsTotal != 1234 {
+		t.Errorf("RequestsTotal = %d, want 1234", got.RequestsTotal)
+	}
+	if got.ActiveConnections != 5 {
+		t.Errorf("ActiveConnections = %d, want 5 (busy_workers)", got.ActiveConnections)
+	}
+	if got.Extra["idle_workers"].(float64) != 95 {
+		t.Errorf("Extra[idle_workers] = %v, want 95", got.Extra["idle_workers"])
+	}
+}
+
+func TestNormaliseSourceStatsCaddy(t *testing.T) {
+	raw := agent.SourceStats{
+		"requests_total":       float64(59),
+		"request_errors_total": float64(3),
+		"collected_at":         "2026-05-15T04:00:00Z",
+	}
+	got := normaliseSourceStats("s", "caddy", raw)
+	if got.RequestsTotal != 59 {
+		t.Errorf("RequestsTotal = %d, want 59", got.RequestsTotal)
+	}
+	// Caddy's error counter lands in Extra (no status-class
+	// breakdown by default).
+	if got.Extra["request_errors_total"].(float64) != 3 {
+		t.Errorf("Extra[request_errors_total] = %v, want 3", got.Extra["request_errors_total"])
+	}
+}
+
+func TestNormaliseSourceStatsTraefikSplitsStatusClass(t *testing.T) {
+	raw := agent.SourceStats{
+		"requests_total": float64(116),
+		"response_2xx":   float64(104),
+		"response_4xx":   float64(7),
+		"response_5xx":   float64(5),
+		"entrypoints":    []any{"web", "websecure"},
+		"collected_at":   "2026-05-15T04:00:00Z",
+	}
+	got := normaliseSourceStats("s", "traefik", raw)
+	if got.RequestsTotal != 116 || got.Response2xx != 104 || got.Response5xx != 5 {
+		t.Errorf("rollups wrong: %+v", got)
+	}
+	// Entrypoints list must survive the normalisation so the
+	// dashboard can render the entrypoint badges.
+	if eps, ok := got.Extra["entrypoints"]; !ok || eps == nil {
+		t.Errorf("Extra[entrypoints] missing")
+	}
+}
+
+func TestNormaliseSourceStatsCollectedAtFallsBackToNow(t *testing.T) {
+	// Agent payloads without collected_at (or with garbage) get
+	// time.Now stamped so the row still lands rather than getting
+	// dropped silently.
+	raw := agent.SourceStats{"requests_total": float64(1)}
+	before := time.Now().UTC().Add(-time.Second)
+	got := normaliseSourceStats("s", "caddy", raw)
+	if got.CollectedAt.Before(before) {
+		t.Errorf("CollectedAt = %v, expected fallback ~now", got.CollectedAt)
+	}
+}
+
+func TestNormaliseSourceStatsTolerantOfMissingFields(t *testing.T) {
+	// Empty payload (e.g. agent returned a body that decoded
+	// cleanly but had no useful fields) — must produce a
+	// zero-valued snapshot, not nil. Persisting the zeros is the
+	// honest thing to do; the dashboard will render "no activity".
+	got := normaliseSourceStats("s", "nginx", agent.SourceStats{})
+	if got == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if got.RequestsTotal != 0 || got.ActiveConnections != 0 {
+		t.Errorf("expected zero counters for empty payload, got %+v", got)
+	}
+}
+
+func TestIsExpectedSourceMiss(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("status 503: no data"), true},
+		{errors.New("status 404: not found"), true},
+		{errors.New("status 500: something broke"), false},
+		{errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		if got := isExpectedSourceMiss(tc.err); got != tc.want {
+			t.Errorf("isExpectedSourceMiss(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}

--- a/gearbox/internal/framework/database/database.go
+++ b/gearbox/internal/framework/database/database.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	_ "modernc.org/sqlite"
 	"github.com/sarg3nt/gearbox/internal/framework/models"
+	_ "modernc.org/sqlite"
 )
 
 // DB wraps the SQLite database connection.
@@ -811,6 +811,15 @@ func (d *DB) ClearMetricsData(boxID string) error {
 		`DELETE FROM stats_history WHERE box_id = ?`,
 		`DELETE FROM backend_history WHERE box_id = ?`,
 		`DELETE FROM system_metrics_history WHERE box_id = ?`,
+		// source_stats lives in the traffic-analysis schema but is
+		// driven by the same metrics-collection cadence as the
+		// HAProxy stats_history table above. Clearing metrics data
+		// must wipe it too, otherwise per-source history stays
+		// visible after the operator clicks "clear" and surprises
+		// them. The column is server_id rather than box_id (table
+		// is shared with traffic_flows which predates the box_id
+		// naming), so the WHERE clause differs.
+		`DELETE FROM source_stats WHERE server_id = ?`,
 	}
 
 	for _, query := range queries {
@@ -839,6 +848,11 @@ func (d *DB) CleanupMetricsByAge(boxID string, retention time.Duration) (int64, 
 		`DELETE FROM stats_history WHERE box_id = ? AND collected_at < ?`,
 		`DELETE FROM backend_history WHERE box_id = ? AND collected_at < ?`,
 		`DELETE FROM system_metrics_history WHERE box_id = ? AND collected_at < ?`,
+		// source_stats follows the same TTL as the HAProxy
+		// histories — see ClearMetricsData for the rationale.
+		// Different WHERE column name because the traffic-analysis
+		// schema uses server_id, not box_id.
+		`DELETE FROM source_stats WHERE server_id = ? AND collected_at < ?`,
 	}
 
 	for _, query := range queries {
@@ -858,14 +872,19 @@ func (d *DB) CleanupMetricsBySize(boxID string, maxSizeMB int) (int64, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Get current stats
-	var statsCount, backendCount, metricsCount int64
+	// Get current stats. source_stats joins the proportional cleanup
+	// at the same rough byte-per-row weight as system_metrics_history
+	// (~150 bytes; 4 numeric columns + a tiny JSON blob). Without it
+	// the per-source table would grow unbounded under the size-based
+	// retention policy.
+	var statsCount, backendCount, metricsCount, sourceCount int64
 	_ = d.db.QueryRow("SELECT COUNT(*) FROM stats_history WHERE box_id = ?", boxID).Scan(&statsCount)
 	_ = d.db.QueryRow("SELECT COUNT(*) FROM backend_history WHERE box_id = ?", boxID).Scan(&backendCount)
 	_ = d.db.QueryRow("SELECT COUNT(*) FROM system_metrics_history WHERE box_id = ?", boxID).Scan(&metricsCount)
+	_ = d.db.QueryRow("SELECT COUNT(*) FROM source_stats WHERE server_id = ?", boxID).Scan(&sourceCount)
 
 	// Estimate current size
-	currentSizeBytes := statsCount*150 + backendCount*200 + metricsCount*100
+	currentSizeBytes := statsCount*150 + backendCount*200 + metricsCount*100 + sourceCount*150
 	maxSizeBytes := int64(maxSizeMB) * 1024 * 1024
 
 	if currentSizeBytes <= maxSizeBytes {
@@ -878,7 +897,7 @@ func (d *DB) CleanupMetricsBySize(boxID string, maxSizeMB int) (int64, error) {
 
 	// Delete oldest records proportionally from each table
 	var totalDeleted int64
-	totalRecords := statsCount + backendCount + metricsCount
+	totalRecords := statsCount + backendCount + metricsCount + sourceCount
 	if totalRecords == 0 {
 		return 0, nil
 	}
@@ -922,6 +941,24 @@ func (d *DB) CleanupMetricsBySize(boxID string, maxSizeMB int) (int64, error) {
 			result, err := d.db.Exec(`
 				DELETE FROM system_metrics_history WHERE box_id = ? AND id IN (
 					SELECT id FROM system_metrics_history WHERE box_id = ? ORDER BY collected_at ASC LIMIT ?
+				)
+			`, boxID, boxID, deleteCount)
+			if err == nil {
+				deleted, _ := result.RowsAffected()
+				totalDeleted += deleted
+			}
+		}
+	}
+
+	// Delete from source_stats (per-source rollups). Different
+	// id-WHERE column (server_id) because the traffic-analysis
+	// schema predates the box_id naming.
+	if sourceCount > 0 {
+		deleteCount := int64(float64(bytesToDelete) * float64(sourceCount) / float64(currentSizeBytes) / 150)
+		if deleteCount > 0 {
+			result, err := d.db.Exec(`
+				DELETE FROM source_stats WHERE server_id = ? AND id IN (
+					SELECT id FROM source_stats WHERE server_id = ? ORDER BY collected_at ASC LIMIT ?
 				)
 			`, boxID, boxID, deleteCount)
 			if err == nil {

--- a/gearbox/internal/framework/database/source_stats.go
+++ b/gearbox/internal/framework/database/source_stats.go
@@ -109,6 +109,14 @@ func (d *DB) GetLatestSourceStats(serverID, source string) (*SourceStatsSnapshot
 // collected_at ascending. Used by the time-series chart cards
 // (request rate over the last hour, etc.). Caller clamps the
 // limit; we just translate the SQL.
+//
+// IMPORTANT ordering note: when the time range contains more rows
+// than `limit` allows, we want the NEWEST rows (so the chart shows
+// the recent end of the window, not stale samples from the start
+// of a multi-day range). The SQL therefore selects in DESC order
+// with LIMIT, then we reverse to chronological order for the
+// caller. SQLite plans this as well as ASC-LIMIT because the
+// underlying index is ordered.
 func (d *DB) GetSourceStatsRange(serverID, source string, since, until time.Time, limit int) ([]SourceStatsSnapshot, error) {
 	if limit <= 0 || limit > 10000 {
 		limit = 10000
@@ -123,7 +131,7 @@ func (d *DB) GetSourceStatsRange(serverID, source string, since, until time.Time
 		FROM source_stats
 		WHERE server_id = ? AND source = ?
 		  AND collected_at >= ? AND collected_at <= ?
-		ORDER BY collected_at ASC
+		ORDER BY collected_at DESC
 		LIMIT ?`,
 		serverID, source, since, until, limit,
 	)
@@ -140,7 +148,15 @@ func (d *DB) GetSourceStatsRange(serverID, source string, since, until time.Time
 		}
 		out = append(out, *s)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Reverse to chronological order so the chart renders earliest
+	// → latest as the caller (and Chart.js) expects.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, nil
 }
 
 // PruneSourceStats deletes rows older than `before` for the given

--- a/gearbox/internal/framework/database/source_stats.go
+++ b/gearbox/internal/framework/database/source_stats.go
@@ -1,0 +1,191 @@
+// Package database — per-source aggregate rollups for the Metrics
+// gear's multi-source pivot (issue #91 Phase 4 / 7 dashboard side).
+//
+// The table is created in traffic.go's initTrafficSchema alongside
+// the other traffic-analysis tables; this file holds the typed
+// save/query helpers the collector and handlers call. Kept in a
+// separate file so it's easy to spot when reading the database/
+// package for the first time — "ah, source_stats has its own
+// helpers, those go with the source-aware Metrics endpoints".
+package database
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// SourceStatsSnapshot is the typed shape of one source_stats row.
+// Mirrors the schema in initTrafficSchema; ExtraJSON unmarshals on
+// demand into per-source structs (the handler picks the right one
+// based on Source). Kept in this package rather than `models/` so
+// it stays the database layer's owned shape — the handler maps it
+// to a JSON response shape that the dashboard consumes.
+type SourceStatsSnapshot struct {
+	ServerID          string    `json:"server_id"`
+	Source            string    `json:"source"`
+	CollectedAt       time.Time `json:"collected_at"`
+	RequestsTotal     int64     `json:"requests_total"`
+	Response2xx       int64     `json:"response_2xx"`
+	Response3xx       int64     `json:"response_3xx"`
+	Response4xx       int64     `json:"response_4xx"`
+	Response5xx       int64     `json:"response_5xx"`
+	ActiveConnections int64     `json:"active_connections"`
+	// Extra carries source-specific fields the common columns don't
+	// capture (nginx reading/writing/waiting; Apache busy/idle
+	// workers; Caddy request_errors_total; Traefik entrypoints).
+	// Stored as a JSON string in the DB; handlers unmarshal into
+	// the right per-source struct.
+	Extra map[string]any `json:"extra,omitempty"`
+}
+
+// ErrNoSourceStats is returned by GetLatestSourceStats when no
+// row exists for the requested (server_id, source) pair. Callers
+// (the handler) translate it into a "this source hasn't been
+// polled yet" envelope rather than a 500.
+var ErrNoSourceStats = errors.New("no source_stats row for the requested server/source")
+
+// SaveSourceStats inserts a new snapshot row. We don't upsert on
+// collected_at the way SaveTrafficFlow does because each scrape is
+// a distinct point-in-time observation — the dashboard derives
+// rates by diffing successive rows, and merging two scrapes into
+// one would lie about timing. The table is bounded by the cleanup
+// loop (TTL via prune_source_stats below), not by per-row upsert.
+func (d *DB) SaveSourceStats(s *SourceStatsSnapshot) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var extraJSON sql.NullString
+	if len(s.Extra) > 0 {
+		b, err := json.Marshal(s.Extra)
+		if err != nil {
+			return fmt.Errorf("marshal extra: %w", err)
+		}
+		extraJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	_, err := d.db.Exec(`
+		INSERT INTO source_stats (
+			server_id, source, collected_at,
+			requests_total, response_2xx, response_3xx, response_4xx, response_5xx,
+			active_connections, extra_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ServerID, s.Source, s.CollectedAt,
+		s.RequestsTotal, s.Response2xx, s.Response3xx, s.Response4xx, s.Response5xx,
+		s.ActiveConnections, extraJSON,
+	)
+	return err
+}
+
+// GetLatestSourceStats returns the most recent snapshot for one
+// (server, source) pair. The handler uses this for the KPI band's
+// current-value cards. Returns ErrNoSourceStats when nothing has
+// been collected yet so the caller can render a clean "not yet
+// collected" envelope.
+func (d *DB) GetLatestSourceStats(serverID, source string) (*SourceStatsSnapshot, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	row := d.db.QueryRow(`
+		SELECT server_id, source, collected_at,
+		       requests_total, response_2xx, response_3xx, response_4xx, response_5xx,
+		       active_connections, extra_json
+		FROM source_stats
+		WHERE server_id = ? AND source = ?
+		ORDER BY collected_at DESC
+		LIMIT 1`,
+		serverID, source,
+	)
+	s, err := scanSourceStats(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNoSourceStats
+	}
+	return s, err
+}
+
+// GetSourceStatsRange returns snapshots in [since, until] order by
+// collected_at ascending. Used by the time-series chart cards
+// (request rate over the last hour, etc.). Caller clamps the
+// limit; we just translate the SQL.
+func (d *DB) GetSourceStatsRange(serverID, source string, since, until time.Time, limit int) ([]SourceStatsSnapshot, error) {
+	if limit <= 0 || limit > 10000 {
+		limit = 10000
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT server_id, source, collected_at,
+		       requests_total, response_2xx, response_3xx, response_4xx, response_5xx,
+		       active_connections, extra_json
+		FROM source_stats
+		WHERE server_id = ? AND source = ?
+		  AND collected_at >= ? AND collected_at <= ?
+		ORDER BY collected_at ASC
+		LIMIT ?`,
+		serverID, source, since, until, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]SourceStatsSnapshot, 0, 64)
+	for rows.Next() {
+		s, err := scanSourceStats(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *s)
+	}
+	return out, rows.Err()
+}
+
+// PruneSourceStats deletes rows older than `before` for the given
+// server. Called by the existing TTL cleanup loop (same cadence as
+// the traffic_flows prune). Returns the number of rows removed so
+// the caller can log it without re-counting.
+func (d *DB) PruneSourceStats(serverID string, before time.Time) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	res, err := d.db.Exec(`
+		DELETE FROM source_stats
+		WHERE server_id = ? AND collected_at < ?`,
+		serverID, before,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// scanSourceStats reads one row from either *sql.Row or *sql.Rows
+// — the small interface is enough to share the column ordering
+// between the latest-snapshot and range queries above.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSourceStats(r rowScanner) (*SourceStatsSnapshot, error) {
+	var s SourceStatsSnapshot
+	var extra sql.NullString
+	if err := r.Scan(
+		&s.ServerID, &s.Source, &s.CollectedAt,
+		&s.RequestsTotal, &s.Response2xx, &s.Response3xx, &s.Response4xx, &s.Response5xx,
+		&s.ActiveConnections, &extra,
+	); err != nil {
+		return nil, err
+	}
+	if extra.Valid && extra.String != "" {
+		if err := json.Unmarshal([]byte(extra.String), &s.Extra); err != nil {
+			// Corrupt JSON shouldn't fail the read — log via the
+			// caller's logger when needed; here we just blank
+			// the field so the row still surfaces.
+			s.Extra = nil
+		}
+	}
+	return &s, nil
+}

--- a/gearbox/internal/framework/database/traffic.go
+++ b/gearbox/internal/framework/database/traffic.go
@@ -99,6 +99,46 @@ func (d *DB) initTrafficSchema() error {
 	CREATE INDEX IF NOT EXISTS idx_traffic_snapshots_server_time
 		ON traffic_snapshots(server_id, collected_at);
 
+	-- Source stats: per-source aggregate snapshots for non-HAProxy
+	-- metric producers (nginx, Apache, Caddy, Traefik). Distinct
+	-- table from traffic_flows because those sources don't emit
+	-- per-IP / per-backend detail — they expose top-level rollups
+	-- via stub_status / mod_status / Prometheus. Adding the rollups
+	-- here keeps traffic_flows's HAProxy-shaped schema clean and
+	-- avoids a forest of NULL columns. If we later land per-IP
+	-- breakdowns via access-log parsing, that's the moment to
+	-- extend traffic_flows with a source column — for now,
+	-- source-aware data lives here.
+	--
+	-- requests_total is monotonic; rates are derived dashboard-side
+	-- by diffing successive collected_at rows. response_{2xx,5xx}
+	-- are populated only for sources that emit per-status-class
+	-- counters (Traefik today); other sources leave them at 0 and
+	-- the dashboard renders the requests/error charts only.
+	--
+	-- extra_json holds source-specific fields that don't fit the
+	-- common shape (nginx active/reading/writing/waiting; Apache
+	-- worker pool; Caddy request_errors_total; Traefik entrypoints)
+	-- — the dashboard parses what it needs per source. JSON column
+	-- keeps the schema additive when new sources land.
+	CREATE TABLE IF NOT EXISTS source_stats (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		server_id TEXT NOT NULL,
+		source TEXT NOT NULL,
+		collected_at DATETIME NOT NULL,
+		requests_total INTEGER NOT NULL DEFAULT 0,
+		response_2xx INTEGER NOT NULL DEFAULT 0,
+		response_3xx INTEGER NOT NULL DEFAULT 0,
+		response_4xx INTEGER NOT NULL DEFAULT 0,
+		response_5xx INTEGER NOT NULL DEFAULT 0,
+		active_connections INTEGER NOT NULL DEFAULT 0,
+		extra_json TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_source_stats_server_source_time
+		ON source_stats(server_id, source, collected_at);
+
 	-- Traffic anomalies: detected issues and suspicious activity
 	CREATE TABLE IF NOT EXISTS traffic_anomalies (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/gearbox/internal/framework/handler/api_metrics_insights.go
+++ b/gearbox/internal/framework/handler/api_metrics_insights.go
@@ -385,13 +385,44 @@ func (h *Handler) hostKPICards(boxID string, since, until, prevSince time.Time) 
 
 // Source identifiers + display labels. Defined as constants so handlers
 // and templates stay aligned and a typo doesn't silently drop a card from
-// the filtered view.
+// the filtered view. New sources land here once the agent's detection +
+// metrics pair is in place; the dashboard collector also references the
+// list in collector.SupportedSources().
 const (
 	sourceHAProxy      = "haproxy"
 	sourceLabelHAProxy = "HAProxy"
 	sourceHost         = "host"
 	sourceLabelHost    = "Host"
+	sourceNginx        = "nginx"
+	sourceLabelNginx   = "nginx"
+	sourceApache       = "apache"
+	sourceLabelApache  = "Apache"
+	sourceCaddy        = "caddy"
+	sourceLabelCaddy   = "Caddy"
+	sourceTraefik      = "traefik"
+	sourceLabelTraefik = "Traefik"
 )
+
+// sourceLabel returns the human-readable label for a source ID. Used
+// by the source-aware handlers to render badges/titles without
+// re-typing the same switch in every caller.
+func sourceLabel(source string) string {
+	switch source {
+	case sourceHAProxy:
+		return sourceLabelHAProxy
+	case sourceHost:
+		return sourceLabelHost
+	case sourceNginx:
+		return sourceLabelNginx
+	case sourceApache:
+		return sourceLabelApache
+	case sourceCaddy:
+		return sourceLabelCaddy
+	case sourceTraefik:
+		return sourceLabelTraefik
+	}
+	return source
+}
 
 // APIMetricsErrorBreakdownHandler powers the "Error Insights" panel: a
 // three-column view of top-N backends, source IPs, and countries

--- a/gearbox/internal/framework/handler/api_metrics_sources.go
+++ b/gearbox/internal/framework/handler/api_metrics_sources.go
@@ -1,0 +1,236 @@
+// Package handler — per-source metrics endpoints for the dashboard's
+// Metrics gear multi-source pivot (issue #91 phases 4 / 5 / 7).
+//
+// Two endpoints live here:
+//
+//	GET /api/{boxID}/metrics/source/{source}/summary
+//	    → latest snapshot + a small time-series for the per-source
+//	      chart cards (request rate, status-class breakdown if
+//	      emitted, active connections for nginx/Apache, etc.).
+//
+//	GET /api/{boxID}/metrics/source/{source}/log-errors
+//	    → recent parsed access-log records via the agent's
+//	      /api/v1/access-log/{source}/recent endpoint. This is the
+//	      Phase-5 refactor: the existing /metrics/log-errors handler
+//	      hard-coded "haproxy"; the new per-source endpoint pushes
+//	      parsing agent-side and lets the Error Insights panel ask
+//	      for any supported source.
+//
+// The HAProxy-only /metrics/log-errors endpoint stays as-is for now
+// to avoid breaking older dashboard clients mid-rollout; the new
+// front-end calls into /source/{source}/log-errors instead.
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
+)
+
+// supportedNonHAProxySources is the dispatch set for /source/{source}/*.
+// HAProxy is intentionally excluded — its data flows through the
+// existing /metrics/summary + /metrics/log-errors endpoints which
+// read from stats_history / GetLogs, not from source_stats.
+//
+// Kept in sync with collector.SupportedSources() (the agent-side
+// scraper polls the same set). A new source landing requires both
+// lists to grow in lockstep; the per-source handler test covers
+// each entry to keep them honest.
+var supportedNonHAProxySources = map[string]struct{}{
+	sourceNginx:   {},
+	sourceApache:  {},
+	sourceCaddy:   {},
+	sourceTraefik: {},
+}
+
+// sourceSummaryResponse is the JSON the per-source summary endpoint
+// emits. Latest is nil-able so the dashboard can distinguish "the
+// source isn't probed Available yet" (Latest == nil, Available ==
+// false) from "the source is Available but has zero traffic"
+// (Latest non-nil, RequestsTotal == 0).
+type sourceSummaryResponse struct {
+	ServerID    string                         `json:"server_id"`
+	Source      string                         `json:"source"`
+	SourceLabel string                         `json:"source_label"`
+	Available   bool                           `json:"available"`
+	Reason      string                         `json:"reason,omitempty"`
+	Range       string                         `json:"range"`
+	WindowStart time.Time                      `json:"window_start"`
+	WindowEnd   time.Time                      `json:"window_end"`
+	Latest      *database.SourceStatsSnapshot  `json:"latest,omitempty"`
+	History     []database.SourceStatsSnapshot `json:"history"`
+}
+
+// APIMetricsSourceSummaryHandler returns the per-source summary for
+// one box. The dashboard's per-source chart card calls this to
+// render its KPIs + time-series — one endpoint per render, response
+// is small enough that compression / sparse-time-series tricks
+// aren't worth it yet.
+func (h *Handler) APIMetricsSourceSummaryHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+	source := chi.URLParam(r, "source")
+	if _, ok := supportedNonHAProxySources[source]; !ok {
+		http.Error(w, "Unsupported source — valid: nginx, apache, caddy, traefik", http.StatusNotFound)
+		return
+	}
+
+	since, until, label := metricsRangeToTimes(r.URL.Query().Get("range"))
+	resp := sourceSummaryResponse{
+		ServerID:    boxID,
+		Source:      source,
+		SourceLabel: sourceLabel(source),
+		Range:       label,
+		WindowStart: since,
+		WindowEnd:   until,
+		History:     []database.SourceStatsSnapshot{},
+	}
+
+	// Available is gated by the agent's capability report — a source
+	// that hasn't probed Available shouldn't surface as "available
+	// with zero data" because that's misleading; render the empty
+	// state with a reason instead so the dashboard can show a
+	// "install nginx / enable stub_status / ..." hint.
+	if caps, ok := h.getBoxCapabilities(boxID); ok && caps != nil {
+		if entry, present := caps.Entry(source); present {
+			resp.Available = entry.IsAvailable()
+			if !resp.Available {
+				resp.Reason = entry.Reason
+			}
+		}
+	}
+
+	// Even when the capability says not-Available we still try to
+	// surface the most recent snapshot — sometimes the capability
+	// table is stale (just-installed nginx, agent restart pending)
+	// and the dashboard would rather show data than nothing.
+	if latest, err := h.db.GetLatestSourceStats(boxID, source); err == nil {
+		resp.Latest = latest
+	} else if !errors.Is(err, database.ErrNoSourceStats) {
+		h.logger.Error("source summary: latest fetch",
+			"server_id", boxID, "source", source, "error", err)
+	}
+
+	history, err := h.db.GetSourceStatsRange(boxID, source, since, until, 2000)
+	if err != nil {
+		h.logger.Error("source summary: range fetch",
+			"server_id", boxID, "source", source, "error", err)
+	} else {
+		resp.History = history
+	}
+
+	h.writeJSON(w, resp)
+}
+
+// APIMetricsSourceLogErrorsHandler is the Phase-5 deliverable: the
+// dashboard now asks the agent for parsed log records rather than
+// shipping raw lines to be parsed client-side. The endpoint proxies
+// to the agent's /api/v1/access-log/{source}/recent and surfaces
+// the structured records the agent emits.
+//
+// Backwards-compatibility note: the existing /metrics/log-errors
+// endpoint (HAProxy only, dashboard-side parser) stays around — see
+// the package doc-comment. Both endpoints will be reconciled when
+// the front-end fully migrates to the per-source UI; until then,
+// keeping both keeps an in-flight rollout safe.
+func (h *Handler) APIMetricsSourceLogErrorsHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	// As with the HAProxy variant, lacking `logs:view` is a soft
+	// "panel unavailable" rather than a hard 403 — the metrics
+	// page's overall view permission lets the operator on the
+	// page; this sub-panel needs the more specific scope.
+	if !h.authManager.HasPermission(r, "logs", "view") {
+		h.writeJSON(w, map[string]any{
+			"server_id":   chi.URLParam(r, "boxID"),
+			"source":      chi.URLParam(r, "source"),
+			"available":   false,
+			"reason":      "Logs permission required to correlate access-log lines with metrics.",
+			"match_count": 0,
+			"records":     []agent.AccessLogRecord{},
+		})
+		return
+	}
+
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+	source := chi.URLParam(r, "source")
+	// HAProxy IS allowed here even though we excluded it from the
+	// summary handler — the agent's access-log endpoint supports
+	// "haproxy" as a profile, and the dashboard's Phase-5 plan is
+	// to migrate the Error Insights panel onto this endpoint for
+	// EVERY source including HAProxy. The summary handler stays
+	// HAProxy-excluded because HAProxy summary still flows through
+	// stats_history; log parsing is the Phase-5 unification point.
+	if source != sourceHAProxy {
+		if _, ok := supportedNonHAProxySources[source]; !ok {
+			http.Error(w, "Unsupported source — valid: haproxy, nginx, apache, caddy, traefik", http.StatusNotFound)
+			return
+		}
+	}
+
+	serverConfig, exists := h.getServerConfig(boxID)
+	if !exists || !serverConfig.UsesAgentAPI() {
+		http.Error(w, "Agent API not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	statusMin := 500
+	if s, err := strconv.Atoi(r.URL.Query().Get("status_min")); err == nil && s >= 0 && s <= 599 {
+		statusMin = s
+	}
+	limit := 500
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 && l <= 10000 {
+		limit = l
+	}
+
+	client := agent.NewClient(serverConfig.AgentURL, serverConfig.APIKey)
+	resp, err := client.GetAccessLogRecent(source, statusMin, limit)
+	if err != nil {
+		// Don't 500 — return an empty envelope with a hint. The
+		// metrics page shouldn't break because logs are
+		// unavailable on this box.
+		h.writeJSON(w, map[string]any{
+			"server_id":   boxID,
+			"source":      source,
+			"available":   false,
+			"reason":      err.Error(),
+			"match_count": 0,
+			"records":     []agent.AccessLogRecord{},
+		})
+		return
+	}
+
+	// Pass the agent's envelope through directly — Available /
+	// Reason / MatchCount / Records all map 1:1 to what the
+	// dashboard expects. Tack on server_id for the front-end's
+	// debugging convenience.
+	h.writeJSON(w, map[string]any{
+		"server_id":   boxID,
+		"source":      resp.Source,
+		"profile":     resp.Profile,
+		"path":        resp.Path,
+		"available":   resp.Available,
+		"reason":      resp.Reason,
+		"match_count": resp.MatchCount,
+		"records":     resp.Records,
+	})
+}

--- a/gearbox/internal/framework/handler/api_metrics_sources.go
+++ b/gearbox/internal/framework/handler/api_metrics_sources.go
@@ -33,20 +33,32 @@ import (
 	"github.com/sarg3nt/gearbox/internal/framework/models"
 )
 
-// supportedNonHAProxySources is the dispatch set for /source/{source}/*.
-// HAProxy is intentionally excluded — its data flows through the
-// existing /metrics/summary + /metrics/log-errors endpoints which
-// read from stats_history / GetLogs, not from source_stats.
-//
-// Kept in sync with collector.SupportedSources() (the agent-side
-// scraper polls the same set). A new source landing requires both
-// lists to grow in lockstep; the per-source handler test covers
-// each entry to keep them honest.
-var supportedNonHAProxySources = map[string]struct{}{
+// supportedSourceSummaries is the dispatch set for the per-source
+// SUMMARY endpoint. HAProxy is intentionally excluded — its data
+// flows through the existing /metrics/summary endpoint which reads
+// from stats_history, not source_stats. Must stay in lockstep with
+// collector.SupportedSources() (the agent-side scraper polls the
+// same set).
+var supportedSourceSummaries = map[string]struct{}{
 	sourceNginx:   {},
 	sourceApache:  {},
 	sourceCaddy:   {},
 	sourceTraefik: {},
+}
+
+// supportedLogErrorSources is the dispatch set for the per-source
+// LOG-ERRORS endpoint. Distinct from supportedSourceSummaries
+// because Traefik has no access-log parser on the agent side
+// (gearbox-agent/internal/gears/accesslog/plugin.go registers
+// haproxy / nginx / apache / caddy only — Traefik's "logs" come
+// through Prometheus). Advertising Traefik here would always proxy
+// to a 404 from the agent, which would surface as a confusing
+// "logs unavailable" envelope.
+var supportedLogErrorSources = map[string]struct{}{
+	sourceHAProxy: {},
+	sourceNginx:   {},
+	sourceApache:  {},
+	sourceCaddy:   {},
 }
 
 // sourceSummaryResponse is the JSON the per-source summary endpoint
@@ -83,7 +95,7 @@ func (h *Handler) APIMetricsSourceSummaryHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	source := chi.URLParam(r, "source")
-	if _, ok := supportedNonHAProxySources[source]; !ok {
+	if _, ok := supportedSourceSummaries[source]; !ok {
 		http.Error(w, "Unsupported source — valid: nginx, apache, caddy, traefik", http.StatusNotFound)
 		return
 	}
@@ -173,18 +185,16 @@ func (h *Handler) APIMetricsSourceLogErrorsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	source := chi.URLParam(r, "source")
-	// HAProxy IS allowed here even though we excluded it from the
-	// summary handler — the agent's access-log endpoint supports
-	// "haproxy" as a profile, and the dashboard's Phase-5 plan is
-	// to migrate the Error Insights panel onto this endpoint for
-	// EVERY source including HAProxy. The summary handler stays
-	// HAProxy-excluded because HAProxy summary still flows through
-	// stats_history; log parsing is the Phase-5 unification point.
-	if source != sourceHAProxy {
-		if _, ok := supportedNonHAProxySources[source]; !ok {
-			http.Error(w, "Unsupported source — valid: haproxy, nginx, apache, caddy, traefik", http.StatusNotFound)
-			return
-		}
+	// supportedLogErrorSources includes HAProxy (the agent's access-
+	// log endpoint supports it as a profile, and Phase 5 unifies log
+	// parsing across every source) but excludes Traefik (the agent
+	// has no Traefik access-log parser — it expects Prometheus-only
+	// metrics from Traefik). Listing Traefik here would proxy to a
+	// 404 from the agent and surface as a confusing
+	// "logs unavailable" envelope.
+	if _, ok := supportedLogErrorSources[source]; !ok {
+		http.Error(w, "Unsupported source — valid: haproxy, nginx, apache, caddy", http.StatusNotFound)
+		return
 	}
 
 	serverConfig, exists := h.getServerConfig(boxID)

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -201,6 +201,65 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="errors-chart"></canvas>
 						</div>
 					</div>
+
+					<!-- Per-source request-rate cards (nginx, Apache, Caddy, Traefik).
+					     Each gets the same data-source / data-source-card
+					     hooks the host + HAProxy cards use so applyCapabilities()
+					     can hide them in one pass when the corresponding agent
+					     gear isn't Available. The render path lives in
+					     loadSourceMetrics() further below. -->
+					<div id="card-nginx" data-source="nginx" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+						<div class="flex justify-between items-center mb-2">
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">nginx:</span> Connections &amp; Requests</h4>
+							<button onclick="toggleFullscreen('card-nginx')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
+								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+								</svg>
+							</button>
+						</div>
+						<div class="chart-aspect-container">
+							<canvas id="nginx-chart"></canvas>
+						</div>
+					</div>
+					<div id="card-apache" data-source="apache" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+						<div class="flex justify-between items-center mb-2">
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Apache:</span> Workers &amp; Requests</h4>
+							<button onclick="toggleFullscreen('card-apache')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
+								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+								</svg>
+							</button>
+						</div>
+						<div class="chart-aspect-container">
+							<canvas id="apache-chart"></canvas>
+						</div>
+					</div>
+					<div id="card-caddy" data-source="caddy" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+						<div class="flex justify-between items-center mb-2">
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Caddy:</span> Requests &amp; Errors</h4>
+							<button onclick="toggleFullscreen('card-caddy')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
+								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+								</svg>
+							</button>
+						</div>
+						<div class="chart-aspect-container">
+							<canvas id="caddy-chart"></canvas>
+						</div>
+					</div>
+					<div id="card-traefik" data-source="traefik" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+						<div class="flex justify-between items-center mb-2">
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Traefik:</span> Status Class</h4>
+							<button onclick="toggleFullscreen('card-traefik')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
+								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+								</svg>
+							</button>
+						</div>
+						<div class="chart-aspect-container">
+							<canvas id="traefik-chart"></canvas>
+						</div>
+					</div>
 				</div>
 			</div>
 
@@ -233,6 +292,36 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
 					</svg>
 					<p class="text-gray-600 dark:text-gray-400 text-sm">No 4xx/5xx responses in this window. Everything's green.</p>
+				</div>
+			</div>
+
+			<!-- Per-Source Recent Errors — Phase 6 of issue #91. One
+			     block per detected non-HAProxy source (nginx, Apache,
+			     Caddy), rendered into the per-source containers below.
+			     Each block fetches /metrics/source/{source}/log-errors
+			     (which proxies to the agent's structured access-log
+			     endpoint) and renders a compact table of recent 5xx
+			     records. Hidden entirely on hosts where no non-HAProxy
+			     source is Available — the existing HAProxy Error
+			     Insights panel above is the only thing on this page
+			     then. -->
+			<div id="source-errors-section" class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6 hidden">
+				<div class="flex items-center justify-between mb-4">
+					<div>
+						<h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100">Per-Source Recent Errors</h3>
+						<p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+							Recent error responses parsed from each source's access log. The agent does the parsing; the dashboard renders. Sources whose log file isn't readable on the host show a hint instead.
+						</p>
+					</div>
+					<button
+						id="source-errors-refresh"
+						class="text-sm px-2 py-1 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+						title="Refresh per-source error tables"
+						onclick="loadSourceErrors()"
+					>↻</button>
+				</div>
+				<div id="source-errors-blocks" class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+					<!-- Populated by loadSourceErrors(). One block per Available source. -->
 				</div>
 			</div>
 
@@ -870,10 +959,214 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				// Kick off insights loads (don't block charts on these).
 				loadKPISummary();
 				loadErrorInsights();
+				loadSourceMetrics(serverID);
+				loadSourceErrors();
 
 			} catch (error) {
 				console.error('Failed to load history data:', error);
 			}
+		}
+
+		// loadSourceMetrics fetches /metrics/source/{source}/summary
+		// for every non-HAProxy source the capability table marked
+		// Available, and paints its chart card. Each source has its
+		// own card structure; we render whatever shape makes sense
+		// for that source rather than forcing a common chart type:
+		//   - nginx  → connection state stacked area (reading / writing / waiting)
+		//   - apache → workers stacked bars (busy + idle)
+		//   - caddy  → requests vs errors (two-line)
+		//   - traefik → status-class stacked area
+		async function loadSourceMetrics(serverID) {
+			const sources = ['nginx', 'apache', 'caddy', 'traefik'];
+			const available = window._availableSources || {};
+			for (const src of sources) {
+				if (!available[src]) continue;
+				try {
+					const res = await fetch('/api/' + serverID + '/metrics/source/' + src + '/summary');
+					if (!res.ok) continue;
+					const data = await res.json();
+					renderSourceCard(src, data);
+				} catch (err) {
+					console.debug('source metrics fetch failed', src, err);
+				}
+			}
+		}
+
+		// renderSourceCard paints one per-source chart card from the
+		// summary endpoint's response. Kept as a single switch
+		// (rather than four separate render* functions) so adding a
+		// new source is a single readable case in one file.
+		function renderSourceCard(source, data) {
+			const canvasID = source + '-chart';
+			const canvas = document.getElementById(canvasID);
+			if (!canvas) return;
+
+			// Drop any previous chart instance so re-renders don't
+			// stack tooltips / event handlers.
+			if (window._sourceCharts && window._sourceCharts[source]) {
+				window._sourceCharts[source].destroy();
+			}
+			window._sourceCharts = window._sourceCharts || {};
+
+			const history = (data && data.history) || [];
+			const labels = history.map(h => new Date(h.collected_at));
+
+			let datasets = [];
+			switch (source) {
+				case 'nginx': {
+					const get = (h, k) => Number((h.extra && h.extra[k]) || 0);
+					datasets = [
+						{ label: 'Reading', data: history.map(h => get(h, 'reading')), borderColor: '#22c55e', backgroundColor: 'rgba(34, 197, 94, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Writing', data: history.map(h => get(h, 'writing')), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Waiting', data: history.map(h => get(h, 'waiting')), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3 },
+					];
+					break;
+				}
+				case 'apache': {
+					const idle = (h) => Number((h.extra && h.extra.idle_workers) || 0);
+					datasets = [
+						{ label: 'Busy workers', data: history.map(h => h.active_connections), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Idle workers', data: history.map(h => idle(h)), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3 },
+					];
+					break;
+				}
+				case 'caddy': {
+					const errs = (h) => Number((h.extra && h.extra.request_errors_total) || 0);
+					datasets = [
+						{ label: 'Requests', data: history.map(h => h.requests_total), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Errors', data: history.map(h => errs(h)), borderColor: '#ef4444', backgroundColor: 'rgba(239, 68, 68, 0.2)', fill: true, tension: 0.3 },
+					];
+					break;
+				}
+				case 'traefik': {
+					datasets = [
+						{ label: '2xx', data: history.map(h => h.response_2xx), borderColor: '#22c55e', backgroundColor: 'rgba(34, 197, 94, 0.2)', fill: true, tension: 0.3 },
+						{ label: '3xx', data: history.map(h => h.response_3xx), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3 },
+						{ label: '4xx', data: history.map(h => h.response_4xx), borderColor: '#f59e0b', backgroundColor: 'rgba(245, 158, 11, 0.2)', fill: true, tension: 0.3 },
+						{ label: '5xx', data: history.map(h => h.response_5xx), borderColor: '#ef4444', backgroundColor: 'rgba(239, 68, 68, 0.2)', fill: true, tension: 0.3 },
+					];
+					break;
+				}
+			}
+
+			window._sourceCharts[source] = new Chart(canvas.getContext('2d'), {
+				type: 'line',
+				data: { labels: labels, datasets: datasets },
+				options: {
+					...chartDefaults(),
+					scales: {
+						x: { type: 'time', time: { tooltipFormat: 'PPpp' } },
+						y: { beginAtZero: true, stacked: source === 'nginx' || source === 'traefik' },
+					},
+					plugins: { ...((chartDefaults().plugins) || {}), legend: { display: true, position: 'bottom' } },
+				},
+			});
+		}
+
+		// loadSourceErrors paints the per-source recent-errors
+		// section. One block per Available source — each block fetches
+		// the agent's /access-log/{source}/recent via the dashboard's
+		// proxy endpoint and shows a compact table of recent 5xx
+		// records. DOM-built (not innerHTML-with-strings) so the
+		// agent-supplied path / timestamp / method fields stay safe
+		// against XSS without leaning on string escaping.
+		async function loadSourceErrors() {
+			const container = document.getElementById('source-errors-blocks');
+			if (!container) return;
+			const serverID = getServerID();
+			if (!serverID) return;
+			const sources = ['nginx', 'apache', 'caddy'];
+			const available = window._availableSources || {};
+
+			// Build into a DocumentFragment first so the section
+			// doesn't flicker through "empty → populated" on slow
+			// agents — single commit at the end.
+			const frag = document.createDocumentFragment();
+			let rendered = 0;
+			for (const src of sources) {
+				if (!available[src]) continue;
+				let data = null;
+				try {
+					const res = await fetch('/api/' + serverID + '/metrics/source/' + src + '/log-errors?status_min=500&limit=20');
+					if (res.ok) data = await res.json();
+				} catch (err) {
+					data = { available: false, reason: String(err) };
+				}
+				frag.appendChild(buildSourceErrorsBlock(src, data));
+				rendered++;
+			}
+			// Clear without innerHTML so we don't trip the XSS
+			// guard that flags innerHTML assignments.
+			while (container.firstChild) container.removeChild(container.firstChild);
+			if (rendered === 0) return;
+			container.appendChild(frag);
+		}
+
+		// buildSourceErrorsBlock returns one DOM block for the
+		// Per-Source Recent Errors section. Built via createElement
+		// + textContent so agent-supplied fields can't inject HTML.
+		function buildSourceErrorsBlock(source, data) {
+			const label = source.charAt(0).toUpperCase() + source.slice(1);
+
+			const block = document.createElement('div');
+			block.className = 'rounded border border-gray-200 dark:border-slate-700 p-3';
+
+			const heading = document.createElement('h4');
+			heading.className = 'text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2';
+			heading.textContent = label;
+			block.appendChild(heading);
+
+			if (!data || data.available === false) {
+				const hint = document.createElement('p');
+				hint.className = 'text-xs text-gray-500 dark:text-gray-400';
+				hint.textContent = (data && data.reason) ? String(data.reason) : 'logs unavailable on this host';
+				block.appendChild(hint);
+				return block;
+			}
+
+			const records = data.records || [];
+			if (records.length === 0) {
+				const ok = document.createElement('p');
+				ok.className = 'text-xs text-gray-500 dark:text-gray-400';
+				ok.textContent = "No 5xx responses in the recent window.";
+				block.appendChild(ok);
+				return block;
+			}
+
+			const table = document.createElement('table');
+			table.className = 'w-full text-xs';
+			const tbody = document.createElement('tbody');
+			records.slice(0, 10).forEach(function(r) {
+				const tr = document.createElement('tr');
+				tr.className = 'border-t border-gray-100 dark:border-slate-700';
+
+				const tdTime = document.createElement('td');
+				tdTime.className = 'px-2 py-1 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap';
+				tdTime.textContent = r.timestamp || r.timestamp_raw || '';
+				tr.appendChild(tdTime);
+
+				const tdStatus = document.createElement('td');
+				tdStatus.className = 'px-2 py-1 text-xs font-mono text-red-600 dark:text-red-400';
+				tdStatus.textContent = String(r.status_code);
+				tr.appendChild(tdStatus);
+
+				const tdReq = document.createElement('td');
+				tdReq.className = 'px-2 py-1 text-xs text-gray-700 dark:text-gray-300';
+				tdReq.textContent = (r.method || '') + ' ' + (r.path || '');
+				tr.appendChild(tdReq);
+
+				tbody.appendChild(tr);
+			});
+			table.appendChild(tbody);
+			block.appendChild(table);
+
+			if (records.length > 10) {
+				const more = document.createElement('p');
+				more.className = 'text-xs text-gray-500 dark:text-gray-400 mt-2';
+				more.textContent = '… plus ' + (records.length - 10) + ' more';
+				block.appendChild(more);
+			}
+			return block;
 		}
 
 		// applyCapabilities fetches the per-box probe table and toggles
@@ -882,13 +1175,22 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 		// fail open: the dashboard reverts to "HAProxy assumed present"
 		// rather than locking the user out of cards they may need.
 		async function applyCapabilities(serverID) {
+			// Tracks which non-HAProxy sources are Available on this
+			// host so loadSourceMetrics() / loadSourceErrors() can
+			// skip the missing ones rather than 404-spamming the
+			// agent. Surfaced on window for the loaders that run
+			// after this returns.
+			window._availableSources = window._availableSources || {};
+
 			let haproxyAvailable = true;
 			let haproxyEntry = null;
+			let gears = {};
 			try {
 				const res = await fetch('/api/' + serverID + '/capabilities');
 				if (res.ok) {
 					const data = await res.json();
-					haproxyEntry = data && data.gears && data.gears.haproxy;
+					gears = (data && data.gears) || {};
+					haproxyEntry = gears.haproxy;
 					if (haproxyEntry) {
 						haproxyAvailable = haproxyEntry.status === 'available';
 					}
@@ -902,6 +1204,32 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			document.querySelectorAll('[data-source="haproxy"]').forEach(function(el) {
 				el.classList.toggle('hidden', !haproxyAvailable);
 			});
+
+			// Gate the per-source chart cards (nginx, apache, caddy,
+			// traefik) on each source's probe verdict. Sources whose
+			// gear is absent / inaccessible stay hidden — there's no
+			// data to render and showing an empty card would look
+			// like a regression. data-source-card distinguishes the
+			// per-source cards from the existing host/haproxy ones
+			// so we don't accidentally hide the latter when toggling.
+			const sourceCards = ['nginx', 'apache', 'caddy', 'traefik'];
+			for (const src of sourceCards) {
+				const entry = gears[src];
+				const available = entry && entry.status === 'available';
+				window._availableSources[src] = !!available;
+				document.querySelectorAll('[data-source="' + src + '"][data-source-card]').forEach(function(el) {
+					el.classList.toggle('hidden', !available);
+				});
+			}
+
+			// Show the per-source errors section only when at least
+			// one non-HAProxy source is Available — otherwise the
+			// section would render as an empty container.
+			const anyNonHAProxy = sourceCards.some(s => window._availableSources[s]);
+			const sourceErrorsSection = document.getElementById('source-errors-section');
+			if (sourceErrorsSection) {
+				sourceErrorsSection.classList.toggle('hidden', !anyNonHAProxy);
+			}
 
 			const banner = document.getElementById('no-haproxy-banner');
 			if (banner) {

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -317,6 +317,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 						id="source-errors-refresh"
 						class="text-sm px-2 py-1 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
 						title="Refresh per-source error tables"
+						aria-label="Refresh per-source error tables"
 						onclick="loadSourceErrors()"
 					>↻</button>
 				</div>
@@ -849,11 +850,22 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			if (card.classList.contains('fullscreen')) {
 				// Exit fullscreen
 				card.classList.remove('fullscreen');
-				// Show all other cards
+				// Show all other cards EXCEPT capability-hidden
+				// per-source cards (data-source-card). Without this
+				// check, exiting fullscreen would un-hide cards for
+				// sources the agent reported as not Available — the
+				// blanket .classList.remove('hidden') below would
+				// otherwise override applyCapabilities()'s decision.
+				const avail = window._availableSources || {};
 				chartsGrid.querySelectorAll('.chart-card').forEach(c => {
-					if (c.id !== cardId) {
-						c.classList.remove('hidden');
+					if (c.id === cardId) return;
+					const srcAttr = c.getAttribute('data-source');
+					const isSourceCard = c.hasAttribute('data-source-card');
+					if (isSourceCard && srcAttr && !avail[srcAttr]) {
+						// Stay hidden — capability gate says no.
+						return;
 					}
+					c.classList.remove('hidden');
 				});
 				currentFullscreenCard = null;
 
@@ -967,22 +979,56 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			}
 		}
 
+		// SOURCES_WITH_ERROR_LOGS is the set the agent has access-log
+		// parsers for. Traefik is NOT in this set — the agent's
+		// accesslog gear registers haproxy/nginx/apache/caddy only
+		// (Traefik's "logs" come through Prometheus instead). The
+		// chart-card rendering set is wider (it does include Traefik)
+		// because Traefik does emit per-status-class metrics via the
+		// summary endpoint. Keeping the two sets separate prevents
+		// the "Per-Source Recent Errors" section from unhiding empty
+		// on a Traefik-only host.
+		const SOURCES_WITH_CHARTS = ['nginx', 'apache', 'caddy', 'traefik'];
+		const SOURCES_WITH_ERROR_LOGS = ['nginx', 'apache', 'caddy'];
+
+		// hoursSelectToRange maps the existing hours-select control
+		// onto the metricsRangeToTimes() range names the per-source
+		// summary handler accepts. Without this the per-source cards
+		// would always fall back to the handler's 24h default,
+		// ignoring the operator's range selection.
+		function hoursSelectToRange() {
+			const sel = document.getElementById('hours-select');
+			if (!sel) return '24h';
+			switch (sel.value) {
+				case '0.083': return '5m';   // 5 minutes
+				case '0.25':  return '15m';  // 15 minutes
+				case '1':     return '1h';
+				case '6':     return '6h';
+				case '24':    return '24h';
+				case '168':   return '7d';
+				case '720':   return '30d';
+				default:      return sel.value + 'h';
+			}
+		}
+
 		// loadSourceMetrics fetches /metrics/source/{source}/summary
-		// for every non-HAProxy source the capability table marked
-		// Available, and paints its chart card. Each source has its
-		// own card structure; we render whatever shape makes sense
-		// for that source rather than forcing a common chart type:
-		//   - nginx  → connection state stacked area (reading / writing / waiting)
-		//   - apache → workers stacked bars (busy + idle)
-		//   - caddy  → requests vs errors (two-line)
-		//   - traefik → status-class stacked area
+		// for every per-source capability the box reported Available,
+		// and paints the matching chart card. Per-source layouts:
+		//   - nginx  → reading/writing/waiting stacked, plus a
+		//              request-rate line derived from successive
+		//              `requests` counter samples.
+		//   - apache → busy + idle workers stacked.
+		//   - caddy  → request rate vs error rate (both derived from
+		//              monotonic counters via successive-sample diffs).
+		//   - traefik → status-class stacked area (each band is a
+		//               rate, not a cumulative total).
 		async function loadSourceMetrics(serverID) {
-			const sources = ['nginx', 'apache', 'caddy', 'traefik'];
 			const available = window._availableSources || {};
-			for (const src of sources) {
+			const range = hoursSelectToRange();
+			for (const src of SOURCES_WITH_CHARTS) {
 				if (!available[src]) continue;
 				try {
-					const res = await fetch('/api/' + serverID + '/metrics/source/' + src + '/summary');
+					const res = await fetch('/api/' + serverID + '/metrics/source/' + src + '/summary?range=' + encodeURIComponent(range));
 					if (!res.ok) continue;
 					const data = await res.json();
 					renderSourceCard(src, data);
@@ -992,74 +1038,117 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			}
 		}
 
-		// renderSourceCard paints one per-source chart card from the
-		// summary endpoint's response. Kept as a single switch
-		// (rather than four separate render* functions) so adding a
-		// new source is a single readable case in one file.
+		// counterDeltas turns a series of monotonic counter samples
+		// into a per-bucket delta series suitable for rate charts.
+		// Resets (current < previous, e.g. service restart) surface
+		// as 0 rather than a huge negative spike; that matches
+		// Prometheus's `rate()` reset handling and keeps the chart
+		// readable across deploys. The first sample has no
+		// predecessor, so its delta is 0.
+		function counterDeltas(samples, getter) {
+			const out = new Array(samples.length).fill(0);
+			for (let i = 1; i < samples.length; i++) {
+				const curr = Number(getter(samples[i]) || 0);
+				const prev = Number(getter(samples[i - 1]) || 0);
+				const d = curr - prev;
+				out[i] = d >= 0 ? d : 0;
+			}
+			return out;
+		}
+
+		// renderSourceCard paints one per-source chart card. Uses
+		// the existing createChartOptions() helper + formatTime()
+		// string labels (no Chart.js time scale — the dashboard
+		// doesn't load a date adapter) so the chart matches the
+		// other cards' visual style without any new dependencies.
 		function renderSourceCard(source, data) {
-			const canvasID = source + '-chart';
-			const canvas = document.getElementById(canvasID);
+			const canvas = document.getElementById(source + '-chart');
 			if (!canvas) return;
 
 			// Drop any previous chart instance so re-renders don't
 			// stack tooltips / event handlers.
-			if (window._sourceCharts && window._sourceCharts[source]) {
+			window._sourceCharts = window._sourceCharts || {};
+			if (window._sourceCharts[source]) {
 				window._sourceCharts[source].destroy();
 			}
-			window._sourceCharts = window._sourceCharts || {};
 
 			const history = (data && data.history) || [];
-			const labels = history.map(h => new Date(h.collected_at));
+			const labels = history.map(h => formatTime(h.collected_at));
 
 			let datasets = [];
+			let stacked = false;
 			switch (source) {
 				case 'nginx': {
-					const get = (h, k) => Number((h.extra && h.extra[k]) || 0);
+					// Three connection states + a request rate. The
+					// `requests` counter is monotonic so we diff
+					// it via counterDeltas to show per-bucket
+					// request rate rather than a forever-rising line.
+					const ext = (k) => (h) => Number((h.extra && h.extra[k]) || 0);
+					stacked = true;
 					datasets = [
-						{ label: 'Reading', data: history.map(h => get(h, 'reading')), borderColor: '#22c55e', backgroundColor: 'rgba(34, 197, 94, 0.2)', fill: true, tension: 0.3 },
-						{ label: 'Writing', data: history.map(h => get(h, 'writing')), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3 },
-						{ label: 'Waiting', data: history.map(h => get(h, 'waiting')), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Reading', data: history.map(ext('reading')), borderColor: '#22c55e', backgroundColor: 'rgba(34, 197, 94, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: 'Writing', data: history.map(ext('writing')), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: 'Waiting', data: history.map(ext('waiting')), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: 'Requests / interval', data: counterDeltas(history, h => h.requests_total), borderColor: '#ec4899', backgroundColor: 'transparent', fill: false, tension: 0.3, borderWidth: 1.5, pointRadius: 0, yAxisID: 'y1' },
 					];
 					break;
 				}
 				case 'apache': {
 					const idle = (h) => Number((h.extra && h.extra.idle_workers) || 0);
+					stacked = true;
 					datasets = [
-						{ label: 'Busy workers', data: history.map(h => h.active_connections), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3 },
-						{ label: 'Idle workers', data: history.map(h => idle(h)), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Busy workers', data: history.map(h => h.active_connections), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: 'Idle workers', data: history.map(h => idle(h)), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
 					];
 					break;
 				}
 				case 'caddy': {
+					// Both counters are monotonic; diff to rates.
 					const errs = (h) => Number((h.extra && h.extra.request_errors_total) || 0);
 					datasets = [
-						{ label: 'Requests', data: history.map(h => h.requests_total), borderColor: '#3b82f6', backgroundColor: 'rgba(59, 130, 246, 0.2)', fill: true, tension: 0.3 },
-						{ label: 'Errors', data: history.map(h => errs(h)), borderColor: '#ef4444', backgroundColor: 'rgba(239, 68, 68, 0.2)', fill: true, tension: 0.3 },
+						{ label: 'Requests / interval', data: counterDeltas(history, h => h.requests_total), borderColor: '#3b82f6', backgroundColor: 'transparent', fill: false, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: 'Errors / interval', data: counterDeltas(history, errs), borderColor: '#ef4444', backgroundColor: 'transparent', fill: false, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
 					];
 					break;
 				}
 				case 'traefik': {
+					// Per-status-class totals are monotonic counters
+					// too — diff each to a per-interval rate so the
+					// stacked area shows traffic shape over time
+					// rather than an ever-rising envelope.
+					stacked = true;
 					datasets = [
-						{ label: '2xx', data: history.map(h => h.response_2xx), borderColor: '#22c55e', backgroundColor: 'rgba(34, 197, 94, 0.2)', fill: true, tension: 0.3 },
-						{ label: '3xx', data: history.map(h => h.response_3xx), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3 },
-						{ label: '4xx', data: history.map(h => h.response_4xx), borderColor: '#f59e0b', backgroundColor: 'rgba(245, 158, 11, 0.2)', fill: true, tension: 0.3 },
-						{ label: '5xx', data: history.map(h => h.response_5xx), borderColor: '#ef4444', backgroundColor: 'rgba(239, 68, 68, 0.2)', fill: true, tension: 0.3 },
+						{ label: '2xx', data: counterDeltas(history, h => h.response_2xx), borderColor: '#22c55e', backgroundColor: 'rgba(34, 197, 94, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: '3xx', data: counterDeltas(history, h => h.response_3xx), borderColor: '#a3a3a3', backgroundColor: 'rgba(163, 163, 163, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: '4xx', data: counterDeltas(history, h => h.response_4xx), borderColor: '#f59e0b', backgroundColor: 'rgba(245, 158, 11, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
+						{ label: '5xx', data: counterDeltas(history, h => h.response_5xx), borderColor: '#ef4444', backgroundColor: 'rgba(239, 68, 68, 0.2)', fill: true, tension: 0.3, borderWidth: 1.5, pointRadius: 0 },
 					];
 					break;
 				}
 			}
 
+			const options = createChartOptions(0);
+			// Stacking is per-source — nginx + Apache + Traefik
+			// stack their primary series; Caddy does not.
+			if (stacked) {
+				options.scales.y.stacked = true;
+				if (options.scales.x) options.scales.x.stacked = true;
+			}
+			// nginx uses a second y-axis for the request-rate line so
+			// it doesn't get crushed by the connection-state stack.
+			if (source === 'nginx') {
+				options.scales.y1 = {
+					position: 'right',
+					beginAtZero: true,
+					ticks: { color: options.scales.y.ticks ? options.scales.y.ticks.color : undefined },
+					grid: { drawOnChartArea: false },
+				};
+			}
+
 			window._sourceCharts[source] = new Chart(canvas.getContext('2d'), {
 				type: 'line',
 				data: { labels: labels, datasets: datasets },
-				options: {
-					...chartDefaults(),
-					scales: {
-						x: { type: 'time', time: { tooltipFormat: 'PPpp' } },
-						y: { beginAtZero: true, stacked: source === 'nginx' || source === 'traefik' },
-					},
-					plugins: { ...((chartDefaults().plugins) || {}), legend: { display: true, position: 'bottom' } },
-				},
+				options: options,
 			});
 		}
 
@@ -1075,15 +1164,18 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			if (!container) return;
 			const serverID = getServerID();
 			if (!serverID) return;
-			const sources = ['nginx', 'apache', 'caddy'];
 			const available = window._availableSources || {};
 
 			// Build into a DocumentFragment first so the section
 			// doesn't flicker through "empty → populated" on slow
-			// agents — single commit at the end.
+			// agents — single commit at the end. SOURCES_WITH_ERROR_LOGS
+			// matches the same set used by applyCapabilities() to
+			// decide whether to show the section — keeps the gate
+			// and the renderer aligned so the section can't unhide
+			// empty.
 			const frag = document.createDocumentFragment();
 			let rendered = 0;
-			for (const src of sources) {
+			for (const src of SOURCES_WITH_ERROR_LOGS) {
 				if (!available[src]) continue;
 				let data = null;
 				try {
@@ -1135,6 +1227,29 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 
 			const table = document.createElement('table');
 			table.className = 'w-full text-xs';
+
+			// Visually-hidden caption + visible thead for assistive
+			// technology — without these, screen readers announce
+			// only the cell values with no column context. The
+			// .sr-only utility is part of the existing Tailwind
+			// preset; falls back to clip-path positioning.
+			const caption = document.createElement('caption');
+			caption.className = 'sr-only';
+			caption.textContent = label + ' recent 5xx responses';
+			table.appendChild(caption);
+
+			const thead = document.createElement('thead');
+			const trh = document.createElement('tr');
+			['Time', 'Status', 'Request'].forEach(function(colLabel) {
+				const th = document.createElement('th');
+				th.scope = 'col';
+				th.className = 'px-2 py-1 text-left text-xs font-medium text-gray-500 dark:text-gray-400';
+				th.textContent = colLabel;
+				trh.appendChild(th);
+			});
+			thead.appendChild(trh);
+			table.appendChild(thead);
+
 			const tbody = document.createElement('tbody');
 			records.slice(0, 10).forEach(function(r) {
 				const tr = document.createElement('tr');
@@ -1205,15 +1320,14 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				el.classList.toggle('hidden', !haproxyAvailable);
 			});
 
-			// Gate the per-source chart cards (nginx, apache, caddy,
-			// traefik) on each source's probe verdict. Sources whose
-			// gear is absent / inaccessible stay hidden — there's no
-			// data to render and showing an empty card would look
-			// like a regression. data-source-card distinguishes the
-			// per-source cards from the existing host/haproxy ones
-			// so we don't accidentally hide the latter when toggling.
-			const sourceCards = ['nginx', 'apache', 'caddy', 'traefik'];
-			for (const src of sourceCards) {
+			// Gate the per-source chart cards on each source's probe
+			// verdict. Sources whose gear is absent / inaccessible
+			// stay hidden — there's no data to render and showing an
+			// empty card would look like a regression.
+			// data-source-card distinguishes per-source cards from
+			// the existing host/haproxy ones so we don't accidentally
+			// hide the latter when toggling.
+			for (const src of SOURCES_WITH_CHARTS) {
 				const entry = gears[src];
 				const available = entry && entry.status === 'available';
 				window._availableSources[src] = !!available;
@@ -1223,12 +1337,15 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			}
 
 			// Show the per-source errors section only when at least
-			// one non-HAProxy source is Available — otherwise the
-			// section would render as an empty container.
-			const anyNonHAProxy = sourceCards.some(s => window._availableSources[s]);
+			// one source we have an access-log parser for is
+			// Available. Using SOURCES_WITH_ERROR_LOGS (rather than
+			// the wider SOURCES_WITH_CHARTS) prevents the section
+			// from unhiding empty on a Traefik-only host — Traefik
+			// has metrics but no access-log parser.
+			const anyErrorSource = SOURCES_WITH_ERROR_LOGS.some(s => window._availableSources[s]);
 			const sourceErrorsSection = document.getElementById('source-errors-section');
 			if (sourceErrorsSection) {
-				sourceErrorsSection.classList.toggle('hidden', !anyNonHAProxy);
+				sourceErrorsSection.classList.toggle('hidden', !anyErrorSource);
 			}
 
 			const banner = document.getElementById('no-haproxy-banner');


### PR DESCRIPTION
## Summary

Closes [#91](https://github.com/sarg3nt/gearbox/issues/91). Dashboard-side companion to [#101](https://github.com/sarg3nt/gearbox/pull/101)'s agent work. The Metrics page now renders per-source chart cards (nginx connections, Apache workers, Caddy requests/errors, Traefik status-class) and a "Per-Source Recent Errors" section, all behind capability gates so a homelab box that only runs HAProxy looks exactly the same as it does today.

This is the second of the two-PR plan I proposed for finishing #91:

- **PR #101** (merged): agent-side metrics collection + access-log endpoint.
- **PR #102** (this one): dashboard ingest, handlers, UI.

After this lands, all of #91's phases except the explicitly-optional Phase 8 ("cross-source aggregates" — Combined toggle, stacked-area "by source" chart) are done. That phase is best designed once at least one real second source on light-hugger drives the UX.

## Phases addressed

| Phase | What lands | Where |
|-------|------------|-------|
| 4 (nginx) | Chart card + history endpoint + collector wiring | `gearbox/` |
| 5 (access-log abstraction) | Log-errors handler now proxies the agent's structured records — no dashboard-side regex parsing of new sources | `gearbox/` |
| 6 (multi-source Error Insights) | New "Per-Source Recent Errors" section, one block per available source | `metrics.templ` |
| 7 (Apache / Caddy / Traefik) | Same pattern as nginx — chart card + handler + collector | `gearbox/` |
| 8 (cross-source aggregates) | **Deferred per #91** — explicitly optional | n/a |

Docker metrics (Phase 7 piece) stays out — that work lives on `feature/containers-gear` with its own moby/client integration. After this and that both land, #91 closes and `feature/containers-gear` rebases against the now-current main (see project memory on the homelab side).

## Files

### New

| Path                                                       | Purpose                                                                                          |
|------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| `internal/framework/database/source_stats.go`              | `SourceStatsSnapshot` + `SaveSourceStats` / `GetLatestSourceStats` / `GetSourceStatsRange` / `PruneSourceStats`. |
| `internal/framework/collector/source_stats.go`             | Per-source polling: walks `nginx/apache/caddy/traefik` every persistHistory tick, normalises agent JSON → `SourceStatsSnapshot`, persists. Silently skips 503/404 (source not Available on host). |
| `internal/framework/collector/source_stats_test.go`        | Normaliser table tests (one per source) + happy/sad-path coverage for `isExpectedSourceMiss`. |
| `internal/framework/handler/api_metrics_sources.go`        | `APIMetricsSourceSummaryHandler` + `APIMetricsSourceLogErrorsHandler`. The latter is the Phase-5 refactor — proxies to the agent's structured access-log endpoint instead of parsing log text client-side. |

### Modified

| Path                                                    | Change                                                                                       |
|---------------------------------------------------------|----------------------------------------------------------------------------------------------|
| `internal/framework/database/traffic.go`                | `source_stats` table + index added to `initTrafficSchema`.                                    |
| `internal/framework/agent/client.go`                    | `GetSourceStats(source)` + `GetAccessLogRecent(source, statusMin, limit)` client methods.    |
| `internal/framework/collector/manager.go`               | Wires the new collector into `persistHistory`.                                                |
| `internal/framework/handler/api_metrics_insights.go`    | Source constants extended for nginx / Apache / Caddy / Traefik; `sourceLabel()` helper.       |
| `cmd/server/main.go`                                    | Two new routes: `/{boxID}/metrics/source/{source}/summary` and `/{boxID}/metrics/source/{source}/log-errors`. |
| `templates/pages/metrics.templ`                         | Four new chart cards + "Per-Source Recent Errors" section + `loadSourceMetrics()` / `loadSourceErrors()` + multi-source `applyCapabilities()`. UI built via `createElement` + `textContent` so agent-supplied path / timestamp / method fields can't inject HTML. |

## Schema design note — why a new table instead of extending `traffic_flows`

I considered adding a `source` column to `traffic_flows` per #91's original plan. Decided against it because the non-HAProxy sources don't emit per-IP/per-backend detail — they expose top-level rollups via stub_status / mod_status / Prometheus. Adding a `source` column would mean every non-HAProxy row carries NULL for `source_ip`, `backend_name`, etc.; HAProxy data would stay shaped as today; and the unique constraint would have to grow `source` for both shapes to coexist.

A separate `source_stats` table is cleaner: HAProxy's per-IP rollups stay in `traffic_flows` untouched (existing chart cards see no diff); aggregate rollups for the new sources live in `source_stats` with the `extra_json` overflow column for per-source nuances. If/when per-IP data lands for the other sources via access-log parsing, that's the right moment to revisit — at that point a `source` column on `traffic_flows` (or a separate per-source flows table) would be justified.

The `extra_json` column matters: nginx wants reading/writing/waiting/accepts/handled; Apache wants idle_workers/cpu_load/uptime; Caddy wants request_errors_total; Traefik wants entrypoints. Squeezing those into named columns would either commit to a least-common-denominator surface or pile up sparse columns. JSON keeps the schema additive when new sources arrive.

## Capability handling

- New sources gate via `caps.Entry("nginx")` (etc.) — same pattern PR #93 established for HAProxy.
- Chart cards default `hidden`; `applyCapabilities()` flips them on per-source.
- "Per-Source Recent Errors" section hides itself entirely when no non-HAProxy source is Available — the existing HAProxy Error Insights panel above is the only thing on-screen in that case.
- `window._availableSources` is exposed so `loadSourceMetrics` / `loadSourceErrors` can skip absent sources rather than 404-spamming the agent on every render.

## Test plan

- [x] `go test ./...` — all packages pass on `gearbox`.
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean on every file added or modified in this PR.
- [x] `templ generate` clean — `metrics_templ.go` regenerated and excluded from VCS as expected (`*_templ.go` gitignored).
- [x] Normaliser tests cover each source's JSON shape including missing fields, missing `collected_at` (falls back to now), and the `isExpectedSourceMiss` swallow logic for 503/404 responses.
- [ ] Manual smoke on `light-hugger`: HAProxy box; the four per-source cards stay hidden, "Per-Source Recent Errors" section stays hidden, HAProxy data continues to render as before. (HAProxy-only host = no visual change.)
- [ ] Manual smoke on a host with nginx installed + stub_status enabled: nginx card appears with reading/writing/waiting stacked area; Per-Source Recent Errors shows an nginx block.

## Backwards compatibility

- New `source_stats` table — additive; existing schemas untouched.
- New endpoints under fresh `/source/{source}/...` paths; existing `/metrics/summary`, `/metrics/log-errors`, etc. behave identically.
- `applyCapabilities()` still hides HAProxy cards when haproxy isn't Available, identical to today. The new per-source logic is purely additive.
- Older agents (pre-#101) lack the per-source endpoints — `isExpectedSourceMiss` swallows the 404s so dashboard logs stay clean. The collector simply persists no rows for those sources, the chart cards stay hidden via capability gates.

## What's NOT in this PR

- **Phase 8** (cross-source aggregates "Combined" toggle + stacked-area chart). Explicitly optional per #91. Worth designing once at least one real second source on the homelab fleet has shaped the UX.
- **Docker metrics**. Lives on `feature/containers-gear` with its own moby/client integration. Reconcile when both PRs land.
- **Reconciling the old `/metrics/log-errors` endpoint with the new per-source one.** The old endpoint stays untouched here so an in-flight rollout can ramp safely — the new front-end calls into `/source/{source}/log-errors` for the multi-source section. Once the rollout fully migrates, the old endpoint can be removed in a follow-up.

## References

- Parent: [#91](https://github.com/sarg3nt/gearbox/issues/91) (source-agnostic Metrics gear).
- Agent side this depends on: [#100](https://github.com/sarg3nt/gearbox/pull/100) (detection) + [#101](https://github.com/sarg3nt/gearbox/pull/101) (metrics collection + access-log).
- Capability-gating pattern: [#93](https://github.com/sarg3nt/gearbox/pull/93) (Phases 0–2 — dashboard side of the capability manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)