### PR TITLE
feat(haproxy): filter dashboard tiles by agent haproxy capability

### DIFF
--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -381,6 +381,12 @@ func main() {
 	authAdapter.SetEncryptor(encryptor)
 	eventsAdapter := services.NewEventsAdapter(eventHub)
 	serverAdapter := services.NewServerAdapter(db, encryptor, servers, logger)
+	// Share the handler's probe-table cache with the adapter so gear
+	// plugins (HAProxy, Logs, Services, …) can filter their box list by
+	// what the agent actually advertises — see issue #112. Without this,
+	// the HAProxy dashboard fires /htmx/{box}/stats|metrics polls at every
+	// enabled box and gets 503s back from agents that don't run HAProxy.
+	serverAdapter.SetCapabilitiesCache(h.CapabilitiesCache())
 
 	gearDeps := gear.Dependencies{
 		DB:         db.GetDB(), // Get the underlying *sql.DB

--- a/gearbox/internal/framework/handler/handler.go
+++ b/gearbox/internal/framework/handler/handler.go
@@ -104,6 +104,16 @@ func NewHandler(
 // explicitly via Handler.invalidateBoxCapabilities for faster refresh.
 const capabilityCacheTTL = 5 * time.Minute
 
+// CapabilitiesCache exposes the dashboard's shared probe-table cache so
+// other framework components (notably the ServerAdapter used by gear
+// plugins) can answer "is gear X available on box Y?" without each
+// holding its own cache. Returns the same *agent.CapabilitiesCache that
+// the handler uses for filterGearsByAgentCapabilities, so callers see
+// consistent capability data across the dashboard.
+func (h *Handler) CapabilitiesCache() *agent.CapabilitiesCache {
+	return h.capabilities
+}
+
 // getBoxCapabilities returns the cached capabilities for boxID, or fetches
 // fresh ones if missing/stale. Returns (nil, false) when the box isn't
 // configured or doesn't use the agent API. Errors are logged at debug —

--- a/gearbox/internal/framework/services/server_adapter.go
+++ b/gearbox/internal/framework/services/server_adapter.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"log/slog"
+	"sync"
 
 	"github.com/sarg3nt/gearbox/internal/framework/agent"
 	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
@@ -113,15 +114,22 @@ func (a *ServerAdapter) SetCapabilitiesCache(c *agent.CapabilitiesCache) {
 
 // GetEnabledServersWithGearAvailable returns the subset of enabled servers
 // whose probe table reports the named **agent** gear as Available. Used by
-// the HAProxy / Logs / Services / OS-Updates dashboard pages to skip
-// rendering tiles and tabs for boxes the gear physically can't run on
-// (e.g. an agent in a distroless container has no haproxy binary, so
-// rendering its HAProxy stats tile produces a 503 storm — issue #112).
+// the HAProxy / Logs / OS-Updates dashboard pages to skip rendering tiles
+// and tabs for boxes the gear physically can't run on (e.g. an agent in a
+// distroless container has no haproxy binary, so rendering its HAProxy
+// stats tile produces a 503 storm — issue #112).
 //
-// The gearName argument is the **agent-side** gear name, not the
-// dashboard gear name (see dashboardGearToAgentGear in handler/gears.go
-// for the mapping). Pass "haproxy", "logs", "services", "metrics",
-// "updates", "certificates", or "traffic" as appropriate.
+// The gearName argument is the **agent-side** gear name. The agent's
+// registered gears (see [internal/gears] in the gearbox-agent repo) are:
+//
+//	access-log, apache, caddy, certificates, docker, haproxy, host,
+//	logs, metrics, nginx, security, traefik, traffic, updates
+//
+// Note that some dashboard gears don't map 1:1 to agent gears — the
+// dashboard's "services" / "alerts" / "bx" gears have no agent-side
+// counterpart and shouldn't be filtered via this method. See
+// dashboardGearToAgentGear in handler/gears.go for the dashboard-side
+// mapping that is filtered.
 //
 // Fail-open contract: a box whose capabilities aren't reachable (agent
 // down, no API key, cache miss + fetch failure) is **included** in the
@@ -130,28 +138,53 @@ func (a *ServerAdapter) SetCapabilitiesCache(c *agent.CapabilitiesCache) {
 // capability cache hasn't been wired in (SetCapabilitiesCache wasn't
 // called), every enabled server is returned — same fail-open posture.
 //
+// Performance: cold-cache fetches are fired in parallel (one goroutine
+// per box) so a render path that calls this on N agents pays one round
+// of fetchTimeout latency at most, instead of N × fetchTimeout when
+// agents are unreachable. The underlying CapabilitiesCache memoizes
+// for capabilityCacheTTL, so steady-state renders are lock-only.
+//
 // The result is in the same order as GetEnabledServersAsModels.
 func (a *ServerAdapter) GetEnabledServersWithGearAvailable(gearName string) []models.BoxConfig {
 	all := a.GetEnabledServersAsModels()
-	if a.capabilities == nil || gearName == "" {
+	if a.capabilities == nil || gearName == "" || len(all) == 0 {
 		return all
 	}
+
+	// Fetch every box's capabilities in parallel — cold-cache requests
+	// can each block up to the cache's fetchTimeout, so sequential
+	// resolution would push page render latency to O(N * timeout) when
+	// agents are unreachable. Bounded by len(all) goroutines per call;
+	// the cache itself memoizes, so warm-cache renders take only the
+	// per-box read-lock latency.
+	keep := make([]bool, len(all))
+	var wg sync.WaitGroup
+	wg.Add(len(all))
+	for i := range all {
+		go func(i int) {
+			defer wg.Done()
+			srv := all[i]
+			caps, err := a.capabilities.Get(srv.ID, srv.AgentURL, srv.APIKey)
+			if err != nil || caps == nil {
+				// Fail-open: include the box if we can't see its probe table.
+				keep[i] = true
+				return
+			}
+			entry, present := caps.Entry(gearName)
+			if !present {
+				// Agent didn't report this gear at all (older agent that
+				// pre-dates it). Fail-open — keep the box.
+				keep[i] = true
+				return
+			}
+			keep[i] = entry.IsAvailable()
+		}(i)
+	}
+	wg.Wait()
+
 	out := make([]models.BoxConfig, 0, len(all))
-	for _, srv := range all {
-		caps, err := a.capabilities.Get(srv.ID, srv.AgentURL, srv.APIKey)
-		if err != nil || caps == nil {
-			// Fail-open: include the box if we can't see its probe table.
-			out = append(out, srv)
-			continue
-		}
-		entry, present := caps.Entry(gearName)
-		if !present {
-			// Agent didn't report this gear at all (older agent that
-			// pre-dates it). Fail-open — keep the box.
-			out = append(out, srv)
-			continue
-		}
-		if entry.IsAvailable() {
+	for i, srv := range all {
+		if keep[i] {
 			out = append(out, srv)
 		}
 	}

--- a/gearbox/internal/framework/services/server_adapter.go
+++ b/gearbox/internal/framework/services/server_adapter.go
@@ -4,6 +4,7 @@ package services
 import (
 	"log/slog"
 
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
 	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
 	"github.com/sarg3nt/gearbox/internal/framework/database"
 	"github.com/sarg3nt/gearbox/internal/framework/gear"
@@ -16,6 +17,14 @@ type ServerAdapter struct {
 	encryptor *crypto.Encryptor
 	fallback  []models.BoxConfig
 	logger    *slog.Logger
+
+	// capabilities is an optional probe-table cache used by
+	// GetEnabledServersWithGearAvailable to filter boxes by which agent
+	// gears probed Available. Nil-safe: if unset, capability-aware
+	// filtering falls through to the full enabled-server list (fail-open),
+	// which preserves current behavior for any caller that hasn't been
+	// migrated yet.
+	capabilities *agent.CapabilitiesCache
 }
 
 // NewServerAdapter creates a new ServerAdapter.
@@ -91,6 +100,62 @@ func (a *ServerAdapter) fallbackServers() []gear.ServerConfig {
 		})
 	}
 	return servers
+}
+
+// SetCapabilitiesCache wires the dashboard's probe-table cache into the
+// adapter so capability-aware methods (GetEnabledServersWithGearAvailable)
+// can decide which boxes should appear on a gear-specific page. Optional:
+// callers that don't need capability filtering can skip this and the
+// adapter degrades to returning the full enabled-server set.
+func (a *ServerAdapter) SetCapabilitiesCache(c *agent.CapabilitiesCache) {
+	a.capabilities = c
+}
+
+// GetEnabledServersWithGearAvailable returns the subset of enabled servers
+// whose probe table reports the named **agent** gear as Available. Used by
+// the HAProxy / Logs / Services / OS-Updates dashboard pages to skip
+// rendering tiles and tabs for boxes the gear physically can't run on
+// (e.g. an agent in a distroless container has no haproxy binary, so
+// rendering its HAProxy stats tile produces a 503 storm — issue #112).
+//
+// The gearName argument is the **agent-side** gear name, not the
+// dashboard gear name (see dashboardGearToAgentGear in handler/gears.go
+// for the mapping). Pass "haproxy", "logs", "services", "metrics",
+// "updates", "certificates", or "traffic" as appropriate.
+//
+// Fail-open contract: a box whose capabilities aren't reachable (agent
+// down, no API key, cache miss + fetch failure) is **included** in the
+// result. This matches filterGearsByAgentCapabilities so a transient
+// agent outage doesn't make gears disappear from the UI. If the
+// capability cache hasn't been wired in (SetCapabilitiesCache wasn't
+// called), every enabled server is returned — same fail-open posture.
+//
+// The result is in the same order as GetEnabledServersAsModels.
+func (a *ServerAdapter) GetEnabledServersWithGearAvailable(gearName string) []models.BoxConfig {
+	all := a.GetEnabledServersAsModels()
+	if a.capabilities == nil || gearName == "" {
+		return all
+	}
+	out := make([]models.BoxConfig, 0, len(all))
+	for _, srv := range all {
+		caps, err := a.capabilities.Get(srv.ID, srv.AgentURL, srv.APIKey)
+		if err != nil || caps == nil {
+			// Fail-open: include the box if we can't see its probe table.
+			out = append(out, srv)
+			continue
+		}
+		entry, present := caps.Entry(gearName)
+		if !present {
+			// Agent didn't report this gear at all (older agent that
+			// pre-dates it). Fail-open — keep the box.
+			out = append(out, srv)
+			continue
+		}
+		if entry.IsAvailable() {
+			out = append(out, srv)
+		}
+	}
+	return out
 }
 
 // GetEnabledServersAsModels returns servers as models.BoxConfig.

--- a/gearbox/internal/framework/templates/pages/overview.templ
+++ b/gearbox/internal/framework/templates/pages/overview.templ
@@ -7,7 +7,12 @@ import "github.com/sarg3nt/gearbox/internal/framework/ui"
 import "github.com/sarg3nt/gearbox/internal/framework/templates/components"
 import "fmt"
 
-templ Overview(user *models.User, servers []models.BoxConfig) {
+// Overview is the HAProxy dashboard page. When servers is empty, the
+// emptyReason string is shown in an InfoAlert in place of the per-box
+// tiles — pass "" to use the default "No servers configured" message,
+// or a more specific reason when the page is reached on a deployment
+// that has boxes but none with the HAProxy gear (see issue #112).
+templ Overview(user *models.User, servers []models.BoxConfig, emptyReason string) {
 	@layouts.Base("HAProxy", user, "/haproxy") {
 		<!-- Hidden container for page header content - will be moved to main header via JS.
 		     Title + box selector live in the global header breadcrumb + chip. -->
@@ -57,7 +62,11 @@ templ Overview(user *models.User, servers []models.BoxConfig) {
 		</div>
 
 		if len(servers) == 0 {
-			@components.InfoAlert("No servers configured. Please check your configuration.")
+			if emptyReason != "" {
+				@components.InfoAlert(emptyReason)
+			} else {
+				@components.InfoAlert("No servers configured. Please check your configuration.")
+			}
 		}
 
 		for _, server := range servers {

--- a/gearbox/internal/gears/haproxy/handlers.go
+++ b/gearbox/internal/gears/haproxy/handlers.go
@@ -21,51 +21,73 @@ func NewHandlers(deps gear.Dependencies) *Handlers {
 }
 
 // OverviewPage serves the HAProxy overview page.
-// If no servers are configured, redirects to the servers settings page.
 //
 // Only servers whose agent probe table reports the haproxy gear as
 // available are rendered — boxes without HAProxy (e.g. a container-mode
 // agent on a TrueNAS host) would otherwise show empty 503-storming
 // stat tiles. See issue #112.
+//
+// Empty-state handling:
+//   - No enabled boxes at all → redirect to /settings/boxes so the
+//     operator can configure one.
+//   - Enabled boxes exist but none advertise the haproxy gear → render
+//     the page with a tailored InfoAlert pointing at the Bx fleet view
+//     and the boxes settings, instead of redirecting (the operator is
+//     on the HAProxy page on purpose; we should explain why it's empty,
+//     not bounce them away from it).
 func (h *Handlers) OverviewPage(w http.ResponseWriter, r *http.Request) {
-	servers := h.getHAProxyServers()
+	all, haproxyServers := h.getServerLists()
 
-	// If no servers configured, redirect to servers settings page
-	if len(servers) == 0 {
+	if len(all) == 0 {
 		http.Redirect(w, r, "/settings/boxes", http.StatusSeeOther)
 		return
 	}
 
 	user := h.getUser(r)
-	pages.Overview(user, servers).Render(r.Context(), w) //nolint:errcheck
+	emptyReason := ""
+	if len(haproxyServers) == 0 {
+		emptyReason = "None of your connected boxes report an HAProxy gear. " +
+			"Check the agent's probe table from the Bx fleet view, or add " +
+			"a box that runs HAProxy via Settings → Boxes."
+	}
+	pages.Overview(user, haproxyServers, emptyReason).Render(r.Context(), w) //nolint:errcheck
 }
 
 // StatusGridPage serves the status grid page.
 //
-// Filtered to HAProxy-capable boxes for the same reason as OverviewPage.
+// Same empty-state treatment as OverviewPage: redirect to /settings/boxes
+// only when there are no enabled boxes; otherwise render with the
+// haproxy-capable subset (which may be empty, in which case the template
+// shows its own empty state).
 func (h *Handlers) StatusGridPage(w http.ResponseWriter, r *http.Request) {
-	servers := h.getHAProxyServers()
+	all, haproxyServers := h.getServerLists()
 
-	if len(servers) == 0 {
+	if len(all) == 0 {
 		http.Redirect(w, r, "/settings/boxes", http.StatusSeeOther)
 		return
 	}
 
 	user := h.getUser(r)
-	pages.StatusGrid(user, servers).Render(r.Context(), w) //nolint:errcheck
+	pages.StatusGrid(user, haproxyServers).Render(r.Context(), w) //nolint:errcheck
 }
 
-// getHAProxyServers returns the list of enabled servers whose agent
-// reports the haproxy gear available. Fail-open: boxes whose capabilities
-// can't be fetched are still included so a transient agent outage doesn't
-// hide the page entirely.
-func (h *Handlers) getHAProxyServers() []models.BoxConfig {
+// getServerLists returns (allEnabled, haproxyCapable) in one pair of
+// calls so OverviewPage / StatusGridPage can distinguish "no boxes at
+// all" (redirect to settings) from "boxes exist but none have HAProxy"
+// (render the empty-state in place).
+//
+// Fail-open: a box whose capabilities aren't reachable is still counted
+// as haproxy-capable, matching the behavior in
+// ServerAdapter.GetEnabledServersWithGearAvailable.
+func (h *Handlers) getServerLists() (all, haproxyCapable []models.BoxConfig) {
 	serverAdapter, ok := h.deps.Servers.(*services.ServerAdapter)
 	if !ok {
 		h.deps.Logger.Error("failed to get server adapter - unexpected type")
-		return nil
+		return nil, nil
 	}
-	return serverAdapter.GetEnabledServersWithGearAvailable("haproxy")
+	all = serverAdapter.GetEnabledServersAsModels()
+	haproxyCapable = serverAdapter.GetEnabledServersWithGearAvailable("haproxy")
+	return all, haproxyCapable
 }
 
 // getUser returns the user from the auth context, or a fallback user.

--- a/gearbox/internal/gears/haproxy/handlers.go
+++ b/gearbox/internal/gears/haproxy/handlers.go
@@ -22,8 +22,13 @@ func NewHandlers(deps gear.Dependencies) *Handlers {
 
 // OverviewPage serves the HAProxy overview page.
 // If no servers are configured, redirects to the servers settings page.
+//
+// Only servers whose agent probe table reports the haproxy gear as
+// available are rendered — boxes without HAProxy (e.g. a container-mode
+// agent on a TrueNAS host) would otherwise show empty 503-storming
+// stat tiles. See issue #112.
 func (h *Handlers) OverviewPage(w http.ResponseWriter, r *http.Request) {
-	servers := h.getServers()
+	servers := h.getHAProxyServers()
 
 	// If no servers configured, redirect to servers settings page
 	if len(servers) == 0 {
@@ -36,8 +41,10 @@ func (h *Handlers) OverviewPage(w http.ResponseWriter, r *http.Request) {
 }
 
 // StatusGridPage serves the status grid page.
+//
+// Filtered to HAProxy-capable boxes for the same reason as OverviewPage.
 func (h *Handlers) StatusGridPage(w http.ResponseWriter, r *http.Request) {
-	servers := h.getServers()
+	servers := h.getHAProxyServers()
 
 	if len(servers) == 0 {
 		http.Redirect(w, r, "/settings/boxes", http.StatusSeeOther)
@@ -48,14 +55,17 @@ func (h *Handlers) StatusGridPage(w http.ResponseWriter, r *http.Request) {
 	pages.StatusGrid(user, servers).Render(r.Context(), w) //nolint:errcheck
 }
 
-// getServers returns the list of enabled servers.
-func (h *Handlers) getServers() []models.BoxConfig {
+// getHAProxyServers returns the list of enabled servers whose agent
+// reports the haproxy gear available. Fail-open: boxes whose capabilities
+// can't be fetched are still included so a transient agent outage doesn't
+// hide the page entirely.
+func (h *Handlers) getHAProxyServers() []models.BoxConfig {
 	serverAdapter, ok := h.deps.Servers.(*services.ServerAdapter)
 	if !ok {
 		h.deps.Logger.Error("failed to get server adapter - unexpected type")
 		return nil
 	}
-	return serverAdapter.GetEnabledServersAsModels()
+	return serverAdapter.GetEnabledServersWithGearAvailable("haproxy")
 }
 
 // getUser returns the user from the auth context, or a fallback user.


### PR DESCRIPTION
## Summary

- The HAProxy dashboard (`/haproxy`) attaches `hx-get="/htmx/{box}/stats"` + `/metrics` to every enabled server. On a box whose agent has no haproxy gear (e.g. container-mode agent on TrueNAS — issue #112), those polls return `503 No stats available` forever and the tiles stay empty. Light-hugger's deployment exhibits this whenever Mjolnir is in the box roster.
- Plumb the framework `Handler.CapabilitiesCache` through into the `ServerAdapter` and expose `GetEnabledServersWithGearAvailable(gearName)`. The HAProxy gear's overview + status-grid handlers now filter through it, so boxes whose probe table marks haproxy as unavailable simply don't appear on the page.
- **Fail-open**: a box whose capabilities can't be fetched (agent unreachable, no API key, TLS verify off) is still included, matching how `filterGearsByAgentCapabilities` handles the same case. A transient agent outage doesn't make the page go dark.
- Default landing route per box (the other half of slice 3 in the roadmap) is left for a follow-up — this PR is scoped to the tile-filtering symptom.

Phase 2 slice of #112.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./internal/framework/services/... ./internal/framework/handler/... ./internal/framework/agent/... ./internal/gears/haproxy/...` clean
- [ ] On a deployment with a mixed box roster (one HAProxy host + one non-HAProxy agent), confirm the non-HAProxy box no longer appears on `/haproxy` and the 503 burst on `/htmx/{nonHAProxy}/stats` is gone.
- [ ] Confirm the page still renders for an agent that's temporarily unreachable (TLS verify off / agent down) — fail-open keeps the box visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)