### PR TITLE
feat(#103): metrics page — per-user, per-box draggable layout (GridStack)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,41 @@ await showAlertDialog({
 
 Existing reference usages: [user-pages/admin-user-detail.js](static/js/user-pages/admin-user-detail.js), [user-pages/profile-management.js](static/js/user-pages/profile-management.js), [haproxy_config/editor.js](static/js/haproxy_config/editor.js).
 
+**When editing any JS or templ file, grep for stray native popups before committing:**
+
+```bash
+rg -n '\b(window\.)?(alert|confirm|prompt)\(' gearbox/static/js gearbox/internal --type-add 'templ:*.templ' --type js --type templ
+```
+
+Treat any hit (outside `static/js/vendor/`) as a bug — replace with the dialog API above. The native primitives strip styling, dark mode, focus traps, and the Esc-handling chain we depend on.
+
+### Info tooltips — always use the shared `InfoTooltip` widget
+
+Any "what is this?" hover affordance — KPI labels, table column headers, settings rows with a non-obvious effect, etc. — must use the shared widget. The canonical look (filled info-circle "i" icon, dark hover bubble, no cursor change, no transition delay) is defined in two places that are kept in lock-step:
+
+- **Server-rendered (templ):** [`@components.InfoTooltip(text)`](gearbox/internal/framework/templates/components/info_tooltip.templ).
+- **Client-built (JS):** `window.createInfoTooltip(text)` / `window.appendInfoTooltipTo(parentEl, text)` from [info-tooltip.js](gearbox/static/js/common/info-tooltip.js), already wired into [base.templ](gearbox/internal/framework/templates/layouts/base.templ) so every page has them.
+
+```templ
+import "github.com/sarg3nt/gearbox/internal/framework/templates/components"
+
+<span class="font-medium">Error Rate</span>
+@components.InfoTooltip("Percentage of requests with 4xx or 5xx status in the selected window.")
+```
+
+```javascript
+// In a JS-built widget (e.g. a chart card or KPI band):
+const labelEl = card.querySelector('.kpi-label');
+window.appendInfoTooltipTo(labelEl, c.description);
+```
+
+**Rules of thumb:**
+
+- **Do not** roll your own `?`-button, `title=`-only tooltips, or `cursor: help` affordances — they look inconsistent with the HAProxy overview pattern, which is the visual reference for every other gear.
+- **Do not** put the rich tooltip text in a `title=` attribute on a card-body — users don't know to hover invisible regions. The widget is the visible cue.
+- If the text needs structure (bold lead-in + body paragraph, multiple paragraphs), drop the same wrapper markup inline rather than extending the component — see the "VPN Gateway Architecture" usage in [overview.templ](gearbox/internal/framework/templates/pages/overview.templ) for the pattern.
+- The widget is pure CSS — no JS event wiring needed and no cursor change. If you find yourself adding `onclick` or `cursor: help`, you've drifted from the standard.
+
 ### Toggle switches — never use a bare `<input type="checkbox">` in templates
 
 For every boolean input in a `.templ` file — feature opt-ins, settings, "enable this gear", "show all", per-row enable/disable — use the shared slider component in [internal/framework/ui/toggle.templ](gearbox/internal/framework/ui/toggle.templ):

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -15,19 +15,19 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	gearbox "github.com/sarg3nt/gearbox"
-	"github.com/sarg3nt/gearbox/internal/framework/collector"
-	"github.com/sarg3nt/gearbox/internal/framework/database"
 	"github.com/sarg3nt/gearbox/internal/framework/auth"
+	"github.com/sarg3nt/gearbox/internal/framework/collector"
 	"github.com/sarg3nt/gearbox/internal/framework/config"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
 	"github.com/sarg3nt/gearbox/internal/framework/events"
 	"github.com/sarg3nt/gearbox/internal/framework/gear"
+	"github.com/sarg3nt/gearbox/internal/framework/handler"
+	gbmiddleware "github.com/sarg3nt/gearbox/internal/framework/middleware"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
 	"github.com/sarg3nt/gearbox/internal/framework/services"
 	"github.com/sarg3nt/gearbox/internal/framework/services/alerts"
 	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
 	"github.com/sarg3nt/gearbox/internal/framework/services/email"
-	"github.com/sarg3nt/gearbox/internal/framework/handler"
-	gbmiddleware "github.com/sarg3nt/gearbox/internal/framework/middleware"
-	"github.com/sarg3nt/gearbox/internal/framework/models"
 
 	// Import gears - blank identifier triggers init() registration
 	_ "github.com/sarg3nt/gearbox/internal/gears/alerts"
@@ -383,13 +383,13 @@ func main() {
 	serverAdapter := services.NewServerAdapter(db, encryptor, servers, logger)
 
 	gearDeps := gear.Dependencies{
-		DB:             db.GetDB(), // Get the underlying *sql.DB
-		Logger:         logger,
-		EventHub:       eventsAdapter,
-		Auth:           authAdapter,
-		Servers:        serverAdapter,
-		HTTPClient:     http.DefaultClient,
-		Config:         make(map[string]any),
+		DB:         db.GetDB(), // Get the underlying *sql.DB
+		Logger:     logger,
+		EventHub:   eventsAdapter,
+		Auth:       authAdapter,
+		Servers:    serverAdapter,
+		HTTPClient: http.DefaultClient,
+		Config:     make(map[string]any),
 	}
 
 	// Create gear manager (no store for now - will add database-backed store later)
@@ -540,7 +540,7 @@ func main() {
 	r.Group(func(r chi.Router) {
 		r.Use(authManager.RequireAuth)
 		r.Use(authManager.RequirePasswordChange) // Enforce password change before any other action
-		r.Use(h.InjectIntegrationStatus) // Add integration status to context for sidebar rendering
+		r.Use(h.InjectIntegrationStatus)         // Add integration status to context for sidebar rendering
 		r.Use(middleware.Timeout(60 * time.Second))
 
 		// Logout
@@ -703,6 +703,14 @@ func main() {
 			// Phase 5 unifies log parsing across every source.
 			r.Get("/{boxID}/metrics/source/{source}/summary", h.APIMetricsSourceSummaryHandler)
 			r.Get("/{boxID}/metrics/source/{source}/log-errors", h.APIMetricsSourceLogErrorsHandler)
+
+			// Per-user, per-box layout (issue #103). GET returns
+			// the user's saved GridStack positions for this box
+			// (or 204 = "use template defaults"); PATCH upserts;
+			// DELETE drops the saved row to reset to defaults.
+			r.Get("/{boxID}/metrics/layout", h.APIMetricsLayoutGetHandler)
+			r.Patch("/{boxID}/metrics/layout", h.APIMetricsLayoutPatchHandler)
+			r.Delete("/{boxID}/metrics/layout", h.APIMetricsLayoutDeleteHandler)
 
 			// Per-box capability manifest — exposes which agent gears probed
 			// available so the metrics gear (and future source-aware UI) can

--- a/gearbox/internal/framework/database/database.go
+++ b/gearbox/internal/framework/database/database.go
@@ -102,6 +102,12 @@ func New(dbPath string, logger *slog.Logger) (*DB, error) {
 		return nil, fmt.Errorf("failed to initialize home schema: %w", err)
 	}
 
+	// Initialize metrics layouts (per-user, per-box GridStack
+	// positions for the metrics page — see issue #103).
+	if err := d.initMetricsLayoutsSchema(); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics layouts schema: %w", err)
+	}
+
 	// Run schema migrations AFTER all schemas are initialized
 	// (migrations may reference tables from any schema)
 	if err := d.runSchemaMigrations(); err != nil {

--- a/gearbox/internal/framework/database/metrics_layouts.go
+++ b/gearbox/internal/framework/database/metrics_layouts.go
@@ -1,0 +1,139 @@
+// Package database — per-user, per-box layout persistence for the
+// Metrics gear's GridStack-driven page (issue #103).
+//
+// The Metrics page renders a fixed set of chart cards (HAProxy
+// stats, host metrics, plus capability-gated per-source cards).
+// Operators rearrange/resize those cards in edit mode; the saved
+// layout lives here. Storage shape: one JSON blob per (user, box)
+// holding GridStack's `save()` output verbatim — array of
+// `{id, x, y, w, h}` objects keyed by the stable tile DOM id
+// (card-cpu, card-memory, card-nginx, …). JSON beats per-tile rows
+// because the dashboard always reads/writes the whole layout at
+// once and there's no querying inside it; the JSON column keeps
+// the schema additive when we add tile shapes later.
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// MetricsLayout is one persisted layout — the GridStack `save()`
+// payload kept verbatim plus the (user, server) coordinates it
+// belongs to.
+//
+// Layout is stored as []byte rather than a typed struct because
+// GridStack's save format is the canonical form here: every field
+// it emits round-trips back through `load()` unchanged. Typing it
+// would mean keeping our Go shape in lockstep with GridStack's
+// minor-version changes — not worth the maintenance cost for a
+// JSON blob the dashboard never inspects.
+type MetricsLayout struct {
+	UserID    string    `json:"user_id"`
+	ServerID  string    `json:"server_id"`
+	Layout    []byte    `json:"layout"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ErrNoMetricsLayout is returned by GetMetricsLayout when no row
+// exists for (userID, serverID). Callers translate this into "use
+// the default layout from the page template" rather than an HTTP
+// 500 — first-visit users hit this path every time.
+var ErrNoMetricsLayout = errors.New("no metrics_layouts row for the user/server pair")
+
+// initMetricsLayoutsSchema creates the per-user-per-box layout
+// table. Called from initSchema during database startup, alongside
+// the other gear schemas. No foreign keys to users(id) intentionally:
+// if a user is deleted we'd rather orphan their saved layouts than
+// take an FK cascade — the orphans are tiny (one JSON blob each) and
+// the simpler schema sidesteps a delete-cascade ordering question.
+//
+// (server_id is text because the dashboard's box / server addressing
+// is string-keyed — server_id matches the convention used by
+// stats_history, traffic_flows, etc.)
+func (d *DB) initMetricsLayoutsSchema() error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS metrics_layouts (
+		user_id     TEXT NOT NULL,
+		server_id   TEXT NOT NULL,
+		layout_json TEXT NOT NULL,
+		updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (user_id, server_id)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_metrics_layouts_user
+		ON metrics_layouts(user_id);
+	`
+	_, err := d.db.Exec(schema)
+	return err
+}
+
+// GetMetricsLayout returns the saved layout for one (user, box) pair.
+// Returns ErrNoMetricsLayout when nothing's saved yet — callers
+// (the handler) translate to "render the default layout from the
+// page template" so first visits work without an extra round trip.
+func (d *DB) GetMetricsLayout(userID string, serverID string) (*MetricsLayout, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	row := d.db.QueryRow(`
+		SELECT user_id, server_id, layout_json, updated_at
+		FROM metrics_layouts
+		WHERE user_id = ? AND server_id = ?`,
+		userID, serverID,
+	)
+	var (
+		out    MetricsLayout
+		layout string
+	)
+	if err := row.Scan(&out.UserID, &out.ServerID, &layout, &out.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNoMetricsLayout
+		}
+		return nil, fmt.Errorf("scan metrics_layouts: %w", err)
+	}
+	out.Layout = []byte(layout)
+	return &out, nil
+}
+
+// SaveMetricsLayout upserts the layout for one (user, box) pair.
+// `layoutJSON` must already be a valid JSON string — the handler
+// is responsible for shape-checking before calling. We don't
+// re-validate here because the canonical schema lives in
+// GridStack's JS, and our agnostic-blob approach intentionally
+// avoids tracking that schema in Go.
+//
+// updated_at is bumped server-side so the dashboard can show
+// "last edited X minutes ago" without trusting client clocks.
+func (d *DB) SaveMetricsLayout(userID string, serverID string, layoutJSON []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, err := d.db.Exec(`
+		INSERT INTO metrics_layouts (user_id, server_id, layout_json, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(user_id, server_id) DO UPDATE SET
+			layout_json = excluded.layout_json,
+			updated_at  = excluded.updated_at`,
+		userID, serverID, string(layoutJSON), time.Now().UTC(),
+	)
+	return err
+}
+
+// DeleteMetricsLayout removes the saved layout for one (user, box)
+// pair, effectively reverting the user's view to the template
+// default on next render. Used by the "reset to default" button in
+// the edit-mode toolbar.
+func (d *DB) DeleteMetricsLayout(userID string, serverID string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, err := d.db.Exec(`
+		DELETE FROM metrics_layouts
+		WHERE user_id = ? AND server_id = ?`,
+		userID, serverID,
+	)
+	return err
+}

--- a/gearbox/internal/framework/database/metrics_layouts_test.go
+++ b/gearbox/internal/framework/database/metrics_layouts_test.go
@@ -1,0 +1,141 @@
+package database
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestGetMetricsLayoutMissingReturnsSentinel(t *testing.T) {
+	// First read on an empty table must return ErrNoMetricsLayout so
+	// the handler can translate to 204 No Content — anything else
+	// would mask the "no saved layout, use template defaults" path.
+	db := setupTestDB(t)
+
+	_, err := db.GetMetricsLayout("user-1", "box-1")
+	if !errors.Is(err, ErrNoMetricsLayout) {
+		t.Errorf("expected ErrNoMetricsLayout, got %v", err)
+	}
+}
+
+func TestSaveAndGetMetricsLayout(t *testing.T) {
+	// Round-trip the JSON blob byte-for-byte — the storage layer is
+	// agnostic to GridStack's payload shape, so the bytes coming back
+	// out must match the bytes going in.
+	db := setupTestDB(t)
+
+	payload := []byte(`[{"id":"card-cpu","x":0,"y":0,"w":6,"h":4},{"id":"card-memory","x":6,"y":0,"w":6,"h":4}]`)
+	if err := db.SaveMetricsLayout("user-1", "box-1", payload); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := db.GetMetricsLayout("user-1", "box-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got.Layout, payload) {
+		t.Errorf("layout round-trip = %s, want %s", got.Layout, payload)
+	}
+	if got.UserID != "user-1" || got.ServerID != "box-1" {
+		t.Errorf("metadata wrong: %+v", got)
+	}
+	if got.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt should be set by SaveMetricsLayout")
+	}
+}
+
+func TestSaveMetricsLayoutUpserts(t *testing.T) {
+	// PK is (user_id, server_id); a second save for the same pair
+	// must replace the layout, not error or create a second row.
+	db := setupTestDB(t)
+
+	first := []byte(`[{"id":"card-cpu","x":0,"y":0,"w":6,"h":4}]`)
+	second := []byte(`[{"id":"card-cpu","x":6,"y":0,"w":6,"h":4}]`)
+
+	if err := db.SaveMetricsLayout("u", "b", first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if err := db.SaveMetricsLayout("u", "b", second); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	got, err := db.GetMetricsLayout("u", "b")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got.Layout, second) {
+		t.Errorf("expected second save to win, got %s", got.Layout)
+	}
+}
+
+func TestMetricsLayoutIsolatedPerUserAndBox(t *testing.T) {
+	// (user_id, server_id) is the PK — different users on the same
+	// box, or the same user on different boxes, must keep separate
+	// layouts.
+	db := setupTestDB(t)
+
+	aliceBox1 := []byte(`[{"id":"card-cpu","x":1,"y":0,"w":6,"h":4}]`)
+	bobBox1 := []byte(`[{"id":"card-cpu","x":2,"y":0,"w":6,"h":4}]`)
+	aliceBox2 := []byte(`[{"id":"card-cpu","x":3,"y":0,"w":6,"h":4}]`)
+
+	if err := db.SaveMetricsLayout("alice", "box-1", aliceBox1); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveMetricsLayout("bob", "box-1", bobBox1); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveMetricsLayout("alice", "box-2", aliceBox2); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		user, box string
+		want      []byte
+	}{
+		{"alice", "box-1", aliceBox1},
+		{"bob", "box-1", bobBox1},
+		{"alice", "box-2", aliceBox2},
+	}
+	for _, tc := range cases {
+		got, err := db.GetMetricsLayout(tc.user, tc.box)
+		if err != nil {
+			t.Errorf("(%s,%s) get: %v", tc.user, tc.box, err)
+			continue
+		}
+		if !bytes.Equal(got.Layout, tc.want) {
+			t.Errorf("(%s,%s) layout = %s, want %s", tc.user, tc.box, got.Layout, tc.want)
+		}
+	}
+}
+
+func TestDeleteMetricsLayoutResetsToDefault(t *testing.T) {
+	// Delete must drop the row so the subsequent Get returns
+	// ErrNoMetricsLayout — that's what drives the "fall back to
+	// template defaults" path after the operator hits Reset.
+	db := setupTestDB(t)
+
+	payload := []byte(`[{"id":"card-cpu","x":0,"y":0,"w":6,"h":4}]`)
+	if err := db.SaveMetricsLayout("u", "b", payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.GetMetricsLayout("u", "b"); err != nil {
+		t.Fatalf("pre-delete get: %v", err)
+	}
+	if err := db.DeleteMetricsLayout("u", "b"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	_, err := db.GetMetricsLayout("u", "b")
+	if !errors.Is(err, ErrNoMetricsLayout) {
+		t.Errorf("expected ErrNoMetricsLayout after delete, got %v", err)
+	}
+}
+
+func TestDeleteMetricsLayoutIsNoOpWhenAbsent(t *testing.T) {
+	// Reset on a box with no saved layout shouldn't surface as an
+	// error — the user clicked the button; the desired state is
+	// "no row", which is already true.
+	db := setupTestDB(t)
+
+	if err := db.DeleteMetricsLayout("u", "never-saved"); err != nil {
+		t.Errorf("delete of absent row should be no-op, got %v", err)
+	}
+}

--- a/gearbox/internal/framework/handler/api_metrics_layout.go
+++ b/gearbox/internal/framework/handler/api_metrics_layout.go
@@ -55,6 +55,12 @@ const maxTilesPerLayout = 64
 const (
 	maxCoord = 1000
 	maxDim   = 100
+	// gridColumns mirrors the GridStack init in static/js/metrics-layout.js
+	// (column: 12). Persisted x+w must fit inside this column count or
+	// the saved tile would silently collide / clamp on next render,
+	// which surfaces as "my layout didn't stick" confusion. Keep this
+	// value in sync with the JS side if the column count ever changes.
+	gridColumns = 12
 )
 
 // layoutTile is the shape we require each entry in the posted
@@ -90,7 +96,20 @@ func validateLayoutTiles(tiles []layoutTile) error {
 		return fmt.Errorf("layout has %d tiles; maximum %d", len(tiles), maxTilesPerLayout)
 	}
 	seen := make(map[string]struct{}, len(tiles))
-	for i, t := range tiles {
+	for i := range tiles {
+		t := &tiles[i]
+		// Normalise omitted w/h. GridStack.save() drops fields that
+		// equal their defaults — including w=1 and h=1 — so a 1×N or
+		// N×1 tile arrives with W or H as the Go zero value. Treat
+		// those as the GridStack default of 1 rather than rejecting
+		// the whole payload (the user resizing a tile to 1 col wide
+		// would otherwise silently fail to persist).
+		if t.W == 0 {
+			t.W = 1
+		}
+		if t.H == 0 {
+			t.H = 1
+		}
 		if t.ID == "" {
 			return fmt.Errorf("tile %d: id is empty", i)
 		}
@@ -109,6 +128,17 @@ func validateLayoutTiles(tiles []layoutTile) error {
 		}
 		if t.W > maxDim || t.H > maxDim {
 			return fmt.Errorf("tile %q: w/h exceed %d (got w=%d, h=%d)", t.ID, maxDim, t.W, t.H)
+		}
+		// Column-count check: a saved x/w pair that overflows the
+		// 12-column grid can never render as-saved. Without this
+		// check the payload would persist successfully, then load,
+		// then silently get clamped by GridStack — and the user
+		// would see "my layout didn't stick" with no diagnostic.
+		if t.X >= gridColumns {
+			return fmt.Errorf("tile %q: x must be < %d columns (got x=%d)", t.ID, gridColumns, t.X)
+		}
+		if t.X+t.W > gridColumns {
+			return fmt.Errorf("tile %q: x+w exceeds %d columns (got x=%d, w=%d)", t.ID, gridColumns, t.X, t.W)
 		}
 	}
 	return nil

--- a/gearbox/internal/framework/handler/api_metrics_layout.go
+++ b/gearbox/internal/framework/handler/api_metrics_layout.go
@@ -1,0 +1,177 @@
+// Package handler — per-user, per-box layout endpoints for the
+// Metrics gear's draggable page (issue #103).
+//
+// Two endpoints live here:
+//
+//	GET   /api/{boxID}/metrics/layout
+//	    → returns the user's saved layout, or 204 No Content when
+//	      no row exists (caller renders the template default).
+//
+//	PATCH /api/{boxID}/metrics/layout
+//	    → upserts the layout from a JSON body. Body is GridStack's
+//	      `save()` output verbatim, validated only as well-formed
+//	      JSON + a tile-shape sanity check.
+//
+// A DELETE variant powers "reset to default" — drops the saved row
+// so the next GET 204s and the page falls back to its template
+// default.
+//
+// All three require `metrics:view` permission (the same scope the
+// metrics page itself uses); we don't have a separate "edit layout"
+// scope because the persisted layout is per-user, so a user can
+// only ever edit their own view.
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/models"
+)
+
+// maxLayoutBytes caps the request body size so a runaway client
+// can't fill the database with megabyte-sized JSON. Real GridStack
+// payloads for the metrics page are ~11 tiles × ~50 bytes/tile +
+// envelope = ~1 KB; 16 KB is generous and matches what other
+// dashboard PATCH endpoints accept.
+const maxLayoutBytes = 16 * 1024
+
+// layoutTile is the minimum shape we require each entry in the
+// posted layout array to carry. GridStack's `save()` includes
+// these four fields for every node; the `id` is the stable DOM id
+// of the tile (e.g. "card-cpu"). We don't enforce the id's value
+// against the known set of cards — the dashboard renders cards by
+// id and ignores anything it doesn't recognise, so an unknown id
+// in the saved layout is a no-op at render time rather than a
+// failure mode worth rejecting here.
+type layoutTile struct {
+	ID string `json:"id"`
+	X  int    `json:"x"`
+	Y  int    `json:"y"`
+	W  int    `json:"w"`
+	H  int    `json:"h"`
+}
+
+// APIMetricsLayoutGetHandler returns the user's saved metrics
+// layout for one box. Returns 204 No Content when nothing's saved
+// — that's the signal for the front-end to use the template's
+// default tile positions rather than the empty grid.
+func (h *Handler) APIMetricsLayoutGetHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	user, err := h.authManager.GetUser(r)
+	if err != nil || user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	layout, err := h.db.GetMetricsLayout(user.ID, boxID)
+	if err != nil {
+		if errors.Is(err, database.ErrNoMetricsLayout) {
+			// Empty response — front-end falls back to defaults.
+			// 204 is the right code: success, no body to return.
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		h.logger.Error("metrics layout get", "user_id", user.ID, "server_id", boxID, "error", err)
+		http.Error(w, "Failed to load layout", http.StatusInternalServerError)
+		return
+	}
+
+	// Pass the JSON blob through verbatim — we never re-parse it
+	// on the way out (it round-trips back into GridStack.load()
+	// on the client).
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(layout.Layout)
+}
+
+// APIMetricsLayoutPatchHandler upserts the layout JSON the
+// dashboard sent. The body must decode as a JSON array of tile
+// objects (see layoutTile); anything else is rejected as 400
+// rather than persisted, so the GET path can trust the stored
+// blob is shape-valid.
+func (h *Handler) APIMetricsLayoutPatchHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	user, err := h.authManager.GetUser(r)
+	if err != nil || user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxLayoutBytes+1))
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxLayoutBytes {
+		http.Error(w, "Layout body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Shape-validate: array of tile objects with at minimum the
+	// four GridStack fields. We don't reject extra keys — the
+	// agnostic-blob design wants newer GridStack versions' extra
+	// fields to round-trip without a Go change.
+	var tiles []layoutTile
+	if err := json.Unmarshal(body, &tiles); err != nil {
+		http.Error(w, "Invalid layout JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(tiles) == 0 {
+		http.Error(w, "Layout must contain at least one tile", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.db.SaveMetricsLayout(user.ID, boxID, body); err != nil {
+		h.logger.Error("metrics layout save", "user_id", user.ID, "server_id", boxID, "error", err)
+		http.Error(w, "Failed to save layout", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// APIMetricsLayoutDeleteHandler drops the user's saved layout for
+// one box. The next GET 204s and the page renders defaults — the
+// "reset to default" button in the edit-mode toolbar hits this.
+func (h *Handler) APIMetricsLayoutDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if !h.authManager.HasPermission(r, models.ComponentMetrics, models.PermissionView) {
+		http.Error(w, "Forbidden: insufficient permissions to view metrics", http.StatusForbidden)
+		return
+	}
+	user, err := h.authManager.GetUser(r)
+	if err != nil || user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Server ID required", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.db.DeleteMetricsLayout(user.ID, boxID); err != nil {
+		h.logger.Error("metrics layout delete", "user_id", user.ID, "server_id", boxID, "error", err)
+		http.Error(w, "Failed to delete layout", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/gearbox/internal/framework/handler/api_metrics_layout.go
+++ b/gearbox/internal/framework/handler/api_metrics_layout.go
@@ -25,6 +25,7 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -40,20 +41,77 @@ import (
 // dashboard PATCH endpoints accept.
 const maxLayoutBytes = 16 * 1024
 
-// layoutTile is the minimum shape we require each entry in the
-// posted layout array to carry. GridStack's `save()` includes
-// these four fields for every node; the `id` is the stable DOM id
-// of the tile (e.g. "card-cpu"). We don't enforce the id's value
-// against the known set of cards — the dashboard renders cards by
-// id and ignores anything it doesn't recognise, so an unknown id
-// in the saved layout is a no-op at render time rather than a
-// failure mode worth rejecting here.
+// maxTilesPerLayout caps the per-PATCH tile count. The page has 11
+// known cards today (7 baseline + 4 per-source); 64 is a comfortable
+// ceiling that survives future growth without letting a misbehaving
+// client commit a thousand-tile blob.
+const maxTilesPerLayout = 64
+
+// maxCoord / maxDim bound the GridStack coordinate space. The grid
+// renders at 12 columns wide; the metrics page typically reaches
+// y ~ 24 on the default layout. Caps a couple of orders of magnitude
+// higher so a wide future layout still fits while a "garbage value"
+// like `x: 9_999_999` gets rejected.
+const (
+	maxCoord = 1000
+	maxDim   = 100
+)
+
+// layoutTile is the shape we require each entry in the posted
+// layout array to carry. GridStack's `save()` includes these four
+// fields for every node; the `id` is the stable DOM id of the tile
+// (e.g. "card-cpu"). We don't enforce the id's value against the
+// known set of cards — the dashboard renders cards by id and
+// ignores anything it doesn't recognise, so an unknown id in the
+// saved layout is a no-op at render time rather than a failure
+// mode worth rejecting here.
 type layoutTile struct {
 	ID string `json:"id"`
 	X  int    `json:"x"`
 	Y  int    `json:"y"`
 	W  int    `json:"w"`
 	H  int    `json:"h"`
+}
+
+// validateLayoutTiles enforces the per-tile invariants we need to
+// trust the stored blob on read-back: non-empty IDs, non-negative
+// coordinates, positive dimensions, bounded values, unique IDs.
+// Without this a misbehaving client could persist tiles with
+// negative coords / zero dimensions / duplicate IDs that would
+// surface as confusing render bugs later. Returns the first
+// problem found rather than aggregating — one good error is more
+// actionable than a list when the source is a misbehaving JS
+// caller, not a hand-edited file.
+func validateLayoutTiles(tiles []layoutTile) error {
+	if len(tiles) == 0 {
+		return errors.New("layout must contain at least one tile")
+	}
+	if len(tiles) > maxTilesPerLayout {
+		return fmt.Errorf("layout has %d tiles; maximum %d", len(tiles), maxTilesPerLayout)
+	}
+	seen := make(map[string]struct{}, len(tiles))
+	for i, t := range tiles {
+		if t.ID == "" {
+			return fmt.Errorf("tile %d: id is empty", i)
+		}
+		if _, dup := seen[t.ID]; dup {
+			return fmt.Errorf("tile %d: duplicate id %q", i, t.ID)
+		}
+		seen[t.ID] = struct{}{}
+		if t.X < 0 || t.Y < 0 {
+			return fmt.Errorf("tile %q: x/y must be non-negative (got x=%d, y=%d)", t.ID, t.X, t.Y)
+		}
+		if t.X > maxCoord || t.Y > maxCoord {
+			return fmt.Errorf("tile %q: x/y exceed %d (got x=%d, y=%d)", t.ID, maxCoord, t.X, t.Y)
+		}
+		if t.W <= 0 || t.H <= 0 {
+			return fmt.Errorf("tile %q: w/h must be positive (got w=%d, h=%d)", t.ID, t.W, t.H)
+		}
+		if t.W > maxDim || t.H > maxDim {
+			return fmt.Errorf("tile %q: w/h exceed %d (got w=%d, h=%d)", t.ID, maxDim, t.W, t.H)
+		}
+	}
+	return nil
 }
 
 // APIMetricsLayoutGetHandler returns the user's saved metrics
@@ -136,8 +194,8 @@ func (h *Handler) APIMetricsLayoutPatchHandler(w http.ResponseWriter, r *http.Re
 		http.Error(w, "Invalid layout JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if len(tiles) == 0 {
-		http.Error(w, "Layout must contain at least one tile", http.StatusBadRequest)
+	if err := validateLayoutTiles(tiles); err != nil {
+		http.Error(w, "Invalid layout: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/gearbox/internal/framework/handler/api_metrics_layout_test.go
+++ b/gearbox/internal/framework/handler/api_metrics_layout_test.go
@@ -21,6 +21,28 @@ func TestValidateLayoutTiles(t *testing.T) {
 		t.Errorf("good tiles rejected: %v", err)
 	}
 
+	// GridStack.save() omits w/h when they're at their default of 1,
+	// so a 1×N or N×1 tile arrives with W or H decoded as the Go
+	// zero value. validateLayoutTiles must normalise those to 1 and
+	// accept the tile rather than reject with "w/h must be positive".
+	omitted := []layoutTile{
+		{ID: "card-cpu", X: 0, Y: 0}, // W and H both omitted (=> 0)
+		{ID: "card-mem", X: 1, Y: 0, W: 0, H: 2},
+		{ID: "card-net", X: 2, Y: 0, W: 2, H: 0},
+	}
+	if err := validateLayoutTiles(omitted); err != nil {
+		t.Errorf("tiles with omitted w/h rejected: %v", err)
+	}
+	if omitted[0].W != 1 || omitted[0].H != 1 {
+		t.Errorf("expected omitted w/h normalised to 1, got w=%d h=%d", omitted[0].W, omitted[0].H)
+	}
+	if omitted[1].W != 1 {
+		t.Errorf("expected W=0 normalised to 1, got w=%d", omitted[1].W)
+	}
+	if omitted[2].H != 1 {
+		t.Errorf("expected H=0 normalised to 1, got h=%d", omitted[2].H)
+	}
+
 	cases := []struct {
 		name      string
 		tiles     []layoutTile
@@ -60,11 +82,6 @@ func TestValidateLayoutTiles(t *testing.T) {
 			wantMatch: "exceed",
 		},
 		{
-			name:      "zero width",
-			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: 0, W: 0, H: 1}},
-			wantMatch: "w/h must be positive",
-		},
-		{
 			name:      "negative height",
 			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: 0, W: 1, H: -1}},
 			wantMatch: "w/h must be positive",
@@ -73,6 +90,16 @@ func TestValidateLayoutTiles(t *testing.T) {
 			name:      "w exceeds bound",
 			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: 0, W: maxDim + 1, H: 1}},
 			wantMatch: "w/h exceed",
+		},
+		{
+			name:      "x at column boundary",
+			tiles:     []layoutTile{{ID: "card-cpu", X: gridColumns, Y: 0, W: 1, H: 1}},
+			wantMatch: "x must be <",
+		},
+		{
+			name:      "x+w overflows columns",
+			tiles:     []layoutTile{{ID: "card-cpu", X: 8, Y: 0, W: 6, H: 1}},
+			wantMatch: "x+w exceeds",
 		},
 		{
 			name:      "too many tiles",

--- a/gearbox/internal/framework/handler/api_metrics_layout_test.go
+++ b/gearbox/internal/framework/handler/api_metrics_layout_test.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+// validateLayoutTiles is a pure function — these tests cover every
+// rejection path the PATCH handler relies on (issue #103 review on
+// PR #104). Full HTTP-level handler tests would need a wired Handler
+// with db + authManager; for the validation surface specifically the
+// table tests below match the handler's behaviour 1:1 because the
+// handler calls validateLayoutTiles directly and forwards its error
+// message verbatim.
+func TestValidateLayoutTiles(t *testing.T) {
+	good := []layoutTile{
+		{ID: "card-cpu", X: 0, Y: 0, W: 6, H: 4},
+		{ID: "card-memory", X: 6, Y: 0, W: 6, H: 4},
+	}
+	if err := validateLayoutTiles(good); err != nil {
+		t.Errorf("good tiles rejected: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		tiles     []layoutTile
+		wantMatch string
+	}{
+		{
+			name:      "empty array",
+			tiles:     nil,
+			wantMatch: "at least one tile",
+		},
+		{
+			name:      "empty id",
+			tiles:     []layoutTile{{ID: "", X: 0, Y: 0, W: 1, H: 1}},
+			wantMatch: "id is empty",
+		},
+		{
+			name: "duplicate id",
+			tiles: []layoutTile{
+				{ID: "card-cpu", X: 0, Y: 0, W: 6, H: 4},
+				{ID: "card-cpu", X: 6, Y: 0, W: 6, H: 4},
+			},
+			wantMatch: "duplicate id",
+		},
+		{
+			name:      "negative x",
+			tiles:     []layoutTile{{ID: "card-cpu", X: -1, Y: 0, W: 1, H: 1}},
+			wantMatch: "must be non-negative",
+		},
+		{
+			name:      "negative y",
+			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: -5, W: 1, H: 1}},
+			wantMatch: "must be non-negative",
+		},
+		{
+			name:      "x exceeds bound",
+			tiles:     []layoutTile{{ID: "card-cpu", X: maxCoord + 1, Y: 0, W: 1, H: 1}},
+			wantMatch: "exceed",
+		},
+		{
+			name:      "zero width",
+			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: 0, W: 0, H: 1}},
+			wantMatch: "w/h must be positive",
+		},
+		{
+			name:      "negative height",
+			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: 0, W: 1, H: -1}},
+			wantMatch: "w/h must be positive",
+		},
+		{
+			name:      "w exceeds bound",
+			tiles:     []layoutTile{{ID: "card-cpu", X: 0, Y: 0, W: maxDim + 1, H: 1}},
+			wantMatch: "w/h exceed",
+		},
+		{
+			name:      "too many tiles",
+			tiles:     buildOversizedTiles(),
+			wantMatch: "maximum",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLayoutTiles(tc.tiles)
+			if err == nil {
+				t.Fatalf("expected validation error containing %q, got nil", tc.wantMatch)
+			}
+			if !strings.Contains(err.Error(), tc.wantMatch) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantMatch)
+			}
+		})
+	}
+}
+
+// buildOversizedTiles returns one more tile than the cap so the
+// "maximum" rejection branch fires.
+func buildOversizedTiles() []layoutTile {
+	tiles := make([]layoutTile, maxTilesPerLayout+1)
+	for i := range tiles {
+		tiles[i] = layoutTile{
+			ID: pseudoTileID(i),
+			X:  0,
+			Y:  i * 4,
+			W:  1,
+			H:  1,
+		}
+	}
+	return tiles
+}
+
+// pseudoTileID returns a deterministic unique-ish id for the
+// over-cap test. Using a simple letter cycle avoids the duplicate-
+// id rejection firing first (which would shadow the cap check).
+func pseudoTileID(i int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+	if i < len(alphabet) {
+		return "card-" + string(alphabet[i])
+	}
+	// Two-char IDs for indices past 36; up to 36*36 = 1296 unique
+	// values which more than covers maxTilesPerLayout+1.
+	a := alphabet[i/len(alphabet)]
+	b := alphabet[i%len(alphabet)]
+	return "card-" + string([]byte{a, b})
+}

--- a/gearbox/internal/framework/templates/components/info_tooltip.templ
+++ b/gearbox/internal/framework/templates/components/info_tooltip.templ
@@ -1,0 +1,29 @@
+package components
+
+// InfoTooltip renders the canonical "info-circle + hover tooltip" widget
+// used across the app — small grey filled-circle "i" icon that, on hover,
+// reveals a short tooltip bubble. Behaviour matches the HAProxy overview
+// pattern verbatim: pure CSS via Tailwind `group` / `group-hover:visible`
+// (no JS), no cursor change (cursor stays as the default arrow), no
+// transition delay.
+//
+// Use this anywhere you want to attach a short explanation to a label,
+// table column header, KPI title, etc. For richer multi-paragraph
+// content (the "VPN Gateway Architecture" style with a bold title +
+// body), drop the same wrapper markup inline so the tooltip can hold
+// arbitrary HTML; this component is the simple text-only variant.
+//
+// Width defaults to w-64 (16rem). Anchor is left-0 / top-6 — the
+// tooltip extends down-and-right from the icon, which keeps it inside
+// content cards whose icons sit near the left edge.
+templ InfoTooltip(text string) {
+	<span class="relative group inline-flex items-center">
+		<svg class="w-4 h-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+			<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path>
+		</svg>
+		<span class="invisible group-hover:visible absolute left-0 top-6 w-64 p-3 bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg shadow-lg z-50 normal-case tracking-normal font-normal">
+			{ text }
+			<span class="absolute -top-1 left-2 w-2 h-2 bg-gray-900 dark:bg-gray-800 transform rotate-45"></span>
+		</span>
+	</span>
+}

--- a/gearbox/internal/framework/templates/layouts/base.templ
+++ b/gearbox/internal/framework/templates/layouts/base.templ
@@ -1378,6 +1378,7 @@ templ Base(title string, user *models.User, currentPath ...string) {
 		<script src="/static/js/common/focus-trap.js" defer></script>
 		<script src="/static/js/common/command-palette.js" defer></script>
 		<script src="/static/js/common/shortcut-help.js" defer></script>
+		<script src="/static/js/common/info-tooltip.js" defer></script>
 	</head>
 	<body class="h-full bg-gray-100 dark:bg-slate-900">
 		@ui.CollapsibleRestoreScript()

--- a/gearbox/internal/framework/templates/pages/alert_rules.templ
+++ b/gearbox/internal/framework/templates/pages/alert_rules.templ
@@ -112,11 +112,11 @@ templ AlertRulesPage(user *models.User, serverID string, serverName string, serv
 		</div>
 
 		<!-- Add/Edit Rule Modal -->
-		<div id="add-rule-modal" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+		<div id="add-rule-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
 			<div class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
 				<div class="p-4 border-b border-gray-200 dark:border-slate-700 flex items-center justify-between">
 					<h3 id="modal-title" class="text-lg font-semibold text-gray-800 dark:text-gray-200">Add Alert Rule</h3>
-					<button onclick="hideAddRuleModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+					<button onclick="hideAddRuleModal()" aria-label="Close" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
 						<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 						</svg>

--- a/gearbox/internal/framework/templates/pages/alerts.templ
+++ b/gearbox/internal/framework/templates/pages/alerts.templ
@@ -162,11 +162,11 @@ templ AlertsPage(user *models.User, servers []models.BoxConfig, perms *models.Us
 			</div>
 
 			<!-- Alert Detail Modal -->
-			<div id="alert-detail-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+			<div id="alert-detail-modal" role="dialog" aria-modal="true" aria-labelledby="alert-detail-modal-title" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
 				<div class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
 					<div class="p-4 border-b border-gray-200 dark:border-slate-700 flex justify-between items-center">
-						<h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Alert Details</h3>
-						<button onclick="hideAlertDetailModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+						<h3 id="alert-detail-modal-title" class="text-lg font-semibold text-gray-800 dark:text-gray-100">Alert Details</h3>
+						<button onclick="hideAlertDetailModal()" aria-label="Close" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
 							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 							</svg>
@@ -251,11 +251,11 @@ templ AlertsPage(user *models.User, servers []models.BoxConfig, perms *models.Us
 			</div>
 
 			<!-- Bulk Action Prompt Modal -->
-			<div id="bulk-action-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+			<div id="bulk-action-modal" role="dialog" aria-modal="true" aria-labelledby="bulk-action-title" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
 				<div class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-md w-full mx-4">
 					<div class="p-4 border-b border-gray-200 dark:border-slate-700 flex justify-between items-center">
 						<h3 id="bulk-action-title" class="text-lg font-semibold text-gray-800 dark:text-gray-100">Bulk Action</h3>
-						<button onclick="closeBulkActionModal(false)" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+						<button onclick="closeBulkActionModal(false)" aria-label="Close" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
 							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 							</svg>

--- a/gearbox/internal/framework/templates/pages/firewall_config.templ
+++ b/gearbox/internal/framework/templates/pages/firewall_config.templ
@@ -144,7 +144,7 @@ templ FirewallConfigPage(user *models.User, server *database.BoxDB, config *agen
 		<!-- Validation Error Modal — shown when Save & Apply runs into errors.
 		     Real-time errors stay inline on the editor lines; this modal is
 		     specifically for the "you tried to save invalid config" case. -->
-		<div id="firewall-error-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+		<div id="firewall-error-modal" role="dialog" aria-modal="true" aria-label="Configuration error" class="hidden fixed inset-0 z-50 overflow-y-auto">
 			<div class="flex items-center justify-center min-h-screen px-4">
 				<div class="fixed inset-0 bg-black bg-opacity-50" data-firewall-error-dismiss></div>
 				<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full">
@@ -171,7 +171,7 @@ templ FirewallConfigPage(user *models.User, server *database.BoxDB, config *agen
 		</div>
 
 		<!-- Snippets Modal — curated nftables patterns the user can insert. -->
-		<div id="firewall-snippets-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+		<div id="firewall-snippets-modal" role="dialog" aria-modal="true" aria-label="Insert nftables snippet" class="hidden fixed inset-0 z-50 overflow-y-auto">
 			<div class="flex items-center justify-center min-h-screen px-4">
 				<div class="fixed inset-0 bg-black bg-opacity-50" data-firewall-snippets-dismiss></div>
 				<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[85vh] flex flex-col">
@@ -207,7 +207,7 @@ templ FirewallConfigPage(user *models.User, server *database.BoxDB, config *agen
 		</div>
 
 		<!-- Backups Modal (kept simple; matches the existing site pattern) -->
-		<div id="firewall-backups-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+		<div id="firewall-backups-modal" role="dialog" aria-modal="true" aria-label="Configuration backups" class="hidden fixed inset-0 z-50 overflow-y-auto">
 			<div class="flex items-center justify-center min-h-screen px-4">
 				<div class="fixed inset-0 bg-black bg-opacity-50" data-firewall-modal-dismiss></div>
 				<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full p-6">

--- a/gearbox/internal/framework/templates/pages/haproxy_config/modals.templ
+++ b/gearbox/internal/framework/templates/pages/haproxy_config/modals.templ
@@ -2,7 +2,7 @@ package haproxy_config
 
 templ Modals() {
 	<!-- Backups Modal -->
-	<div id="backups-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+	<div id="backups-modal" role="dialog" aria-modal="true" aria-label="Configuration backups" class="hidden fixed inset-0 z-50 overflow-y-auto">
 		<div class="flex items-center justify-center min-h-screen px-4">
 			<div id="backups-modal-backdrop" class="fixed inset-0 bg-black bg-opacity-50"></div>
 			<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full p-6">
@@ -19,7 +19,7 @@ templ Modals() {
 		</div>
 	</div>
 	<!-- Error Dialog for tampered markers -->
-	<div id="marker-error-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+	<div id="marker-error-modal" role="dialog" aria-modal="true" aria-label="Configuration error" class="hidden fixed inset-0 z-50 overflow-y-auto">
 		<div class="flex items-center justify-center min-h-screen px-4">
 			<div class="fixed inset-0 bg-black bg-opacity-50"></div>
 			<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full">
@@ -56,7 +56,7 @@ templ Modals() {
 		</div>
 	</div>
 	<!-- Save Reason Dialog -->
-	<div id="save-reason-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+	<div id="save-reason-modal" role="dialog" aria-modal="true" aria-label="Save configuration" class="hidden fixed inset-0 z-50 overflow-y-auto">
 		<div class="flex items-center justify-center min-h-screen px-4">
 			<div id="save-reason-backdrop" class="fixed inset-0 bg-black bg-opacity-50"></div>
 			<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-md w-full">
@@ -103,7 +103,7 @@ templ Modals() {
 		</div>
 	</div>
 	<!-- Validation Output Dialog -->
-	<div id="validation-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+	<div id="validation-modal" role="dialog" aria-modal="true" aria-labelledby="validation-modal-title" class="hidden fixed inset-0 z-50 overflow-y-auto">
 		<div class="flex items-center justify-center min-h-screen px-4">
 			<div id="validation-modal-backdrop" class="fixed inset-0 bg-black bg-opacity-50"></div>
 			<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full">
@@ -134,7 +134,7 @@ templ Modals() {
 		</div>
 	</div>
 	<!-- Insert Snippets Modal -->
-	<div id="snippets-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+	<div id="snippets-modal" role="dialog" aria-modal="true" aria-label="Insert configuration snippet" class="hidden fixed inset-0 z-50 overflow-y-auto">
 		<div class="flex items-center justify-center min-h-screen px-4">
 			<div id="snippets-modal-backdrop" class="fixed inset-0 bg-black bg-opacity-50"></div>
 			<div class="relative bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[85vh] flex flex-col">

--- a/gearbox/internal/framework/templates/pages/haproxy_settings.templ
+++ b/gearbox/internal/framework/templates/pages/haproxy_settings.templ
@@ -225,7 +225,7 @@ templ HAProxyBoxesPageContent(user *models.User, servers []*database.BoxDB) {
 						</div>
 					</div>
 					<div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-						<button type="button" onclick="closeNotesModal()" class="w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-slate-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-600 sm:w-auto sm:text-sm">
+						<button type="button" onclick="closeNotesModal()" aria-label="Close" class="w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-slate-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-600 sm:w-auto sm:text-sm">
 							Close
 						</button>
 					</div>
@@ -263,7 +263,7 @@ templ HAProxyBoxesPageContent(user *models.User, servers []*database.BoxDB) {
 						<button type="button" id="delete-confirm-btn" onclick="confirmDeleteServer()" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 sm:ml-3 sm:w-auto sm:text-sm">
 							Yes, Delete
 						</button>
-						<button type="button" onclick="closeDeleteModal()" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-slate-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-600 sm:mt-0 sm:w-auto sm:text-sm">
+						<button type="button" onclick="closeDeleteModal()" aria-label="Cancel" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-slate-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-600 sm:mt-0 sm:w-auto sm:text-sm">
 							No, Cancel
 						</button>
 					</div>

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -156,7 +156,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-cpu" gs-x="0" gs-y="0" gs-w="6" gs-h="4">
 					<div id="card-cpu" data-source="host" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> CPU Load</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> CPU Load</h4>
+								<span id="cpu-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-cpu')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -173,7 +176,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-memory" gs-x="6" gs-y="0" gs-w="6" gs-h="4">
 					<div id="card-memory" data-source="host" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Memory Usage</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Memory Usage</h4>
+								<span id="memory-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-memory')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -190,7 +196,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-network" gs-x="0" gs-y="4" gs-w="6" gs-h="4">
 					<div id="card-network" data-source="host" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Network Throughput</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Network Throughput</h4>
+								<span id="network-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-network')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -207,7 +216,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-response-time" gs-x="6" gs-y="4" gs-w="6" gs-h="4">
 					<div id="card-response-time" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Response Times</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Response Times</h4>
+								<span id="response-time-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-response-time')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -224,7 +236,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-health" gs-x="0" gs-y="8" gs-w="6" gs-h="4">
 					<div id="card-health" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Server Health</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Server Health</h4>
+								<span id="health-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-health')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -241,7 +256,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-errors" gs-x="6" gs-y="8" gs-w="6" gs-h="4">
 					<div id="card-errors" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Error Rates (5xx)</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Error Rates (5xx)</h4>
+								<span id="errors-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-errors')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -258,7 +276,10 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				<div class="grid-stack-item" gs-id="card-sessions" gs-x="0" gs-y="12" gs-w="12" gs-h="4">
 					<div id="card-sessions" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Sessions & Requests</h4>
+							<div class="flex items-baseline gap-3 min-w-0">
+								<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Sessions & Requests</h4>
+								<span id="sessions-live" class="chart-live-value"></span>
+							</div>
 							<button onclick="toggleFullscreen('card-sessions')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
 								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
@@ -427,7 +448,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							target="_blank"
 							rel="noopener"
 						>View logs →</a>
-						<button onclick="closeDrillDown()" class="p-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700" title="Close (Esc)">
+						<button onclick="closeDrillDown()" aria-label="Close" class="p-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700" title="Close (Esc)">
 							<svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 							</svg>
@@ -569,8 +590,37 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			text-transform: uppercase;
 			letter-spacing: 0.04em;
 			font-weight: 500;
+			display: flex;
+			align-items: center;
+			gap: 0.35rem;
 		}
 		.dark .kpi-label { color: #94a3b8; }
+		/* Small "?" affordance next to the KPI title. Surfaces the
+		   existing description tooltip (already on the card) with a
+		   visible cue so users don't have to know to hover the card
+		   body. cursor:help renders the native tooltip on hover. */
+		.kpi-help {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 14px;
+			height: 14px;
+			border-radius: 9999px;
+			border: 1px solid currentColor;
+			background: transparent;
+			color: #94a3b8;
+			font-size: 9px;
+			font-weight: 700;
+			line-height: 1;
+			padding: 0;
+			cursor: help;
+			flex-shrink: 0;
+			text-transform: none;
+			letter-spacing: 0;
+		}
+		.kpi-help:hover, .kpi-help:focus-visible { color: #4338ca; outline: none; }
+		.dark .kpi-help { color: #64748b; }
+		.dark .kpi-help:hover, .dark .kpi-help:focus-visible { color: #a5b4fc; }
 		.kpi-value {
 			font-size: 1.5rem;
 			font-weight: 600;
@@ -611,6 +661,21 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			vertical-align: 0.15em;
 		}
 		.dark .source-tag { background: rgba(99, 102, 241, 0.15); color: #a5b4fc; }
+		/* Live readout shown to the right of each chart title — gives
+		   a glanceable "current value" so a flat-looking chart (e.g.
+		   memory parked at 3%) still tells the user what the number
+		   actually is. Mono + tabular-nums keeps digits from jittering
+		   as values change. */
+		.chart-live-value {
+			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			font-variant-numeric: tabular-nums;
+			font-size: 0.85rem;
+			font-weight: 500;
+			color: #475569;
+			white-space: nowrap;
+		}
+		.dark .chart-live-value { color: #cbd5e1; }
+		.chart-live-value:empty { display: none; }
 		.kpi-source-badge {
 			position: absolute;
 			top: 0.5rem;
@@ -1063,6 +1128,8 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			renderNetworkChart(cachedMetricsData);
 			renderResponseTimeChart(cachedStatsData);
 			renderErrorsChart(cachedStatsData);
+			updateHostLiveValues(cachedMetricsData);
+			updateHaproxyLiveValues(cachedStatsData);
 		}
 
 		// Get current server ID - handles both multi-server (select) and single-server (hidden input) modes
@@ -1715,10 +1782,12 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				]);
 			}
 			if (charts.errors) {
+				// Per-interval delta — see renderErrorsChart for why.
 				updateChartData(charts.errors, sampledData, [
-					sampledData.map(d => d.total_5xx_errors)
+					counterDeltas(sampledData, d => d.total_5xx_errors)
 				]);
 			}
+			updateHaproxyLiveValues(cachedStatsData);
 		}
 
 		function appendMetricsData(newData) {
@@ -1771,8 +1840,101 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				// Network needs special handling for rate calculation
 				updateNetworkChart(sampledData);
 			}
+			updateHostLiveValues(cachedMetricsData);
 		}
 
+		// ──────────────────────────────────────────────────────────────
+		// Live chart-title readouts. Each formatter takes the latest
+		// data point(s) and returns the short string shown next to the
+		// chart title. The point is to make flat-looking charts (e.g.
+		// memory parked at 3% on a 0–100 axis) still answer "what's the
+		// number right now?" without the user reading axis ticks.
+		// ──────────────────────────────────────────────────────────────
+		function setLiveValue(id, text) {
+			const el = document.getElementById(id);
+			if (el) el.textContent = text || '';
+		}
+		function fmtPercent(v) {
+			if (v == null || isNaN(v)) return '';
+			// 1 decimal under 10 (where it actually matters), integer
+			// above — keeps the readout from being "12.7%" when "13%"
+			// reads cleaner.
+			return v < 10 ? v.toFixed(1) + '%' : Math.round(v) + '%';
+		}
+		function fmtLoad(v) {
+			if (v == null || isNaN(v)) return '0.00';
+			return v.toFixed(2);
+		}
+		function fmtMs(v) {
+			if (v == null || isNaN(v)) return '';
+			if (v >= 1000) return (v / 1000).toFixed(1) + ' s';
+			return Math.round(v) + ' ms';
+		}
+		function fmtMbps(v) {
+			if (v == null || isNaN(v)) return '0';
+			if (v >= 100) return Math.round(v).toString();
+			if (v >= 10)  return v.toFixed(1);
+			return v.toFixed(2);
+		}
+		function fmtCount(v) {
+			if (v == null || isNaN(v)) return '0';
+			if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+			if (v >= 1e3) return (v / 1e3).toFixed(1) + 'k';
+			return Math.round(v).toString();
+		}
+		function updateHostLiveValues(history) {
+			if (!history || history.length === 0) {
+				setLiveValue('cpu-live', '');
+				setLiveValue('memory-live', '');
+				setLiveValue('network-live', '');
+				return;
+			}
+			const last = history[history.length - 1];
+			setLiveValue('cpu-live',
+				fmtLoad(last.load_average_1) + ' / ' +
+				fmtLoad(last.load_average_5) + ' / ' +
+				fmtLoad(last.load_average_15));
+			setLiveValue('memory-live', fmtPercent(last.memory_usage_percent));
+			// Network rate needs two consecutive points; same delta
+			// math the chart uses internally.
+			if (history.length >= 2) {
+				const prev = history[history.length - 2];
+				const dt = (new Date(last.collected_at) - new Date(prev.collected_at)) / 1000;
+				if (dt > 0) {
+					const rxDiff = last.network_rx_bytes - prev.network_rx_bytes;
+					const txDiff = last.network_tx_bytes - prev.network_tx_bytes;
+					const rxMbps = rxDiff >= 0 ? (rxDiff * 8 / 1e6) / dt : 0;
+					const txMbps = txDiff >= 0 ? (txDiff * 8 / 1e6) / dt : 0;
+					setLiveValue('network-live', '↓' + fmtMbps(rxMbps) + ' ↑' + fmtMbps(txMbps) + ' Mbps');
+					return;
+				}
+			}
+			setLiveValue('network-live', '');
+		}
+		function updateHaproxyLiveValues(history) {
+			if (!history || history.length === 0) {
+				setLiveValue('sessions-live', '');
+				setLiveValue('health-live', '');
+				setLiveValue('response-time-live', '');
+				setLiveValue('errors-live', '');
+				return;
+			}
+			const last = history[history.length - 1];
+			const healthy = last.healthy_servers || 0;
+			const total = last.total_servers || 0;
+			setLiveValue('health-live', healthy + ' / ' + total + ' healthy');
+			setLiveValue('response-time-live', fmtMs(last.avg_response_time));
+			// total_5xx_errors is a cumulative counter (see renderErrorsChart).
+			// Show the window-total — (last - first), clamped on resets —
+			// so the readout agrees with the KPI band's "5xx Errors" card.
+			let inWindow5xx = 0;
+			if (history.length >= 2) {
+				const delta = (last.total_5xx_errors || 0) - (history[0].total_5xx_errors || 0);
+				if (delta > 0) inWindow5xx = delta;
+			}
+			setLiveValue('errors-live', fmtCount(inWindow5xx) + ' in window');
+			setLiveValue('sessions-live', fmtCount(last.total_sessions) + ' active');
+		}
 		function getDownsampleFactor() {
 			const slider = document.getElementById('resolution-slider');
 			// Invert: slider 10 (highest res) = factor 1 (no downsampling)
@@ -2091,12 +2253,20 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			const sampledData = downsampleData(data, factor);
 			const colors = getChartColors();
 
+			// total_5xx_errors is a sum of HAProxy's monotonic hrsp_5xx
+			// counters across all frontends/backends — i.e. cumulative
+			// since the haproxy process started. Plotting it raw made
+			// the chart climb forever and diverge from the KPI band
+			// (which reports per-window counts from the database).
+			// Diff to a per-bucket count instead so the line answers
+			// "when did 5xxs happen and how many" — same framing as
+			// the Caddy/Traefik response-class charts.
 			charts.errors = new Chart(ctx.getContext('2d'), {
 				type: 'line',
 				data: {
 					labels: sampledData.map(d => formatTime(d.collected_at)),
 					datasets: [
-						makeAreaDataset('5xx Errors', sampledData.map(d => d.total_5xx_errors), colors.danger)
+						makeAreaDataset('5xx / interval', counterDeltas(sampledData, d => d.total_5xx_errors), colors.danger)
 					]
 				},
 				options: createIntegerYAxisOptions()
@@ -2138,10 +2308,17 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				const sourceBadge = c.source_label
 					? '<span class="kpi-source-badge" title="Reported by ' + escapeAttr(c.source_label) + '">' + escapeHtml(c.source_label) + '</span>'
 					: '';
+				// Small "?" affordance — the card already has the
+				// description as a `title=` tooltip, but most users
+				// won't think to hover the card body. The button
+				// advertises that help is available.
+				const help = c.description
+					? '<button type="button" class="kpi-help" tabindex="0" aria-label="About this metric" title="' + escapeAttr(c.description) + '">?</button>'
+					: '';
 				return ''
 					+ '<div class="kpi-card status-' + (c.status || 'good') + '" data-source="' + escapeAttr(c.source || '') + '" title="' + escapeAttr(c.description || '') + '">'
 					+   sourceBadge
-					+   '<div class="kpi-label">' + escapeHtml(c.label) + '</div>'
+					+   '<div class="kpi-label">' + escapeHtml(c.label) + help + '</div>'
 					+   '<div class="kpi-value">' + valueText + '</div>'
 					+   '<div class="kpi-delta-row mt-1">' + deltaHTML + '</div>'
 					+   '<canvas class="kpi-sparkline" data-spark="' + escapeAttr(JSON.stringify(c.sparkline || [])) + '"'
@@ -2184,7 +2361,17 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				return '<span class="kpi-delta neutral">live</span>';
 			}
 			const d = c.delta_pct || 0;
-			if (!isFinite(d) || (c.prev_value === 0 && c.value === 0)) {
+			// Both windows are zero — there's data, it's just all
+			// quiet. "—" is the honest summary; the old "no prior
+			// data" label was misleading because we *do* have prior
+			// data, it's just also zero.
+			if (c.prev_value === 0 && c.value === 0) {
+				return '<span class="kpi-delta neutral">—</span>';
+			}
+			// True absence of comparison data (delta couldn't be
+			// computed) — keep the explicit label so it's not
+			// confused with the both-zero case above.
+			if (!isFinite(d)) {
 				return '<span class="kpi-delta neutral">no prior data</span>';
 			}
 			let cls = 'neutral';
@@ -2376,6 +2563,9 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 
 		document.addEventListener('keydown', function(e) {
 			if (e.key === 'Escape' && document.getElementById('drilldown-drawer').classList.contains('open')) {
+				// preventDefault so the global Esc handler doesn't also
+				// run on the same press (e.g. fall through to history.back).
+				e.preventDefault();
 				closeDrillDown();
 			}
 		});

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -300,7 +300,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				     When a source becomes Available later, makeWidget()
 				     puts the tile back at its default position. -->
 				<div class="grid-stack-item" gs-id="card-nginx" gs-x="0" gs-y="16" gs-w="6" gs-h="4">
-					<div id="card-nginx" data-source="nginx" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+					<div id="card-nginx" data-source="nginx" data-source-card="true" data-cap-hidden="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">nginx:</span> Connections &amp; Requests</h4>
 							<button onclick="toggleFullscreen('card-nginx')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -315,7 +315,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 					</div>
 				</div>
 				<div class="grid-stack-item" gs-id="card-apache" gs-x="6" gs-y="16" gs-w="6" gs-h="4">
-					<div id="card-apache" data-source="apache" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+					<div id="card-apache" data-source="apache" data-source-card="true" data-cap-hidden="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Apache:</span> Workers &amp; Requests</h4>
 							<button onclick="toggleFullscreen('card-apache')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -330,7 +330,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 					</div>
 				</div>
 				<div class="grid-stack-item" gs-id="card-caddy" gs-x="0" gs-y="20" gs-w="6" gs-h="4">
-					<div id="card-caddy" data-source="caddy" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+					<div id="card-caddy" data-source="caddy" data-source-card="true" data-cap-hidden="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Caddy:</span> Requests &amp; Errors</h4>
 							<button onclick="toggleFullscreen('card-caddy')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -345,7 +345,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 					</div>
 				</div>
 				<div class="grid-stack-item" gs-id="card-traefik" gs-x="6" gs-y="20" gs-w="6" gs-h="4">
-					<div id="card-traefik" data-source="traefik" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+					<div id="card-traefik" data-source="traefik" data-source-card="true" data-cap-hidden="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Traefik:</span> Status Class</h4>
 							<button onclick="toggleFullscreen('card-traefik')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -1086,9 +1086,13 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			return mapping[cardId];
 		}
 
-		// Handle Escape key to exit fullscreen
+		// Handle Escape key to exit fullscreen. preventDefault so the
+		// global Esc handler in shortcut-help.js doesn't also fire on
+		// the same press (it falls through to history.back() when
+		// nothing else consumes Esc).
 		document.addEventListener('keydown', function(e) {
 			if (e.key === 'Escape' && currentFullscreenCard) {
+				e.preventDefault();
 				toggleFullscreen(currentFullscreenCard);
 			}
 		});
@@ -1498,9 +1502,16 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			}
 
 			// Toggle every element tagged data-source="haproxy". Includes
-			// the chart cards plus the Error Insights panel.
+			// the chart cards plus the Error Insights panel. We set
+			// both `.hidden` (for the visual hide) and
+			// `data-cap-hidden` (the dedicated marker metrics-layout.js
+			// reads so it can tell capability-driven hides apart from
+			// fullscreen-driven `.hidden`s on neighbouring cards).
 			document.querySelectorAll('[data-source="haproxy"]').forEach(function(el) {
 				el.classList.toggle('hidden', !haproxyAvailable);
+				if (el.classList.contains('chart-card')) {
+					el.dataset.capHidden = haproxyAvailable ? 'false' : 'true';
+				}
 			});
 
 			// Gate the per-source chart cards on each source's probe
@@ -1516,6 +1527,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				window._availableSources[src] = !!available;
 				document.querySelectorAll('[data-source="' + src + '"][data-source-card]').forEach(function(el) {
 					el.classList.toggle('hidden', !available);
+					el.dataset.capHidden = available ? 'false' : 'true';
 				});
 			}
 
@@ -2833,8 +2845,11 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 
 		<!-- GridStack vendor JS (issue #103). Same bundle the Home
 		     gear uses. Loaded with defer so it doesn't block initial
-		     paint; the inline metrics-layout.js script below waits
-		     on DOMContentLoaded before initialising. -->
+		     paint; defer also guarantees both scripts run after the
+		     DOM is parsed, in source order — so metrics-layout.js
+		     can rely on GridStack being defined and on its target
+		     #charts-grid element existing the moment its top-level
+		     IIFE executes (no extra DOMContentLoaded gate needed). -->
 		<script src="/static/js/vendor/gridstack/gridstack-all.js" defer></script>
 		<script src="/static/js/metrics-layout.js" defer></script>
 	}

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -448,12 +448,36 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			outline-offset: -4px;
 			cursor: move;
 		}
+		/* Make each tile a flex column so the chart container can
+		   flex to fill the GridStack-controlled height instead of
+		   computing its own from the chart-aspect-container's
+		   padding-bottom trick (which was sized to viewport width
+		   and overflowed the tile). overflow:hidden clips any
+		   stragglers (legends, axis labels) that briefly extend past
+		   the bounds during GridStack resize transitions. */
 		#charts-grid .grid-stack-item-content {
-			/* Inherit the chart-card's own border-radius rather than
-			   the GridStack default (which is rectangular) so the
-			   drag handle visually matches the card. */
-			overflow: visible;
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			overflow: hidden;
 		}
+		/* Inside a GridStack tile, drop the percent-of-width
+		   aspect-ratio trick — the tile's height comes from gs-h *
+		   cellHeight, and the canvas should fill what's left after
+		   the header row. min-height: 0 is the flex-child idiom
+		   that lets the container shrink below its content's
+		   intrinsic size (without it, the chart's reported size
+		   refuses to go below ~432px and overflows). */
+		#charts-grid .chart-aspect-container {
+			position: relative;
+			flex: 1 1 auto;
+			min-height: 0;
+			width: 100%;
+			height: auto;
+			padding-bottom: 0;
+		}
+		/* Original aspect-ratio rule preserved for any usages
+		   outside the metrics grid (drill-down drawer, etc.). */
 		.chart-aspect-container {
 			position: relative;
 			width: 100%;

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -443,6 +443,19 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 		   per row. Edit-mode visual cue (dashed outline) mirrors
 		   Home's .home-grid-edit class so the affordance reads
 		   consistently across pages. */
+		/* Absorb GridStack's 6px outer inset (from marginLeft/Right/Top
+		   = 6) so the grid's first column/row aligns with the KPI
+		   band above and the page-content edges. Without these
+		   negative margins the chart grid floats 6px in from every
+		   outer edge while the KPI band sits flush — visually
+		   inconsistent. The -10px top compensates for the KPI's
+		   mb-4 (16px) so the gap from KPI bottom to first chart-tile
+		   visible-top is 12px, matching the inter-tile rhythm. */
+		#charts-grid {
+			margin-left: -6px;
+			margin-right: -6px;
+			margin-top: -10px;
+		}
 		#charts-grid.metrics-grid-edit .grid-stack-item-content {
 			outline: 2px dashed rgba(59, 130, 246, 0.5);
 			outline-offset: -4px;

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -454,8 +454,12 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 		   padding-bottom trick (which was sized to viewport width
 		   and overflowed the tile). overflow:hidden clips any
 		   stragglers (legends, axis labels) that briefly extend past
-		   the bounds during GridStack resize transitions. */
-		#charts-grid .grid-stack-item-content {
+		   the bounds during GridStack resize transitions.
+		   :not(.hidden) is critical — without it this rule has
+		   higher specificity than Tailwind's .hidden (display:none)
+		   utility and wins the cascade, so capability-hidden cards
+		   stay visible. */
+		#charts-grid .grid-stack-item-content:not(.hidden) {
 			display: flex;
 			flex-direction: column;
 			height: 100%;

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -595,32 +595,6 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			gap: 0.35rem;
 		}
 		.dark .kpi-label { color: #94a3b8; }
-		/* Small "?" affordance next to the KPI title. Surfaces the
-		   existing description tooltip (already on the card) with a
-		   visible cue so users don't have to know to hover the card
-		   body. cursor:help renders the native tooltip on hover. */
-		.kpi-help {
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			width: 14px;
-			height: 14px;
-			border-radius: 9999px;
-			border: 1px solid currentColor;
-			background: transparent;
-			color: #94a3b8;
-			font-size: 9px;
-			font-weight: 700;
-			line-height: 1;
-			padding: 0;
-			cursor: help;
-			flex-shrink: 0;
-			text-transform: none;
-			letter-spacing: 0;
-		}
-		.kpi-help:hover, .kpi-help:focus-visible { color: #4338ca; outline: none; }
-		.dark .kpi-help { color: #64748b; }
-		.dark .kpi-help:hover, .dark .kpi-help:focus-visible { color: #a5b4fc; }
 		.kpi-value {
 			font-size: 1.5rem;
 			font-weight: 600;
@@ -2299,6 +2273,12 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			const band = document.getElementById('kpi-band');
 			if (!band) return;
 
+			// Build the band as a string first, then append the
+			// canonical info-tooltip nodes via createInfoTooltip()
+			// (window helper from /static/js/common/info-tooltip.js).
+			// Keeping the tooltip out of the innerHTML string means
+			// description text never needs HTML-escaping and matches
+			// the HAProxy overview tooltip behaviour exactly.
 			band.innerHTML = cards.map(function(c) {
 				const valueText = formatKPIValue(c);
 				const deltaHTML = formatKPIDelta(c);
@@ -2308,23 +2288,29 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				const sourceBadge = c.source_label
 					? '<span class="kpi-source-badge" title="Reported by ' + escapeAttr(c.source_label) + '">' + escapeHtml(c.source_label) + '</span>'
 					: '';
-				// Small "?" affordance — the card already has the
-				// description as a `title=` tooltip, but most users
-				// won't think to hover the card body. The button
-				// advertises that help is available.
-				const help = c.description
-					? '<button type="button" class="kpi-help" tabindex="0" aria-label="About this metric" title="' + escapeAttr(c.description) + '">?</button>'
-					: '';
 				return ''
-					+ '<div class="kpi-card status-' + (c.status || 'good') + '" data-source="' + escapeAttr(c.source || '') + '" title="' + escapeAttr(c.description || '') + '">'
+					+ '<div class="kpi-card status-' + (c.status || 'good') + '" data-source="' + escapeAttr(c.source || '') + '" data-kpi-key="' + escapeAttr(c.key || '') + '">'
 					+   sourceBadge
-					+   '<div class="kpi-label">' + escapeHtml(c.label) + help + '</div>'
+					+   '<div class="kpi-label"><span class="kpi-label-text">' + escapeHtml(c.label) + '</span><span class="kpi-info-slot"></span></div>'
 					+   '<div class="kpi-value">' + valueText + '</div>'
 					+   '<div class="kpi-delta-row mt-1">' + deltaHTML + '</div>'
 					+   '<canvas class="kpi-sparkline" data-spark="' + escapeAttr(JSON.stringify(c.sparkline || [])) + '"'
 					+     ' data-status="' + (c.status || 'good') + '"></canvas>'
 					+ '</div>';
 			}).join('');
+
+			// Attach the canonical info tooltip (matches the HAProxy
+			// dashboard widget byte-for-byte) to each card whose
+			// description is non-empty.
+			cards.forEach(function(c) {
+				if (!c.description) return;
+				const card = band.querySelector('.kpi-card[data-kpi-key="' + (c.key || '').replace(/"/g, '\\"') + '"]');
+				if (!card) return;
+				const slot = card.querySelector('.kpi-info-slot');
+				if (slot && typeof window.appendInfoTooltipTo === 'function') {
+					window.appendInfoTooltipTo(slot, c.description);
+				}
+			});
 
 			// Render sparklines.
 			band.querySelectorAll('canvas.kpi-sparkline').forEach(function(canvas) {

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -62,6 +62,35 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
 					</svg>
 				</button>
+
+				<!-- Reset-to-default button (issue #103). Hidden
+				     outside edit mode — appears next to the toggle
+				     once the operator starts editing so a "back to
+				     defaults" path is one click away during a drag
+				     session that went wrong. -->
+				<button
+					id="metrics-reset-layout"
+					type="button"
+					class="metrics-edit-only hidden h-[38px] px-3 py-1.5 text-sm border border-amber-300 dark:border-amber-700 rounded-lg bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+					title="Reset the chart layout for this box to the default arrangement"
+					aria-label="Reset chart layout to default"
+				>
+					↺ Reset layout
+				</button>
+
+				<!-- Edit layout toggle (issue #103). Locks/unlocks
+				     the GridStack-driven chart grid for drag + resize.
+				     Mirrors Home's #home-edit-toggle UX. -->
+				<button
+					id="metrics-edit-toggle"
+					type="button"
+					class="h-[38px] px-3 py-1.5 text-sm border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+					title="Rearrange and resize the chart layout for this box"
+					aria-label="Edit chart layout"
+				>
+					<span class="metrics-edit-off-label">✏️ Edit layout</span>
+					<span class="metrics-edit-on-label hidden">✓ Done editing</span>
+				</button>
 			</div>
 		</div>
 
@@ -93,42 +122,31 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 				}
 			</div>
 
-			<div class="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6">
-
-				<!-- Charts Grid - 4 columns on 2xl, 3 on xl, 2 on lg, 1 on smaller -->
-				<div id="charts-grid" class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
-					<!-- Sessions & Requests -->
-					<div id="card-sessions" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
-						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Sessions & Requests</h4>
-							<button onclick="toggleFullscreen('card-sessions')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
-								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
-								</svg>
-							</button>
-						</div>
-						<div class="chart-aspect-container">
-							<canvas id="sessions-chart"></canvas>
-						</div>
-					</div>
-
-					<!-- Server Health -->
-					<div id="card-health" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
-						<div class="flex justify-between items-center mb-2">
-							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Server Health</h4>
-							<button onclick="toggleFullscreen('card-health')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
-								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
-								</svg>
-							</button>
-						</div>
-						<div class="chart-aspect-container">
-							<canvas id="health-chart"></canvas>
-						</div>
-					</div>
-
-					<!-- CPU Load -->
-					<div id="card-cpu" data-source="host" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+			<!-- Chart grid (issue #103). GridStack-driven; each card is
+			     a tile that can be dragged + resized in edit mode. The
+			     wrapper panel that used to surround the grid is gone —
+			     cards are top-level so they can flow into any layout
+			     the operator chooses. Default tile coordinates below
+			     match the layout proposed in #103:
+			       row 0  | CPU      | Memory
+			       row 1  | Network  | Response Time
+			       row 2  | Health   | Error Rates
+			       row 3  | Sessions & Requests (full width)
+			       rows 4+ | per-source cards, capability-gated
+			     Each tile defaults to gs-w=6 / gs-h=4 (half-width,
+			     four cell rows tall — matches the existing aspect-
+			     ratio container). The "Sessions & Requests" tile is
+			     gs-w=12 because it deserves the full row on its own.
+			     Per-source tiles are gs-w=6 and live in two rows
+			     below the baseline cards. -->
+			<div
+				id="charts-grid"
+				class="grid-stack"
+				data-default-rendered="false"
+			>
+				<!-- CPU Load (row 0, left) -->
+				<div class="grid-stack-item" gs-id="card-cpu" gs-x="0" gs-y="0" gs-w="6" gs-h="4">
+					<div id="card-cpu" data-source="host" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> CPU Load</h4>
 							<button onclick="toggleFullscreen('card-cpu')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -141,9 +159,11 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="cpu-chart"></canvas>
 						</div>
 					</div>
+				</div>
 
-					<!-- Memory Usage -->
-					<div id="card-memory" data-source="host" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+				<!-- Memory Usage (row 0, right) -->
+				<div class="grid-stack-item" gs-id="card-memory" gs-x="6" gs-y="0" gs-w="6" gs-h="4">
+					<div id="card-memory" data-source="host" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Memory Usage</h4>
 							<button onclick="toggleFullscreen('card-memory')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -156,9 +176,11 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="memory-chart"></canvas>
 						</div>
 					</div>
+				</div>
 
-					<!-- Network Traffic -->
-					<div id="card-network" data-source="host" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+				<!-- Network Throughput (row 1, left) -->
+				<div class="grid-stack-item" gs-id="card-network" gs-x="0" gs-y="4" gs-w="6" gs-h="4">
+					<div id="card-network" data-source="host" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Host:</span> Network Throughput</h4>
 							<button onclick="toggleFullscreen('card-network')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -171,9 +193,11 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="network-chart"></canvas>
 						</div>
 					</div>
+				</div>
 
-					<!-- Response Times -->
-					<div id="card-response-time" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+				<!-- Response Times (row 1, right) -->
+				<div class="grid-stack-item" gs-id="card-response-time" gs-x="6" gs-y="4" gs-w="6" gs-h="4">
+					<div id="card-response-time" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Response Times</h4>
 							<button onclick="toggleFullscreen('card-response-time')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -186,9 +210,28 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="response-time-chart"></canvas>
 						</div>
 					</div>
+				</div>
 
-					<!-- Error Rates -->
-					<div id="card-errors" data-source="haproxy" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+				<!-- Server Health (row 2, left) -->
+				<div class="grid-stack-item" gs-id="card-health" gs-x="0" gs-y="8" gs-w="6" gs-h="4">
+					<div id="card-health" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+						<div class="flex justify-between items-center mb-2">
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Server Health</h4>
+							<button onclick="toggleFullscreen('card-health')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
+								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+								</svg>
+							</button>
+						</div>
+						<div class="chart-aspect-container">
+							<canvas id="health-chart"></canvas>
+						</div>
+					</div>
+				</div>
+
+				<!-- Error Rates (row 2, right) -->
+				<div class="grid-stack-item" gs-id="card-errors" gs-x="6" gs-y="8" gs-w="6" gs-h="4">
+					<div id="card-errors" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Error Rates (5xx)</h4>
 							<button onclick="toggleFullscreen('card-errors')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -201,14 +244,34 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="errors-chart"></canvas>
 						</div>
 					</div>
+				</div>
 
-					<!-- Per-source request-rate cards (nginx, Apache, Caddy, Traefik).
-					     Each gets the same data-source / data-source-card
-					     hooks the host + HAProxy cards use so applyCapabilities()
-					     can hide them in one pass when the corresponding agent
-					     gear isn't Available. The render path lives in
-					     loadSourceMetrics() further below. -->
-					<div id="card-nginx" data-source="nginx" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+				<!-- Sessions & Requests (row 3, full width — gs-w=12) -->
+				<div class="grid-stack-item" gs-id="card-sessions" gs-x="0" gs-y="12" gs-w="12" gs-h="4">
+					<div id="card-sessions" data-source="haproxy" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative">
+						<div class="flex justify-between items-center mb-2">
+							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">HAProxy:</span> Sessions & Requests</h4>
+							<button onclick="toggleFullscreen('card-sessions')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
+								<svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+								</svg>
+							</button>
+						</div>
+						<div class="chart-aspect-container">
+							<canvas id="sessions-chart"></canvas>
+						</div>
+					</div>
+				</div>
+
+				<!-- Per-source cards (rows 4 + 5). Hidden by default
+				     via the existing applyCapabilities() pass; the
+				     GridStack-init layer also calls removeWidget()
+				     for any source whose gear isn't Available so the
+				     grid doesn't reserve slots for invisible tiles.
+				     When a source becomes Available later, makeWidget()
+				     puts the tile back at its default position. -->
+				<div class="grid-stack-item" gs-id="card-nginx" gs-x="0" gs-y="16" gs-w="6" gs-h="4">
+					<div id="card-nginx" data-source="nginx" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">nginx:</span> Connections &amp; Requests</h4>
 							<button onclick="toggleFullscreen('card-nginx')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -221,7 +284,9 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="nginx-chart"></canvas>
 						</div>
 					</div>
-					<div id="card-apache" data-source="apache" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+				</div>
+				<div class="grid-stack-item" gs-id="card-apache" gs-x="6" gs-y="16" gs-w="6" gs-h="4">
+					<div id="card-apache" data-source="apache" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Apache:</span> Workers &amp; Requests</h4>
 							<button onclick="toggleFullscreen('card-apache')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -234,7 +299,9 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="apache-chart"></canvas>
 						</div>
 					</div>
-					<div id="card-caddy" data-source="caddy" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+				</div>
+				<div class="grid-stack-item" gs-id="card-caddy" gs-x="0" gs-y="20" gs-w="6" gs-h="4">
+					<div id="card-caddy" data-source="caddy" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Caddy:</span> Requests &amp; Errors</h4>
 							<button onclick="toggleFullscreen('card-caddy')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -247,7 +314,9 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 							<canvas id="caddy-chart"></canvas>
 						</div>
 					</div>
-					<div id="card-traefik" data-source="traefik" data-source-card="true" class="chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
+				</div>
+				<div class="grid-stack-item" gs-id="card-traefik" gs-x="6" gs-y="20" gs-w="6" gs-h="4">
+					<div id="card-traefik" data-source="traefik" data-source-card="true" class="grid-stack-item-content chart-card bg-gray-50 dark:bg-slate-700 rounded-lg p-4 relative hidden">
 						<div class="flex justify-between items-center mb-2">
 							<h4 class="text-lg font-medium text-gray-700 dark:text-gray-300"><span class="source-tag">Traefik:</span> Status Class</h4>
 							<button onclick="toggleFullscreen('card-traefik')" class="fullscreen-btn p-1 hover:bg-gray-200 dark:hover:bg-slate-600 rounded transition-colors" title="Toggle fullscreen">
@@ -363,7 +432,28 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			</aside>
 		}
 
+		<!-- GridStack vendor styles (issue #103). Shared with the Home
+		     gear; loaded inline rather than via base.templ because the
+		     stylesheet only matters on the metrics page. -->
+		<link rel="stylesheet" href="/static/css/vendor/gridstack/gridstack.min.css"/>
+
 		<style>
+		/* Per-page GridStack tweaks: tighter cell height than the
+		   Home gear because chart cards want more breathing room
+		   per row. Edit-mode visual cue (dashed outline) mirrors
+		   Home's .home-grid-edit class so the affordance reads
+		   consistently across pages. */
+		#charts-grid.metrics-grid-edit .grid-stack-item-content {
+			outline: 2px dashed rgba(59, 130, 246, 0.5);
+			outline-offset: -4px;
+			cursor: move;
+		}
+		#charts-grid .grid-stack-item-content {
+			/* Inherit the chart-card's own border-radius rather than
+			   the GridStack default (which is rectangular) so the
+			   drag handle visually matches the card. */
+			overflow: visible;
+		}
 		.chart-aspect-container {
 			position: relative;
 			width: 100%;
@@ -1355,6 +1445,14 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 					updateNoHAProxyBanner(haproxyEntry);
 				}
 			}
+
+			// Notify the GridStack layer (metrics-layout.js) that the
+			// capability-driven .hidden classes have been re-applied.
+			// It listens for this event and removes/re-adds widgets
+			// from the grid so unavailable sources don't leave gaps.
+			// Decoupled via CustomEvent so the two scripts don't need
+			// to know about each other's globals.
+			window.dispatchEvent(new CustomEvent('metrics:capabilities-applied'));
 		}
 
 		// updateNoHAProxyBanner picks user-facing copy that matches the
@@ -2504,5 +2602,12 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 		});
 		observer.observe(document.documentElement, { attributes: true });
 		</script>
+
+		<!-- GridStack vendor JS (issue #103). Same bundle the Home
+		     gear uses. Loaded with defer so it doesn't block initial
+		     paint; the inline metrics-layout.js script below waits
+		     on DOMContentLoaded before initialising. -->
+		<script src="/static/js/vendor/gridstack/gridstack-all.js" defer></script>
+		<script src="/static/js/metrics-layout.js" defer></script>
 	}
 }

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -449,20 +449,23 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			cursor: move;
 		}
 		/* Make each tile a flex column so the chart container can
-		   flex to fill the GridStack-controlled height instead of
-		   computing its own from the chart-aspect-container's
-		   padding-bottom trick (which was sized to viewport width
-		   and overflowed the tile). overflow:hidden clips any
-		   stragglers (legends, axis labels) that briefly extend past
-		   the bounds during GridStack resize transitions.
-		   :not(.hidden) is critical — without it this rule has
-		   higher specificity than Tailwind's .hidden (display:none)
-		   utility and wins the cascade, so capability-hidden cards
-		   stay visible. */
+		   flex to fill the GridStack-controlled vertical space
+		   (between top:marginTop and bottom:marginBottom set
+		   inline by GridStack). overflow:hidden clips any
+		   stragglers (legends, axis labels) that briefly extend
+		   past the bounds during GridStack resize transitions.
+		   :not(.hidden) keeps Tailwind's .hidden (display:none)
+		   winning the cascade for capability-hidden cards.
+		   IMPORTANT: do NOT set `height: 100%` here — GridStack's
+		   own inline `top` + `bottom` positioning already sizes
+		   the absolute-positioned inner content. height: 100%
+		   would over-constrain (height + top + bottom all set →
+		   height wins per CSS spec), making the inner extend
+		   marginBottom px past the outer's bottom and visually
+		   eat the vertical gap between rows. */
 		#charts-grid .grid-stack-item-content:not(.hidden) {
 			display: flex;
 			flex-direction: column;
-			height: 100%;
 			overflow: hidden;
 		}
 		/* Inside a GridStack tile, drop the percent-of-width

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -78,18 +78,26 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 					↺ Reset layout
 				</button>
 
-				<!-- Edit layout toggle (issue #103). Locks/unlocks
-				     the GridStack-driven chart grid for drag + resize.
-				     Mirrors Home's #home-edit-toggle UX. -->
+				<!-- Edit-layout toggle (issue #103). Standardised
+				     "gear cog" affordance shared with the Home gear
+				     and intended to be reused by future gears; same
+				     SVG path as the main sidebar Settings icon so the
+				     visual vocabulary stays consistent. Icon-only;
+				     aria-pressed conveys edit state. The colour
+				     shifts to the accent blue while pressed so the
+				     edit-mode state is glanceable. -->
 				<button
 					id="metrics-edit-toggle"
 					type="button"
-					class="h-[38px] px-3 py-1.5 text-sm border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
-					title="Rearrange and resize the chart layout for this box"
+					class="gear-cog-btn h-[38px] w-[38px] inline-flex items-center justify-center rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+					title="Edit chart layout"
 					aria-label="Edit chart layout"
+					aria-pressed="false"
 				>
-					<span class="metrics-edit-off-label">✏️ Edit layout</span>
-					<span class="metrics-edit-on-label hidden">✓ Done editing</span>
+					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+					</svg>
 				</button>
 			</div>
 		</div>

--- a/gearbox/internal/framework/templates/pages/metrics.templ
+++ b/gearbox/internal/framework/templates/pages/metrics.templ
@@ -141,7 +141,7 @@ templ Metrics(user *models.User, servers []models.BoxConfig) {
 			     below the baseline cards. -->
 			<div
 				id="charts-grid"
-				class="grid-stack"
+				class="grid-stack mb-6"
 				data-default-rendered="false"
 			>
 				<!-- CPU Load (row 0, left) -->

--- a/gearbox/internal/gears/home/pages.templ
+++ b/gearbox/internal/gears/home/pages.templ
@@ -233,19 +233,32 @@ templ IndexPage(d IndexPageData) {
 					}
 				</button>
 				<button
-					id="home-edit-toggle"
-					type="button"
-					class="text-sm px-3 py-1.5 rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-800 dark:text-white hover:bg-gray-50 dark:hover:bg-slate-600"
-				>
-					<span class="home-edit-off-label">Edit</span>
-					<span class="home-edit-on-label hidden">Done</span>
-				</button>
-				<button
 					id="home-add-tile"
 					type="button"
 					class="text-sm px-3 py-1.5 rounded-md bg-blue-600 hover:bg-blue-700 text-white whitespace-nowrap"
 				>
 					+ Add tile
+				</button>
+				<!-- Edit toggle — standardised "gear cog" affordance
+				     shared with the Metrics gear's #metrics-edit-toggle
+				     (same SVG as the main sidebar Settings icon).
+				     Icon-only; aria-pressed conveys edit state and
+				     drives the blue-tinted "pressed" appearance via
+				     the .gear-cog-btn rule below. Anchored at the far
+				     right of the header so every gear's settings
+				     entry-point lands in a consistent spot. -->
+				<button
+					id="home-edit-toggle"
+					type="button"
+					class="gear-cog-btn h-[34px] w-[34px] inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
+					title="Edit board"
+					aria-label="Edit board"
+					aria-pressed="false"
+				>
+					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+					</svg>
 				</button>
 			</div>
 		</div>

--- a/gearbox/static/css/components/buttons.css
+++ b/gearbox/static/css/components/buttons.css
@@ -103,3 +103,35 @@
     background: inherit;
     border-radius: inherit;
 }
+
+/*
+ * Gear-cog button — standardised settings/edit affordance shared
+ * across gears (Home, Metrics, and any future gear that needs a
+ * page-level "enter edit mode" entry point). Same SVG path as the
+ * main sidebar Settings cog so the visual vocabulary stays
+ * consistent.
+ *
+ * Default state matches a neutral icon button. aria-pressed="true"
+ * (driven from JS when edit mode is on) tints the button blue so
+ * the active state is glanceable at a glance.
+ *
+ * Plain CSS rather than @apply so the rule survives the Tailwind
+ * CDN runtime (issue #99) without depending on the build pipeline.
+ */
+/* !important because the buttons carry Tailwind dark:bg-slate-*
+ * etc. utility classes — under the Tailwind v4 Play CDN those
+ * compile to rules that win the cascade against plain selectors of
+ * the same logical specificity, regardless of source order. The
+ * explicit !important here is the lowest-friction way to make the
+ * pressed-state palette deterministic without stripping the
+ * utility classes off the buttons. */
+.gear-cog-btn[aria-pressed="true"] {
+    background-color: rgb(219, 234, 254) !important;
+    color: rgb(29, 78, 216) !important;
+    border-color: rgb(147, 197, 253) !important;
+}
+.dark .gear-cog-btn[aria-pressed="true"] {
+    background-color: rgba(30, 58, 138, 0.4) !important;
+    color: rgb(147, 197, 253) !important;
+    border-color: rgba(96, 165, 250, 0.5) !important;
+}

--- a/gearbox/static/js/charts/chart-fullscreen.js
+++ b/gearbox/static/js/charts/chart-fullscreen.js
@@ -81,6 +81,9 @@ export function exitFullscreen(onResize) {
 export function setupFullscreenKeyHandler(onResize) {
 	document.addEventListener('keydown', function(e) {
 		if (e.key === 'Escape' && currentFullscreenCard) {
+			// preventDefault so the global Esc handler in
+			// shortcut-help.js doesn't fall through to history.back().
+			e.preventDefault();
 			exitFullscreen(onResize);
 		}
 	});

--- a/gearbox/static/js/common/info-tooltip.js
+++ b/gearbox/static/js/common/info-tooltip.js
@@ -1,0 +1,69 @@
+/**
+ * info-tooltip.js — client-side counterpart of the InfoTooltip templ
+ * component (internal/framework/templates/components/info_tooltip.templ).
+ *
+ * Use this anywhere a chart, KPI card, or other widget is built in JS
+ * and you want to attach the canonical info-circle + hover-tooltip
+ * affordance. The DOM it produces matches the templ component, so both
+ * server-rendered and client-built widgets look and behave the same.
+ *
+ * Behaviour matches the HAProxy overview pattern verbatim: pure CSS
+ * via Tailwind `group` / `group-hover:visible`, no JS event wiring,
+ * no cursor change (cursor stays as the default arrow), no transition
+ * delay.
+ *
+ * Two surfaces are exposed:
+ *
+ *   window.createInfoTooltip(text)
+ *     Returns a detached <span> element you can appendChild into a
+ *     container. Safe under CSP — uses textContent for the user-
+ *     supplied tooltip body, so the text can't introduce HTML.
+ *
+ *   window.appendInfoTooltipTo(parentEl, text)
+ *     Convenience wrapper — creates the tooltip and appends it.
+ */
+(function () {
+    'use strict';
+
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+    var INFO_PATH = 'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z';
+
+    function createInfoTooltip(text) {
+        var wrapper = document.createElement('span');
+        wrapper.className = 'relative group inline-flex items-center';
+
+        var svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('class', 'w-4 h-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300');
+        svg.setAttribute('fill', 'currentColor');
+        svg.setAttribute('viewBox', '0 0 20 20');
+        svg.setAttribute('aria-hidden', 'true');
+        var path = document.createElementNS(SVG_NS, 'path');
+        path.setAttribute('fill-rule', 'evenodd');
+        path.setAttribute('clip-rule', 'evenodd');
+        path.setAttribute('d', INFO_PATH);
+        svg.appendChild(path);
+        wrapper.appendChild(svg);
+
+        var bubble = document.createElement('span');
+        bubble.className = 'invisible group-hover:visible absolute left-0 top-6 w-64 p-3 bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg shadow-lg z-50 normal-case tracking-normal font-normal';
+        // textContent — escapes everything; user-supplied text can't
+        // introduce HTML into the bubble.
+        bubble.textContent = text == null ? '' : String(text);
+        var arrow = document.createElement('span');
+        arrow.className = 'absolute -top-1 left-2 w-2 h-2 bg-gray-900 dark:bg-gray-800 transform rotate-45';
+        bubble.appendChild(arrow);
+        wrapper.appendChild(bubble);
+
+        return wrapper;
+    }
+
+    function appendInfoTooltipTo(parent, text) {
+        if (!parent) return null;
+        var node = createInfoTooltip(text);
+        parent.appendChild(node);
+        return node;
+    }
+
+    window.createInfoTooltip = createInfoTooltip;
+    window.appendInfoTooltipTo = appendInfoTooltipTo;
+})();

--- a/gearbox/static/js/common/shortcut-help.js
+++ b/gearbox/static/js/common/shortcut-help.js
@@ -21,7 +21,7 @@
         { keys: ['Cmd/Ctrl', 'K'],        label: 'Open command palette',                              join: '+' },
         { keys: ['g', 'b'],               label: 'Switch box (palette)',                              join: 'then' },
         { keys: ['/'],                    label: 'Focus the page search input' },
-        { keys: ['Esc'],                  label: 'Close dialog · or blur input · or go back' },
+        { keys: ['Esc'],                  label: 'Close dialog · exit edit mode · blur input · go back' },
         { keys: ['↑', '↓'],               label: 'Navigate dialog items',                             join: '/' },
         { keys: ['↵'],                    label: 'Select highlighted item' },
         { keys: ['Tab'],                  label: 'Cycle focus within a dialog' },
@@ -110,55 +110,132 @@
             }
         });
 
-        // `Esc` — universal "back out" key.
-        //   1. If a focusable control (input/select/textarea/contenteditable)
-        //      has focus, blur it. This is the primary motivator: a user
-        //      who pressed `/` and typed a filter can hit Esc to leave the
-        //      input, freeing `?` / `Cmd+K` / `/` to work again.
-        //   2. If nothing is focused and no overlay/dialog is open, fall
-        //      back to `history.back()`. Lets the user `/`→type→Esc→Esc
-        //      to bounce back to the previous gear without reaching for
-        //      the mouse. Skips when an overlay is up (those have their
-        //      own Esc handlers that close them).
+        // `Esc` — universal "back out" key. Priority order, top wins:
+        //   1. A per-modal handler already called preventDefault — bail.
+        //      (cmdk input, shortcuts-help overlay, etc.)
+        //   2. A dialog is open — close the topmost one. Catches the
+        //      pre-existing list (cmdk/help/confirm/prompt/alert) plus
+        //      every `[role="dialog"]` that lacks its own Esc handler.
+        //   3. A gear is in edit mode (a `.gear-cog-btn` is pressed) —
+        //      click the cog to exit. Home, Metrics, and future gears.
+        //   4. A focusable control has focus — blur it. Lets the user
+        //      `/`→type→Esc→Esc to bounce back to the previous gear.
+        //   5. Fall through to `history.back()` as a last resort.
         //
-        // The browsers stopped doing Esc-as-back natively because of
-        // accidental form-data loss; we sidestep that by requiring the
-        // page to be in a clean state (no focused input) first.
-        function anyOverlayOpen() {
-            const ids = [
-                'cmdk-overlay', 'shortcuts-help-overlay',
-                'confirm-dialog', 'prompt-dialog', 'alert-dialog',
-            ];
-            for (let i = 0; i < ids.length; i++) {
-                const el = document.getElementById(ids[i]);
-                if (el && !el.classList.contains('hidden')) return true;
-            }
-            // Narrow-viewport Filters sheet popped out under the header
-            // (`.filters-open` on #header-page-content). Treat as an
-            // overlay so pressing Esc to close it doesn't fall through
-            // to history.back().
-            const headerContent = document.getElementById('header-page-content');
-            if (headerContent && headerContent.classList.contains('filters-open')) {
-                return true;
-            }
-            // Right-click "Reorder gears" context menu on the sidebar.
-            const ctxMenu = document.getElementById('sidebar-context-menu');
-            if (ctxMenu && !ctxMenu.classList.contains('hidden')) {
-                return true;
-            }
-            return false;
-        }
+        // Browsers dropped native Esc-as-back because of accidental
+        // form-data loss; the priority chain above mirrors that intent
+        // by handling every "back out of something on the page" case
+        // before nav is even considered.
         function isBlurrableTarget(el) {
             if (!el) return false;
             const tag = el.tagName;
             if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
             return !!el.isContentEditable;
         }
+        function isVisible(el) {
+            if (!el) return false;
+            if (el.classList.contains('hidden')) return false;
+            if (el.hasAttribute('hidden')) return false;
+            const style = window.getComputedStyle(el);
+            if (style.display === 'none' || style.visibility === 'hidden') return false;
+            return true;
+        }
+        function visibleDialogs() {
+            // Anything tagged as a dialog/modal by ARIA. Backstops:
+            // a couple of legacy overlays that don't carry role yet
+            // (#cmdk-overlay does carry it; the narrow-viewport
+            // Filters sheet and the sidebar context menu don't).
+            const out = [];
+            document.querySelectorAll('[role="dialog"], [aria-modal="true"]').forEach(function (el) {
+                if (isVisible(el)) out.push(el);
+            });
+            const headerContent = document.getElementById('header-page-content');
+            if (headerContent && headerContent.classList.contains('filters-open')) {
+                out.push(headerContent);
+            }
+            const ctxMenu = document.getElementById('sidebar-context-menu');
+            if (ctxMenu && isVisible(ctxMenu)) out.push(ctxMenu);
+            return out;
+        }
+        function pickTopDialog(list) {
+            // Highest z-index wins; ties broken by DOM order (later =
+            // on top in the painting model). Crude but good enough —
+            // we just need to avoid closing a dialog underneath an
+            // open one.
+            let top = null;
+            let topZ = -Infinity;
+            let topIdx = -1;
+            for (let i = 0; i < list.length; i++) {
+                const z = parseInt(window.getComputedStyle(list[i]).zIndex, 10);
+                const zVal = isNaN(z) ? 0 : z;
+                if (zVal > topZ || (zVal === topZ && i > topIdx)) {
+                    top = list[i];
+                    topZ = zVal;
+                    topIdx = i;
+                }
+            }
+            return top;
+        }
+        function clickCloseButton(dialog) {
+            // Try to invoke any existing close button so per-modal
+            // cleanup (state resets, focus restoration, persistence)
+            // runs. Selector list covers every close-button convention
+            // I found in the templates: aria-label, generic data-*,
+            // and the per-modal `data-<name>-close|dismiss` flavour.
+            const buttons = dialog.querySelectorAll('button, [role="button"], a');
+            for (let i = 0; i < buttons.length; i++) {
+                const btn = buttons[i];
+                if (btn.disabled) continue;
+                const label = (btn.getAttribute('aria-label') || '').toLowerCase();
+                if (label === 'close' || label === 'dismiss' || label === 'cancel') {
+                    btn.click();
+                    return true;
+                }
+                const attrs = btn.attributes;
+                for (let j = 0; j < attrs.length; j++) {
+                    const name = attrs[j].name;
+                    if (!name.startsWith('data-')) continue;
+                    if (name === 'data-close' || name === 'data-dismiss' ||
+                        name.endsWith('-close') || name.endsWith('-dismiss')) {
+                        btn.click();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        function closeTopmostDialog() {
+            const list = visibleDialogs();
+            if (list.length === 0) return false;
+            const top = pickTopDialog(list);
+            if (!top) return false;
+            // Special-case the narrow-viewport Filters sheet: it has
+            // a dedicated toggler that also flips header layout state.
+            if (top.id === 'header-page-content' &&
+                typeof window.toggleHeaderFilters === 'function') {
+                window.toggleHeaderFilters();
+                return true;
+            }
+            if (clickCloseButton(top)) return true;
+            // Last resort: just hide it. Better than letting Esc fall
+            // through to history.back() with a modal still on screen.
+            top.classList.add('hidden');
+            return true;
+        }
+        function exitGearEditMode() {
+            const btn = document.querySelector('.gear-cog-btn[aria-pressed="true"]');
+            if (!btn) return false;
+            btn.click();
+            return true;
+        }
         document.addEventListener('keydown', function (e) {
             if (e.key !== 'Escape') return;
             if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-            // Let dialogs handle their own Esc.
-            if (anyOverlayOpen()) return;
+            // A per-modal handler already consumed it (cmdk, help,
+            // icon-picker, etc. all call preventDefault).
+            if (e.defaultPrevented) return;
+            if (closeTopmostDialog()) { e.preventDefault(); return; }
+            if (exitGearEditMode())   { e.preventDefault(); return; }
             const el = document.activeElement;
             if (isBlurrableTarget(el)) {
                 el.blur();

--- a/gearbox/static/js/gears/home.js
+++ b/gearbox/static/js/gears/home.js
@@ -402,9 +402,12 @@
     });
   }
   // Escape closes the picker (without closing the underlying add-tile modal).
+  // preventDefault + stopImmediatePropagation so the global Esc handler in
+  // shortcut-help.js doesn't also close the parent modal in the same press.
   document.addEventListener("keydown", (ev) => {
     if (ev.key === "Escape" && iconPicker && !iconPicker.classList.contains("hidden")) {
-      ev.stopPropagation();
+      ev.preventDefault();
+      ev.stopImmediatePropagation();
       closeIconPicker();
     }
   });

--- a/gearbox/static/js/gears/home.js
+++ b/gearbox/static/js/gears/home.js
@@ -210,6 +210,13 @@
     editBtn.addEventListener("click", () => {
       const isStatic = grid.classList.toggle("home-grid-edit") === false;
       gs.setStatic(isStatic);
+      // aria-pressed drives the cog button's blue-tinted "pressed"
+      // appearance via the .gear-cog-btn[aria-pressed="true"] rule
+      // in components/buttons.css — shared with the Metrics gear.
+      editBtn.setAttribute("aria-pressed", isStatic ? "false" : "true");
+      // Legacy text-label spans (.home-edit-on-label / -off-label)
+      // were removed when the button became icon-only, but keep the
+      // guarded toggle in case a downstream variant re-adds them.
       const onLabel = editBtn.querySelector(".home-edit-on-label");
       const offLabel = editBtn.querySelector(".home-edit-off-label");
       if (onLabel && offLabel) {

--- a/gearbox/static/js/haproxy_config/editor.js
+++ b/gearbox/static/js/haproxy_config/editor.js
@@ -1569,6 +1569,10 @@ May your configs be valid and your uptime eternal. 🙏`
 
 		document.addEventListener('keydown', function(e) {
 			if (e.key === 'Escape' && fullscreenState === 1) {
+				// preventDefault so the global Esc handler doesn't
+				// then try to close a dialog or fall through to
+				// history.back() in the same keypress.
+				e.preventDefault();
 				exitBrowserFullscreen();
 			}
 		});
@@ -1644,7 +1648,9 @@ May your configs be valid and your uptime eternal. 🙏`
 				});
 			}
 
-			// Escape key closes any open modal
+			// Escape key closes any open modal. preventDefault stops
+			// the global handler from also closing something or
+			// navigating back.
 			document.addEventListener('keydown', function(e) {
 				if (e.key !== 'Escape') return;
 				const modals = [
@@ -1657,6 +1663,7 @@ May your configs be valid and your uptime eternal. 🙏`
 				for (const m of modals) {
 					const el = document.getElementById(m.id);
 					if (el && !el.classList.contains('hidden')) {
+						e.preventDefault();
 						m.hide();
 						break;
 					}

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -70,19 +70,24 @@
   // 12-column grid matches the templ's default coordinates (half-
   // width tiles are gs-w=6, the full-width Sessions tile is gs-w=12).
   //
-  // Asymmetric margins: rows need more breathing room than columns
-  // because chart axis labels live at the top/bottom of each tile,
-  // pushing the visual content edges closer together vertically
-  // than horizontally. With a symmetric 12px-each-side margin, two
-  // stacked rows looked merged. 18 top/bottom (= 36px between
-  // rows) + 12 left/right (= 24px between side-by-side neighbours)
-  // gives a comfortable read.
+  // Asymmetric margins so rows breathe more than columns: chart
+  // axis labels live at the top/bottom of each tile so adjacent
+  // rows' visible content edges approach each other faster than
+  // adjacent columns. 24 top/bottom (= 48px between rows) +
+  // 12 left/right (= 24px between side-by-side) is the ratio that
+  // reads right after multiple feedback passes on PR #104.
+  //
+  // ALSO: keep getCellHeight(false) (not cellHeight()) anywhere we
+  // need the cell height — the bare cellHeight() getter side-
+  // effects opts.cellHeight to a width-derived value, which then
+  // makes GridStack's generated top/height CSS rules drift away
+  // from the configured 80 every time we read.
   const gs = GridStack.init(
     {
       column: 12,
       cellHeight: 80,
-      marginTop: 18,
-      marginBottom: 18,
+      marginTop: 24,
+      marginBottom: 24,
       marginLeft: 12,
       marginRight: 12,
       float: false,
@@ -123,7 +128,17 @@
    *  matches GridStack's own positioning so the spacing below the
    *  last row equals the spacing between rows. */
   function updateContainerHeight() {
-    const ch = gs.cellHeight();
+    // CAREFUL: GridStack's cellHeight() — note the parens — is an
+    // implicit setter when called as a getter. It re-computes
+    // opts.cellHeight from cellWidth + (marginVertical -
+    // marginHorizontal) which silently overrides whatever value
+    // we passed to init. That breaks the row-spacing math because
+    // the styled `top` rules use opts.cellHeight, so every call
+    // here was drifting cellHeight away from 80 toward
+    // (containerWidth/12 + 12). getCellHeight(false) is the
+    // non-side-effecting getter that returns opts.cellHeight as
+    // it currently is.
+    const ch = gs.getCellHeight(false);
     if (!ch) return;
     let maxBottom = 0;
     (gs.engine.nodes || []).forEach(function (n) {

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -1,0 +1,263 @@
+/**
+ * metrics-layout.js — wires the GridStack-driven chart grid on the
+ * Metrics page (issue #103). Lives in a separate file from
+ * metrics.templ's existing inline script because (a) it interacts
+ * with a different concern (layout, not data) and (b) inlining a
+ * second large script in the templ makes the file unreadable.
+ *
+ * Responsibilities:
+ *   - Initialise GridStack on #charts-grid in read-only mode.
+ *   - Remove tiles whose data-source is capability-hidden so the
+ *     grid auto-compacts (no permanent gaps on HAProxy-less hosts).
+ *   - Toggle edit mode via #metrics-edit-toggle; persist on exit.
+ *   - Fetch saved layout on load; apply via GridStack's `load()`.
+ *   - Reset-to-default button drops the saved row and reloads.
+ *
+ * Vanilla JS, no framework. Mirrors the Home gear's home.js
+ * structure (init / edit-mode / persist) so a reader who knows one
+ * file can read the other without remapping conventions.
+ */
+(function () {
+  "use strict";
+
+  // Wait for GridStack to load + DOM to be ready. Both scripts use
+  // `defer`, so this just confirms; bailing if either is missing
+  // means the page degrades to "tiles render at their default
+  // positions, no drag" rather than throwing.
+  if (typeof GridStack === "undefined") {
+    console.warn("GridStack not loaded; metrics layout will be static.");
+    return;
+  }
+
+  const grid = document.getElementById("charts-grid");
+  if (!grid) return;
+
+  /** The chart cards we know about. Order matches the templ's
+   *  default-position attributes; capability-gated source cards live
+   *  at the tail so the baseline 7 always survive even on minimal
+   *  hosts. The strings are the gs-id attribute values the templ
+   *  emits — i.e. the same "card-X" the existing chart-render code
+   *  targets. */
+  const KNOWN_TILES = [
+    "card-cpu",
+    "card-memory",
+    "card-network",
+    "card-response-time",
+    "card-health",
+    "card-errors",
+    "card-sessions",
+    "card-nginx",
+    "card-apache",
+    "card-caddy",
+    "card-traefik",
+  ];
+
+  /** getServerID reads the currently-selected box from the global
+   *  server selector. Falls back to the URL when there's no
+   *  selector on the page (shouldn't happen, but defensive). */
+  function getServerID() {
+    const sel = document.getElementById("server-select");
+    if (sel && sel.value) return sel.value;
+    const match = window.location.pathname.match(/^\/servers\/([^/]+)/);
+    return match ? match[1] : "";
+  }
+
+  // 12-column grid matches the templ's default coordinates (half-
+  // width tiles are gs-w=6, the full-width Sessions tile is gs-w=12).
+  // Margin matches the page's existing gap-4 (16px) so the GridStack
+  // layout reads identically to the prior flex grid when no edits
+  // have been made.
+  const gs = GridStack.init(
+    {
+      column: 12,
+      cellHeight: 80,
+      margin: 8,
+      float: false,
+      staticGrid: true, // read-only until edit mode toggles
+      acceptWidgets: false,
+      animate: true,
+    },
+    grid,
+  );
+
+  // suppressChange guards against the change-handler firing during
+  // setup (load(), removeWidget for capability flips, etc.) and
+  // accidentally persisting the wrong layout. Mirrors home.js's
+  // pattern — same name on purpose so a future contributor reading
+  // both files sees the same idiom.
+  let suppressChange = true;
+
+  /** captureLayout returns the current grid state in the same shape
+   *  the PATCH endpoint expects — array of {id, x, y, w, h}. We use
+   *  gs.save(false) (no node data, just positions); the dashboard
+   *  doesn't need the full GridStack node objects. */
+  function captureLayout() {
+    return gs.save(false);
+  }
+
+  /** applyCapabilityHiding inspects each tile's inner card for the
+   *  `.hidden` class set by the existing applyCapabilities() pass
+   *  (which runs from metrics.templ's inline script). Capability-
+   *  hidden tiles are removed from the grid without DOM removal so
+   *  visible tiles compact upward. When a source flips Available
+   *  later, makeCapabilityVisible() puts them back.
+   *
+   *  Called after every applyCapabilities() run (the inline script
+   *  emits a `metrics:capabilities-applied` CustomEvent we listen
+   *  for below). */
+  function applyCapabilityHiding() {
+    KNOWN_TILES.forEach(function (id) {
+      const item = grid.querySelector(`.grid-stack-item[gs-id="${id}"]`);
+      if (!item) return;
+      const card = item.querySelector(`#${id}`);
+      if (!card) return;
+
+      // The inner card carries `.hidden` when capability gating
+      // says the source isn't Available. Pull the surrounding
+      // grid-stack-item out of the engine to free its slot.
+      const isCapHidden = card.classList.contains("hidden");
+      const isInGrid = !!item.gridstackNode;
+
+      if (isCapHidden && isInGrid) {
+        gs.removeWidget(item, false); // keep DOM, drop slot
+      } else if (!isCapHidden && !isInGrid) {
+        gs.makeWidget(item);
+      }
+    });
+  }
+
+  /* ---- Layout persistence ---- */
+
+  /** loadSavedLayout fetches the user's saved layout for the
+   *  current box from /api/{boxID}/metrics/layout and applies it
+   *  via GridStack.load(). 204 = no saved layout → keep the
+   *  template's default positions. Non-2xx (auth, server error)
+   *  also falls back to defaults; failing open keeps the page
+   *  usable when the layout endpoint is briefly unreachable. */
+  async function loadSavedLayout() {
+    const serverID = getServerID();
+    if (!serverID) return;
+    try {
+      const res = await fetch(`/api/${serverID}/metrics/layout`);
+      if (res.status === 204 || !res.ok) return; // use template defaults
+      const layout = await res.json();
+      if (!Array.isArray(layout) || layout.length === 0) return;
+      gs.load(layout);
+    } catch (err) {
+      console.debug("metrics layout load failed; using defaults", err);
+    }
+  }
+
+  /** saveLayout PATCHes the current grid state. Called from the
+   *  GridStack change handler (debounced) and on edit-mode exit. */
+  let saveTimer = null;
+  function saveLayout() {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(async function () {
+      const serverID = getServerID();
+      if (!serverID) return;
+      try {
+        await fetch(`/api/${serverID}/metrics/layout`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(captureLayout()),
+        });
+      } catch (err) {
+        console.warn("metrics layout save failed", err);
+      }
+    }, 400);
+  }
+
+  /** resetLayout DELETEs the saved row and reloads the page so the
+   *  template defaults take effect. Used by the Reset button in the
+   *  edit-mode toolbar. */
+  async function resetLayout() {
+    const serverID = getServerID();
+    if (!serverID) return;
+    try {
+      await fetch(`/api/${serverID}/metrics/layout`, { method: "DELETE" });
+    } catch (err) {
+      console.warn("metrics layout reset failed", err);
+    }
+    window.location.reload();
+  }
+
+  /* ---- Edit-mode toggle ---- */
+
+  const editBtn = document.getElementById("metrics-edit-toggle");
+  if (editBtn) {
+    editBtn.addEventListener("click", function () {
+      // `staticGrid` is the inverse of "editable" — when staticGrid
+      // is true, drag/resize are off. Toggle by inspecting the
+      // class we add to the grid container; that keeps the visual
+      // affordance + the GridStack state in sync.
+      const enteringEdit = !grid.classList.contains("metrics-grid-edit");
+      grid.classList.toggle("metrics-grid-edit", enteringEdit);
+      gs.setStatic(!enteringEdit);
+
+      const offLabel = editBtn.querySelector(".metrics-edit-off-label");
+      const onLabel = editBtn.querySelector(".metrics-edit-on-label");
+      if (offLabel && onLabel) {
+        offLabel.classList.toggle("hidden", enteringEdit);
+        onLabel.classList.toggle("hidden", !enteringEdit);
+      }
+
+      // Reveal/hide edit-only controls (Reset button, future
+      // affordances). Mirrors the Home gear's .home-edit-only
+      // pattern so the visual idiom reads the same across pages.
+      document.querySelectorAll(".metrics-edit-only").forEach(function (el) {
+        el.classList.toggle("hidden", !enteringEdit);
+      });
+
+      // Persist on exit. Entering edit mode is a no-op for
+      // persistence — only the resulting layout matters.
+      if (!enteringEdit) saveLayout();
+    });
+  }
+
+  /* ---- Reset button ---- */
+
+  const resetBtn = document.getElementById("metrics-reset-layout");
+  if (resetBtn) {
+    resetBtn.addEventListener("click", async function () {
+      // Inline confirm rather than a modal — this is destructive
+      // but trivially recoverable (just rearrange tiles again).
+      if (!window.confirm("Reset the metrics layout for this box to defaults?")) return;
+      await resetLayout();
+    });
+  }
+
+  /* ---- Persistence hook ---- */
+
+  gs.on("change", function () {
+    if (suppressChange) return;
+    saveLayout();
+  });
+
+  /* ---- Re-apply capability-driven visibility on every cap update ---- */
+
+  // The inline script in metrics.templ dispatches a CustomEvent
+  // after each applyCapabilities() run. Listening here keeps the
+  // capability-hiding logic localised — neither file needs to call
+  // the other's internals.
+  window.addEventListener("metrics:capabilities-applied", function () {
+    suppressChange = true;
+    applyCapabilityHiding();
+    setTimeout(function () {
+      suppressChange = false;
+    }, 50);
+  });
+
+  /* ---- Init ---- */
+
+  // Initial fetch on first paint. Suppress the change-event so
+  // GridStack.load() doesn't PATCH the layout we just received
+  // back to the server.
+  (async function init() {
+    await loadSavedLayout();
+    applyCapabilityHiding();
+    setTimeout(function () {
+      suppressChange = false;
+    }, 100);
+  })();
+})();

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -100,6 +100,33 @@
     return gs.save(false);
   }
 
+  /** updateContainerHeight pins the grid's min-height to the bottom
+   *  edge of the tallest tile in pixels. GridStack normally auto-
+   *  sizes the container via its own engine, but with staticGrid +
+   *  capability-driven removeWidget() calls the auto-sizing can lag
+   *  the actual layout, causing whatever section comes after the
+   *  grid to overlap the bottom tiles (issue reported in PR #104
+   *  review). Computing manually after every load/capability flip
+   *  closes the gap.
+   *
+   *  Math: GridStack positions each tile at top = y*cellHeight + margin/2
+   *  with height = h*cellHeight - margin. Bottom edge of the last
+   *  row = (y+h)*cellHeight. Adding the margin once at the end
+   *  matches GridStack's own positioning so the spacing below the
+   *  last row equals the spacing between rows. */
+  function updateContainerHeight() {
+    const ch = gs.cellHeight();
+    if (!ch) return;
+    let maxBottom = 0;
+    (gs.engine.nodes || []).forEach(function (n) {
+      const bottom = (n.y || 0) + (n.h || 0);
+      if (bottom > maxBottom) maxBottom = bottom;
+    });
+    if (maxBottom > 0) {
+      grid.style.minHeight = maxBottom * ch + "px";
+    }
+  }
+
   /** applyCapabilityHiding inspects each tile's inner card for the
    *  `.hidden` class set by the existing applyCapabilities() pass
    *  (which runs from metrics.templ's inline script). Capability-
@@ -129,6 +156,7 @@
         gs.makeWidget(item);
       }
     });
+    updateContainerHeight();
   }
 
   /* ---- Layout persistence ---- */
@@ -271,6 +299,11 @@
   /* ---- Persistence hook ---- */
 
   gs.on("change", function () {
+    // Recompute container height on every layout change so a drag
+    // that bumps a tile down doesn't leave the section below
+    // overlapping. Cheap (O(tiles)) and fires regardless of save
+    // suppression.
+    updateContainerHeight();
     if (suppressChange) return;
     saveLayout();
   });
@@ -296,7 +329,7 @@
   // back to the server.
   (async function init() {
     await loadSavedLayout();
-    applyCapabilityHiding();
+    applyCapabilityHiding(); // also calls updateContainerHeight()
     setTimeout(function () {
       suppressChange = false;
     }, 100);

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -70,12 +70,11 @@
   // 12-column grid matches the templ's default coordinates (half-
   // width tiles are gs-w=6, the full-width Sessions tile is gs-w=12).
   //
-  // Asymmetric margins so rows breathe more than columns: chart
-  // axis labels live at the top/bottom of each tile so adjacent
-  // rows' visible content edges approach each other faster than
-  // adjacent columns. 24 top/bottom (= 48px between rows) +
-  // 12 left/right (= 24px between side-by-side) is the ratio that
-  // reads right after multiple feedback passes on PR #104.
+  // Margins set to 6 on every side → 12px visible gap between
+  // tiles on both axes. Matches the KPI band's Tailwind gap-3
+  // (12px) directly above the grid, so the whole metrics page
+  // reads as one consistently-spaced surface rather than two
+  // grids with different rhythms.
   //
   // ALSO: keep getCellHeight(false) (not cellHeight()) anywhere we
   // need the cell height — the bare cellHeight() getter side-
@@ -86,10 +85,10 @@
     {
       column: 12,
       cellHeight: 80,
-      marginTop: 24,
-      marginBottom: 24,
-      marginLeft: 12,
-      marginRight: 12,
+      marginTop: 6,
+      marginBottom: 6,
+      marginLeft: 6,
+      marginRight: 6,
       float: false,
       staticGrid: true, // read-only until edit mode toggles
       acceptWidgets: false,

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -69,14 +69,16 @@
 
   // 12-column grid matches the templ's default coordinates (half-
   // width tiles are gs-w=6, the full-width Sessions tile is gs-w=12).
-  // Margin 16 matches Tailwind's gap-4 (the prior flex grid's gap)
-  // and the Home gear's gridstack init — keeps spacing consistent
-  // when GridStack takes over.
+  // margin: 16 felt too tight vertically — adjacent rows visibly
+  // butted up against each other in dark mode where the inner
+  // card backgrounds blur into the page background. Bumped to 24
+  // (12px around every tile → 24px between neighbours) so rows
+  // breathe without spreading the grid too wide.
   const gs = GridStack.init(
     {
       column: 12,
       cellHeight: 80,
-      margin: 16,
+      margin: 24,
       float: false,
       staticGrid: true, // read-only until edit mode toggles
       acceptWidgets: false,

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -69,16 +69,22 @@
 
   // 12-column grid matches the templ's default coordinates (half-
   // width tiles are gs-w=6, the full-width Sessions tile is gs-w=12).
-  // margin: 16 felt too tight vertically — adjacent rows visibly
-  // butted up against each other in dark mode where the inner
-  // card backgrounds blur into the page background. Bumped to 24
-  // (12px around every tile → 24px between neighbours) so rows
-  // breathe without spreading the grid too wide.
+  //
+  // Asymmetric margins: rows need more breathing room than columns
+  // because chart axis labels live at the top/bottom of each tile,
+  // pushing the visual content edges closer together vertically
+  // than horizontally. With a symmetric 12px-each-side margin, two
+  // stacked rows looked merged. 18 top/bottom (= 36px between
+  // rows) + 12 left/right (= 24px between side-by-side neighbours)
+  // gives a comfortable read.
   const gs = GridStack.init(
     {
       column: 12,
       cellHeight: 80,
-      margin: 24,
+      marginTop: 18,
+      marginBottom: 18,
+      marginLeft: 12,
+      marginRight: 12,
       float: false,
       staticGrid: true, // read-only until edit mode toggles
       acceptWidgets: false,

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -104,12 +104,32 @@
   // both files sees the same idiom.
   let suppressChange = true;
 
+  // capHiddenSnapshots remembers the (x, y, w, h) of each tile we
+  // pulled out of the grid because its source went unavailable. When
+  // captureLayout() serialises the grid, those tiles aren't in the
+  // engine (so gs.save() omits them) — but we still want their last-
+  // known positions to ride along in the persisted blob so that a
+  // capability flip back to Available a week later restores the
+  // user's chosen position instead of dropping the tile at its templ
+  // default coords.
+  const capHiddenSnapshots = {};
+
   /** captureLayout returns the current grid state in the same shape
    *  the PATCH endpoint expects — array of {id, x, y, w, h}. We use
    *  gs.save(false) (no node data, just positions); the dashboard
-   *  doesn't need the full GridStack node objects. */
+   *  doesn't need the full GridStack node objects. Capability-hidden
+   *  tiles aren't in the engine so we merge in their snapshots
+   *  before returning, otherwise the saved blob loses them. */
   function captureLayout() {
-    return gs.save(false);
+    const out = gs.save(false) || [];
+    const present = new Set(out.map(function (t) { return t.id; }));
+    Object.keys(capHiddenSnapshots).forEach(function (id) {
+      if (!present.has(id)) {
+        const s = capHiddenSnapshots[id];
+        out.push({ id: id, x: s.x, y: s.y, w: s.w, h: s.h });
+      }
+    });
+    return out;
   }
 
   /** updateContainerHeight pins the grid's min-height to the bottom
@@ -123,9 +143,10 @@
    *
    *  Math: GridStack positions each tile at top = y*cellHeight + margin/2
    *  with height = h*cellHeight - margin. Bottom edge of the last
-   *  row = (y+h)*cellHeight. Adding the margin once at the end
-   *  matches GridStack's own positioning so the spacing below the
-   *  last row equals the spacing between rows. */
+   *  row at index (y+h) sits at (y+h)*cellHeight. We use that bottom
+   *  edge as min-height directly — GridStack already paints the
+   *  marginBottom inside the cellHeight allowance, so adding it
+   *  again would over-pad the section below the grid. */
   function updateContainerHeight() {
     // CAREFUL: GridStack's cellHeight() — note the parens — is an
     // implicit setter when called as a getter. It re-computes
@@ -166,16 +187,25 @@
       const card = item.querySelector(`#${id}`);
       if (!card) return;
 
-      // The inner card carries `.hidden` when capability gating
-      // says the source isn't Available. Pull the surrounding
-      // grid-stack-item out of the engine to free its slot.
-      const isCapHidden = card.classList.contains("hidden");
+      // The capability marker is a dedicated `data-cap-hidden`
+      // attribute set by applyCapabilities() in metrics.templ — we
+      // intentionally do NOT key off `.hidden`, because chart-
+      // fullscreen.js also adds `.hidden` to every non-focused card
+      // while one is fullscreened. Reading `.hidden` here would
+      // remove the entire grid mid-fullscreen and never re-add it.
+      const isCapHidden = card.dataset.capHidden === "true";
       const isInGrid = !!item.gridstackNode;
 
       if (isCapHidden && isInGrid) {
+        // Snapshot the position before removing so captureLayout()
+        // can persist it. Without this the user's chosen position
+        // is lost the moment a source goes unavailable.
+        const n = item.gridstackNode;
+        capHiddenSnapshots[id] = { x: n.x || 0, y: n.y || 0, w: n.w || 1, h: n.h || 1 };
         gs.removeWidget(item, false); // keep DOM, drop slot
       } else if (!isCapHidden && !isInGrid) {
         gs.makeWidget(item);
+        delete capHiddenSnapshots[id];
       }
     });
     updateContainerHeight();
@@ -197,7 +227,13 @@
       if (res.status === 204 || !res.ok) return; // use template defaults
       const layout = await res.json();
       if (!Array.isArray(layout) || layout.length === 0) return;
-      gs.load(layout);
+      // addRemove:false — without it, gs.load() would yank any
+      // grid-stack-item DOM nodes whose gs-id isn't in the loaded
+      // array (capability-hidden tiles that were captured into
+      // capHiddenSnapshots but not currently in the engine). We
+      // intentionally keep those DOM nodes around so makeWidget()
+      // can re-attach them later when their source goes Available.
+      gs.load(layout, false);
     } catch (err) {
       console.debug("metrics layout load failed; using defaults", err);
     }
@@ -221,11 +257,22 @@
     const serverID = getServerID();
     if (!serverID) return;
     try {
-      await fetch(`/api/${serverID}/metrics/layout`, {
+      const res = await fetch(`/api/${serverID}/metrics/layout`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(captureLayout()),
       });
+      // fetch() doesn't throw on HTTP 4xx/5xx — surface non-2xx so a
+      // 401/403/413/500 doesn't silently swallow the user's layout
+      // edit. console.warn keeps it visible in devtools without
+      // popping a dialog mid-edit.
+      if (!res.ok) {
+        console.warn(
+          "metrics layout save returned non-2xx",
+          res.status,
+          res.statusText,
+        );
+      }
     } catch (err) {
       console.warn("metrics layout save failed", err);
     }

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -309,9 +309,16 @@
   const resetBtn = document.getElementById("metrics-reset-layout");
   if (resetBtn) {
     resetBtn.addEventListener("click", async function () {
-      // Inline confirm rather than a modal — this is destructive
-      // but trivially recoverable (just rearrange tiles again).
-      if (!window.confirm("Reset the metrics layout for this box to defaults?")) return;
+      // Use the app's standard confirm dialog (base.templ) rather
+      // than the browser's native window.confirm — keeps the look
+      // consistent with the rest of the app and respects dark mode.
+      const ok = await window.showConfirmDialog({
+        title: "Reset metrics layout",
+        message: "Reset the metrics layout for this box to defaults? Your custom arrangement will be lost.",
+        confirmText: "Reset",
+        type: "warning",
+      });
+      if (!ok) return;
       await resetLayout();
     });
   }

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -52,26 +52,31 @@
     "card-traefik",
   ];
 
-  /** getServerID reads the currently-selected box from the global
-   *  server selector. Falls back to the URL when there's no
-   *  selector on the page (shouldn't happen, but defensive). */
+  /** getServerID matches metrics.templ's inline helper of the same
+   *  name: prefer #server-select (multi-server mode), fall back to
+   *  #default-server-id (single-server mode), then to the URL.
+   *  Missing this single-server fallback meant the layout endpoints
+   *  silently no-op'd on single-box installs — see review on PR #104.
+   */
   function getServerID() {
     const sel = document.getElementById("server-select");
     if (sel && sel.value) return sel.value;
+    const fallback = document.getElementById("default-server-id");
+    if (fallback && fallback.value) return fallback.value;
     const match = window.location.pathname.match(/^\/servers\/([^/]+)/);
     return match ? match[1] : "";
   }
 
   // 12-column grid matches the templ's default coordinates (half-
   // width tiles are gs-w=6, the full-width Sessions tile is gs-w=12).
-  // Margin matches the page's existing gap-4 (16px) so the GridStack
-  // layout reads identically to the prior flex grid when no edits
-  // have been made.
+  // Margin 16 matches Tailwind's gap-4 (the prior flex grid's gap)
+  // and the Home gear's gridstack init — keeps spacing consistent
+  // when GridStack takes over.
   const gs = GridStack.init(
     {
       column: 12,
       cellHeight: 80,
-      margin: 8,
+      margin: 16,
       float: false,
       staticGrid: true, // read-only until edit mode toggles
       acceptWidgets: false,
@@ -148,32 +153,66 @@
     }
   }
 
-  /** saveLayout PATCHes the current grid state. Called from the
-   *  GridStack change handler (debounced) and on edit-mode exit. */
+  /** saveLayout PATCHes the current grid state. Two call sites:
+   *  - drag/resize during edit mode → debounced 400 ms so a
+   *    multi-tile drag flushes once, not N times.
+   *  - edit-mode exit → flush=true to bypass the debounce; without
+   *    this a fast close-tab right after "Done editing" could drop
+   *    the layout the user just confirmed.
+   *
+   *  saveTimer is module-scoped so resetLayout() can cancel it
+   *  before issuing the DELETE — otherwise a pending PATCH could
+   *  fire after the reset and re-create the row the user just
+   *  threw away. */
   let saveTimer = null;
-  function saveLayout() {
-    if (saveTimer) clearTimeout(saveTimer);
-    saveTimer = setTimeout(async function () {
-      const serverID = getServerID();
-      if (!serverID) return;
-      try {
-        await fetch(`/api/${serverID}/metrics/layout`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(captureLayout()),
-        });
-      } catch (err) {
-        console.warn("metrics layout save failed", err);
-      }
+  let savesSuppressed = false;
+
+  async function patchLayout() {
+    const serverID = getServerID();
+    if (!serverID) return;
+    try {
+      await fetch(`/api/${serverID}/metrics/layout`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(captureLayout()),
+      });
+    } catch (err) {
+      console.warn("metrics layout save failed", err);
+    }
+  }
+
+  function saveLayout(opts) {
+    if (savesSuppressed) return;
+    const flush = !!(opts && opts.flush);
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    if (flush) {
+      // Don't await — caller (edit-mode exit handler) is
+      // synchronous; the PATCH fires immediately and any
+      // failure surfaces in the console.
+      void patchLayout();
+      return;
+    }
+    saveTimer = setTimeout(function () {
+      saveTimer = null;
+      void patchLayout();
     }, 400);
   }
 
   /** resetLayout DELETEs the saved row and reloads the page so the
-   *  template defaults take effect. Used by the Reset button in the
-   *  edit-mode toolbar. */
+   *  template defaults take effect. Suppresses further saves +
+   *  cancels any in-flight debounce before issuing the DELETE so a
+   *  pending PATCH can't race the reset and resurrect the row. */
   async function resetLayout() {
     const serverID = getServerID();
     if (!serverID) return;
+    savesSuppressed = true;
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
     try {
       await fetch(`/api/${serverID}/metrics/layout`, { method: "DELETE" });
     } catch (err) {
@@ -209,9 +248,11 @@
         el.classList.toggle("hidden", !enteringEdit);
       });
 
-      // Persist on exit. Entering edit mode is a no-op for
-      // persistence — only the resulting layout matters.
-      if (!enteringEdit) saveLayout();
+      // Persist on exit. Flush bypasses the debounce so a close-
+      // tab right after clicking "Done editing" can't drop the
+      // layout. Entering edit mode is a no-op for persistence —
+      // only the resulting layout matters.
+      if (!enteringEdit) saveLayout({ flush: true });
     });
   }
 

--- a/gearbox/static/js/metrics-layout.js
+++ b/gearbox/static/js/metrics-layout.js
@@ -284,12 +284,10 @@
       grid.classList.toggle("metrics-grid-edit", enteringEdit);
       gs.setStatic(!enteringEdit);
 
-      const offLabel = editBtn.querySelector(".metrics-edit-off-label");
-      const onLabel = editBtn.querySelector(".metrics-edit-on-label");
-      if (offLabel && onLabel) {
-        offLabel.classList.toggle("hidden", enteringEdit);
-        onLabel.classList.toggle("hidden", !enteringEdit);
-      }
+      // aria-pressed drives the cog button's visual state via the
+      // .gear-cog-btn[aria-pressed="true"] CSS rule — shared with
+      // Home's edit toggle so the affordance reads consistently.
+      editBtn.setAttribute("aria-pressed", enteringEdit ? "true" : "false");
 
       // Reveal/hide edit-only controls (Reset button, future
       // affordances). Mirrors the Home gear's .home-edit-only

--- a/gearbox/static/js/os-updates/os-updates-page.js
+++ b/gearbox/static/js/os-updates/os-updates-page.js
@@ -191,6 +191,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 // Central Escape key handler — closes whichever modal is currently visible.
+// preventDefault stops the global Esc handler in shortcut-help.js from then
+// trying to close another dialog or navigating back in the same keypress.
 document.addEventListener('keydown', function(e) {
 	if (e.key !== 'Escape') return;
 	const modals = [
@@ -206,6 +208,7 @@ document.addEventListener('keydown', function(e) {
 	for (const m of modals) {
 		const el = document.getElementById(m.id);
 		if (el && !el.classList.contains('hidden')) {
+			e.preventDefault();
 			m.hide();
 			break;
 		}


### PR DESCRIPTION
## Summary

Closes [#103](https://github.com/sarg3nt/gearbox/issues/103). Metrics page chart grid becomes drag + resize editable, with the layout persisted per (user, box). Reuses the Home gear's GridStack vendor bundle — no new dependency. Default layout matches the row order proposed on the issue:

```text
┌──────────────────┬──────────────────┐
│  CPU Load        │  Memory          │
├──────────────────┼──────────────────┤
│  Network         │  Response Time   │
├──────────────────┼──────────────────┤
│  Server Health   │  Error Rates     │
├──────────────────┴──────────────────┤
│  Sessions & Requests (full-width)   │
├──────────────────┬──────────────────┤
│  nginx*          │  Apache*         │
├──────────────────┼──────────────────┤
│  Caddy*          │  Traefik*        │
└──────────────────┴──────────────────┘
```

(* per-source tiles only appear when the agent's capability table reports the gear Available)

## Files

### New

| Path                                                | Purpose                                                                                  |
|-----------------------------------------------------|------------------------------------------------------------------------------------------|
| `internal/framework/database/metrics_layouts.go`    | `metrics_layouts` table (PK `(user_id, server_id)`) + `GetMetricsLayout` / `SaveMetricsLayout` / `DeleteMetricsLayout` + `ErrNoMetricsLayout` sentinel. |
| `internal/framework/handler/api_metrics_layout.go`  | GET / PATCH / DELETE handlers. JSON body capped at 16 KiB and shape-validated as `[{id,x,y,w,h}]`. |
| `static/js/metrics-layout.js`                       | GridStack init, edit-mode toggle, layout fetch/save (debounced PATCH), capability-driven reflow via a CustomEvent emitted by the existing `applyCapabilities()`. |

### Modified

| Path                                                       | Change                                                                                                 |
|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
| `internal/framework/database/database.go`                  | Wires `initMetricsLayoutsSchema()` into `New()` right after the Home schema.                            |
| `cmd/server/main.go`                                       | Registers the three new layout routes alongside the existing `/metrics/...` endpoints.                  |
| `internal/framework/templates/pages/metrics.templ`         | Wrapper panel removed; each chart card now sits inside a `.grid-stack-item` with default `gs-*` attrs. Cards reordered to the layout above. Edit toggle + Reset button added to the controls bar. GridStack vendor CSS + JS + `metrics-layout.js` script tags added. `applyCapabilities()` dispatches `metrics:capabilities-applied` so the JS layer can reflow without coupling. |

## How the per-user → per-box persistence works

- **First visit** → `GET /api/{boxID}/metrics/layout` returns 204 → JS keeps the template's default positions.
- **Drag/resize in edit mode** → no save during the drag; debounced 400 ms after the last change OR on edit-mode exit, a single PATCH writes the whole layout JSON.
- **Switch box** → fresh GET for the new (user, server) pair; layouts isolate per user AND per box.
- **Reset** → DELETE the row, page reloads, defaults return.

Layout stored as a JSON blob rather than per-tile rows because the access pattern is always "fetch / write the whole layout"; there's no querying inside it. The blob is GridStack's `save()` output verbatim — the storage layer never inspects it, which keeps it agnostic to GridStack version changes.

## Capability-driven reflow

PR #102 added per-source chart cards that hide via a `.hidden` class when the agent reports the gear as Unavailable. GridStack doesn't know about those classes — without coordination, an unavailable source would leave a permanent gap in the grid.

The fix is event-driven:

1. `applyCapabilities()` in metrics.templ's inline script toggles `.hidden` per card as today, then dispatches a `metrics:capabilities-applied` CustomEvent on `window`.
2. `metrics-layout.js` listens for that event and per-card decides whether to call `gs.removeWidget(item, false)` (keep DOM, drop the grid slot — surrounding tiles compact up) or `gs.makeWidget(item)` (re-add to the grid).
3. The change-event handler in `metrics-layout.js` is suppressed during this reflow so the capability-driven moves don't accidentally PATCH the user's saved layout.

Decoupling via CustomEvent means neither file needs to know about the other's globals.

## Test plan

- [x] `go test ./...` clean on `gearbox`.
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean on every file added or modified.
- [x] `templ generate` clean — generated `metrics_templ.go` regenerates with the new structure (gitignored as expected).
- [ ] Manual smoke: load metrics page on a box, confirm default layout matches the design.
- [ ] Manual smoke: edit mode → drag CPU below Memory → exit edit mode → reload → CPU stays below Memory.
- [ ] Manual smoke: switch user (logout / re-login as a different operator) → layout doesn't follow them.
- [ ] Manual smoke: switch box → fresh layout for that box.
- [ ] Manual smoke: HAProxy-not-available host (`mjolnir`) — HAProxy tiles disappear, host tiles compact up to fill the grid with no gaps.
- [ ] Manual smoke: Reset Layout → confirm dialog → page reloads with template defaults.

## Backwards compatibility

Purely additive.

- New table — no impact on existing schemas.
- New endpoints under fresh `/metrics/layout` paths — no changes to existing `/metrics/...` endpoints.
- Older sessions without GridStack support (e.g. browser with JS disabled) render the page in its default order via the template attributes; drag/resize is silently disabled but no functional regression.

## Out of scope

- Layout import/export.
- Sharing layouts between users.
- Mobile-specific layouts (GridStack auto-compacts on narrow viewports — same behaviour Home relies on).
- Default-layout customisation (every user starts with the same template positions; edit mode + persistence covers the personalisation case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)