### PR TITLE
fix(boxes): Test Connection on existing-box edit form

### DIFF
--- a/gearbox/internal/framework/templates/pages/haproxy_settings.templ
+++ b/gearbox/internal/framework/templates/pages/haproxy_settings.templ
@@ -708,9 +708,12 @@ templ haProxyBoxForm(user *models.User, server *database.BoxDB, isEdit bool, err
 			spinner.classList.remove('hidden');
 			resultDiv.classList.add('hidden');
 
-			// Build form data for Gearbox Agent API connection test
+			// Build form data for Gearbox Agent API connection test.
+			// On edit the api_key field is empty (we never surface the stored
+			// secret to the browser); box_id lets the backend look up and
+			// decrypt the stored key server-side. See haproxy_config.go.
 			const formData = new URLSearchParams();
-			formData.append('server_id', document.getElementById('server_id')?.value || '');
+			formData.append('box_id', document.getElementById('box_id')?.value || '');
 			formData.append('agent_url', document.getElementById('agent_url')?.value || '');
 			formData.append('api_key', document.getElementById('api_key')?.value || '');
 


### PR DESCRIPTION
## Summary

- Test Connection on the box edit form was failing on existing boxes because the JS sent a non-existent `server_id` form field. The backend already supports a "look up by `box_id`, decrypt the stored key, run probe server-side" recovery path at [`haproxy_config.go:427-449`](../blob/main/gearbox/internal/framework/handler/haproxy_config.go#L427-L449) — it just never received the `box_id` needed to trigger it.
- Fix: rename the form field the JS sends (`server_id` → `box_id`) and read from the existing readonly `box_id` input that the edit form already renders. No backend changes needed.
- Phase 0 of the rotation plan in #72; landed independently so the visible bug clears now and the multi-key rotation work that follows starts from a working Test Connection baseline.

## Test plan

- [ ] On a freshly-added box, Test Connection succeeds (regression check — this code path was already working).
- [ ] On an existing box opened via the edit form **without** typing anything into the API Key field, Test Connection succeeds (the actual bug being fixed).
- [ ] On an existing box where the operator pastes a *new* API key into the field, Test Connection uses the typed key (form takes precedence over stored key when both are present — backend behavior unchanged).
- [ ] On an existing box that has no API key configured at all (rare), Test Connection returns the existing "API key is required" error rather than silently using a stale lookup.
- [ ] `make templ-generate && make build` clean.

## Related

- Closes the "cannot test connection of an existing box" bug noted in #72.
- Adjacent to #111 (Test Connection 404 on non-HAProxy boxes + server-side API key handling audit) — they touch the same surface but address different failure modes; both can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)