### PR TITLE
feat(rotation): Phase 2 — install/use/remove endpoints + rotator (#72)

### DIFF
--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -542,7 +542,7 @@ func main() {
 	// backoff layered on top — see 2026-05 audit P1-7).
 	rateLimiter := middleware.DefaultRateLimiter(logger)
 	authBackoff := middleware.DefaultBackoffTracker(logger)
-	keyRingHandler := api.NewKeyRingHandler(server.KeyRing(), logger)
+	keyRingHandler := api.NewKeyRingHandler(server.KeyRing(), cfg.KeyRingPath, logger)
 	pluginRouter := server.Router().Group(func(r chi.Router) {
 		r.Use(middleware.RateLimitMiddleware(rateLimiter))
 		r.Use(middleware.APIKeyAuth(server.KeyRing(), logger, authBackoff))

--- a/gearbox-agent/internal/api/keyring.go
+++ b/gearbox-agent/internal/api/keyring.go
@@ -1,42 +1,58 @@
 package api
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
+	"sync"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/sarg3nt/gearbox-agent/internal/framework/crypto"
 )
 
-// KeyRingHandler exposes the agent's keyring metadata over the HTTP API.
-// Phase 1 ships only the read endpoint; Phase 2 adds install/use/remove
-// for the controller-driven three-phase rotation flow (issue #72).
+// KeyRingHandler exposes the agent's keyring metadata and rotation
+// endpoints over the HTTP API. The mutation endpoints (install/use/
+// remove) drive the controller-orchestrated three-phase rotation from
+// issue #72; the metadata endpoint is read-only.
 type KeyRingHandler struct {
 	keyring *crypto.KeyRingPointer
+	path    string
 	logger  *slog.Logger
+
+	// mu serializes mutation handlers — keyring writes are tmpfile+
+	// rename atomic on disk, but two concurrent installs racing would
+	// still let the second one's read-modify-write step lose the
+	// first one's changes.
+	mu sync.Mutex
 }
 
-// NewKeyRingHandler wires a handler around the agent's keyring pointer.
-func NewKeyRingHandler(keyring *crypto.KeyRingPointer, logger *slog.Logger) *KeyRingHandler {
-	return &KeyRingHandler{keyring: keyring, logger: logger}
+// NewKeyRingHandler wires a handler around the agent's keyring pointer
+// and the disk path the keyring is persisted to.
+func NewKeyRingHandler(keyring *crypto.KeyRingPointer, path string, logger *slog.Logger) *KeyRingHandler {
+	return &KeyRingHandler{keyring: keyring, path: path, logger: logger}
 }
 
 // RegisterRoutes mounts the keyring endpoints on r. The caller is
 // responsible for putting r behind the API-key auth middleware.
 func (h *KeyRingHandler) RegisterRoutes(r chi.Router) {
 	r.Get("/api/v1/system/keyring", h.handleGet)
+	r.Post("/api/v1/system/keyring/install", h.handleInstall)
+	r.Post("/api/v1/system/keyring/use", h.handleUse)
+	r.Delete("/api/v1/system/keyring/{kid}", h.handleRemove)
 }
 
-// keyRingResponse is what the API returns. Never includes secret bytes.
+// keyRingResponse is what GET returns. Never includes secret bytes.
 type keyRingResponse struct {
-	Version int                       `json:"version"`
-	Entries []crypto.KeyRingMetadata  `json:"entries"`
+	Version int                      `json:"version"`
+	Entries []crypto.KeyRingMetadata `json:"entries"`
 }
 
-// handleGet returns the keyring metadata — kids, roles, creation times,
-// and short fingerprints — but never the actual secrets.
+// handleGet returns keyring metadata — kids, roles, creation times,
+// fingerprints. Secrets are never exposed.
 //
 //	@Summary		Get agent keyring metadata
 //	@Description	Returns the currently-installed API keys' metadata. Secrets are NEVER exposed. The fingerprint is the first 8 hex chars of sha256(secret); useful to verify the dashboard has the same secret without round-tripping the secret itself.
@@ -61,8 +77,251 @@ func (h *KeyRingHandler) handleGet(w http.ResponseWriter, _ *http.Request) {
 		Version: kr.Version,
 		Entries: kr.Snapshot(),
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		h.logger.Error("encode keyring response failed", "error", err)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// installRequest is the install endpoint's body. Secret is base64url-
+// encoded raw bytes (the same encoding used in the on-wire token).
+type installRequest struct {
+	KID      string `json:"kid"`
+	SecretB64 string `json:"secret_b64"`
+	Role     string `json:"role"` // optional; defaults to "secondary"
+}
+
+// handleInstall adds a new entry to the keyring. Idempotent: re-
+// installing the same (kid, secret) pair is a no-op and returns 200.
+// Installing a different secret under an existing kid returns 409.
+//
+//	@Summary		Install a new keyring entry
+//	@Description	Adds a new accepted API key to the agent's keyring. New entries default to role=secondary; the controller calls /use to flip primary after confirming installation.
+//	@Tags			system
+//	@Security		BearerAuth
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		installRequest	true	"new key"
+//	@Success		200		{object}	keyRingResponse
+//	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		401		{string}	string	"Unauthorized"
+//	@Failure		409		{string}	string	"Conflict"
+//	@Failure		507		{string}	string	"Keyring full"
+//	@Router			/api/v1/system/keyring/install [post]
+func (h *KeyRingHandler) handleInstall(w http.ResponseWriter, r *http.Request) {
+	var req installRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
+	req.KID = strings.TrimSpace(req.KID)
+	if req.KID == "" || req.SecretB64 == "" {
+		writeError(w, http.StatusBadRequest, "kid and secret_b64 are required")
+		return
+	}
+	secret, err := base64.RawURLEncoding.DecodeString(req.SecretB64)
+	if err != nil || len(secret) != crypto.SecretLength {
+		writeError(w, http.StatusBadRequest, "secret_b64 must be base64url-encoded 32 random bytes")
+		return
+	}
+	role := req.Role
+	if role == "" {
+		role = "secondary"
+	}
+	if role != "primary" && role != "secondary" {
+		writeError(w, http.StatusBadRequest, "role must be 'primary' or 'secondary'")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	current := h.keyring.Load()
+	next := current.Clone()
+
+	// Idempotency: same (kid, secret) → 200 with current state. Same
+	// kid + different secret → 409. The controller treats both as
+	// "already done" but the 409 surfaces a state divergence to logs.
+	if existing := findEntry(current, req.KID); existing != nil {
+		if constantTimeEq(existing.Secret, secret) {
+			writeJSON(w, http.StatusOK, keyRingResponse{
+				Version: current.Version,
+				Entries: current.Snapshot(),
+			})
+			return
+		}
+		writeError(w, http.StatusConflict, "kid already exists with a different secret")
+		return
+	}
+
+	entry := crypto.KeyRingEntry{
+		KID:    req.KID,
+		Secret: secret,
+		Role:   role,
+	}
+	if err := next.Add(entry); err != nil {
+		if errors.Is(err, crypto.ErrKeyRingFull) {
+			writeError(w, http.StatusInsufficientStorage, "keyring at maximum capacity")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "add entry: "+err.Error())
+		return
+	}
+
+	if err := crypto.SaveKeyRing(h.path, next); err != nil {
+		h.logger.Error("save keyring", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist keyring")
+		return
+	}
+	h.keyring.Store(next)
+	h.logger.Info("keyring: installed entry", "kid", req.KID, "role", role)
+
+	writeJSON(w, http.StatusOK, keyRingResponse{
+		Version: next.Version,
+		Entries: next.Snapshot(),
+	})
+}
+
+// useRequest is the use endpoint's body.
+type useRequest struct {
+	KID string `json:"kid"`
+}
+
+// handleUse flips the named entry to role=primary and demotes the
+// existing primary to secondary. Both stay accepted; the agent doesn't
+// distinguish primary vs secondary for inbound auth purposes, but the
+// /keyring metadata response and the kid echoed in `X-Gearbox-Kid` let
+// the controller drive the overlap window correctly.
+//
+//	@Summary		Promote a keyring entry to primary
+//	@Description	Flips the named keyring entry's role to "primary" and demotes the prior primary to "secondary". Both keys remain valid for inbound auth.
+//	@Tags			system
+//	@Security		BearerAuth
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		useRequest	true	"target kid"
+//	@Success		200		{object}	keyRingResponse
+//	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		401		{string}	string	"Unauthorized"
+//	@Failure		404		{string}	string	"Unknown kid"
+//	@Router			/api/v1/system/keyring/use [post]
+func (h *KeyRingHandler) handleUse(w http.ResponseWriter, r *http.Request) {
+	var req useRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.KID = strings.TrimSpace(req.KID)
+	if req.KID == "" {
+		writeError(w, http.StatusBadRequest, "kid is required")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	next := h.keyring.Load().Clone()
+	if err := next.SetPrimary(req.KID); err != nil {
+		if errors.Is(err, crypto.ErrUnknownKID) {
+			writeError(w, http.StatusNotFound, "unknown kid")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "set primary: "+err.Error())
+		return
+	}
+
+	if err := crypto.SaveKeyRing(h.path, next); err != nil {
+		h.logger.Error("save keyring", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist keyring")
+		return
+	}
+	h.keyring.Store(next)
+	h.logger.Info("keyring: promoted to primary", "kid", req.KID)
+
+	writeJSON(w, http.StatusOK, keyRingResponse{
+		Version: next.Version,
+		Entries: next.Snapshot(),
+	})
+}
+
+// handleRemove deletes the named entry. Refuses to remove the only
+// remaining entry — an operator error otherwise bricks the box.
+//
+//	@Summary		Remove a keyring entry
+//	@Description	Deletes the named keyring entry. Refuses to remove the only remaining entry; the agent always retains at least one accepted key.
+//	@Tags			system
+//	@Security		BearerAuth
+//	@Param			kid	path	string	true	"key id"
+//	@Success		200	{object}	keyRingResponse
+//	@Failure		401	{string}	string	"Unauthorized"
+//	@Failure		404	{string}	string	"Unknown kid"
+//	@Failure		409	{string}	string	"Cannot remove last key"
+//	@Router			/api/v1/system/keyring/{kid} [delete]
+func (h *KeyRingHandler) handleRemove(w http.ResponseWriter, r *http.Request) {
+	kid := strings.TrimSpace(chi.URLParam(r, "kid"))
+	if kid == "" {
+		writeError(w, http.StatusBadRequest, "kid is required")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	next := h.keyring.Load().Clone()
+	if err := next.Remove(kid); err != nil {
+		switch {
+		case errors.Is(err, crypto.ErrUnknownKID):
+			writeError(w, http.StatusNotFound, "unknown kid")
+		case errors.Is(err, crypto.ErrCannotRemoveLast):
+			writeError(w, http.StatusConflict, "cannot remove the only remaining key")
+		default:
+			writeError(w, http.StatusInternalServerError, "remove: "+err.Error())
+		}
+		return
+	}
+
+	if err := crypto.SaveKeyRing(h.path, next); err != nil {
+		h.logger.Error("save keyring", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist keyring")
+		return
+	}
+	h.keyring.Store(next)
+	h.logger.Info("keyring: removed entry", "kid", kid)
+
+	writeJSON(w, http.StatusOK, keyRingResponse{
+		Version: next.Version,
+		Entries: next.Snapshot(),
+	})
+}
+
+// findEntry returns the entry with the given kid, or nil. Reads only
+// — does not lock; caller already holds the handler mutex.
+func findEntry(kr *crypto.KeyRing, kid string) *crypto.KeyRingEntry {
+	for i := range kr.Entries {
+		if kr.Entries[i].KID == kid {
+			return &kr.Entries[i]
+		}
+	}
+	return nil
+}
+
+// constantTimeEq compares two byte slices in constant time. Used by
+// the install-idempotency check so reinstalling under an existing kid
+// doesn't leak timing about the existing secret.
+func constantTimeEq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := range a {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
 }

--- a/gearbox-agent/internal/api/keyring_test.go
+++ b/gearbox-agent/internal/api/keyring_test.go
@@ -1,0 +1,317 @@
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox-agent/internal/framework/crypto"
+)
+
+func newKeyRingTestHandler(t *testing.T) (*KeyRingHandler, *chi.Mux, *crypto.KeyRingPointer, string) {
+	t.Helper()
+	t.Setenv("GEARBOX_AGENT_ENCRYPTION_KEY", "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+
+	// Seed with one entry so tests can start from a sane baseline.
+	kid, _ := crypto.NewKID()
+	secret, _ := crypto.NewSecret()
+	kr := &crypto.KeyRing{Version: 1, Entries: []crypto.KeyRingEntry{{
+		KID:       kid,
+		Secret:    secret,
+		SecretHex: hex.EncodeToString(secret),
+		Role:      "primary",
+		CreatedAt: time.Now().UTC(),
+	}}}
+	if err := crypto.SaveKeyRing(path, kr); err != nil {
+		t.Fatalf("SaveKeyRing: %v", err)
+	}
+
+	ptr := crypto.NewKeyRingPointer(kr)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := NewKeyRingHandler(ptr, path, logger)
+
+	r := chi.NewRouter()
+	h.RegisterRoutes(r)
+	return h, r, ptr, path
+}
+
+func TestKeyRing_Get_ReturnsMetadataNoSecrets(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/keyring", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !bytes.Contains(w.Body.Bytes(), []byte("entries")) {
+		t.Errorf("missing entries field: %s", body)
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("\"secret\"")) {
+		t.Errorf("response leaked secret field: %s", body)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("\"fingerprint\"")) {
+		t.Errorf("missing fingerprint field: %s", body)
+	}
+}
+
+func TestKeyRing_Install_AddsSecondary(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+
+	newSecret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid":        "abc123",
+		"secret_b64": base64.RawURLEncoding.EncodeToString(newSecret),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	kr := ptr.Load()
+	if len(kr.Entries) != 2 {
+		t.Fatalf("expected 2 entries after install, got %d", len(kr.Entries))
+	}
+	// Find the new one.
+	found := false
+	for _, e := range kr.Entries {
+		if e.KID == "abc123" {
+			if e.Role != "secondary" {
+				t.Errorf("new entry role = %q, want secondary", e.Role)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("new kid not in keyring: %+v", kr.Entries)
+	}
+}
+
+func TestKeyRing_Install_Idempotent(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+
+	newSecret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid":        "abc123",
+		"secret_b64": base64.RawURLEncoding.EncodeToString(newSecret),
+	})
+
+	// First install.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first install: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Same kid + same secret → 200, no-op.
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("second install (idempotent): status=%d, want 200", w.Code)
+	}
+}
+
+func TestKeyRing_Install_KIDClashDifferentSecret_409(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+
+	secretA, _ := crypto.NewSecret()
+	bodyA, _ := json.Marshal(map[string]string{
+		"kid": "shared", "secret_b64": base64.RawURLEncoding.EncodeToString(secretA),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(bodyA))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("install A: %d", w.Code)
+	}
+
+	secretB, _ := crypto.NewSecret()
+	bodyB, _ := json.Marshal(map[string]string{
+		"kid": "shared", "secret_b64": base64.RawURLEncoding.EncodeToString(secretB),
+	})
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(bodyB))
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("install B (collision): status=%d, want 409", w.Code)
+	}
+}
+
+func TestKeyRing_Install_BadSecretLength(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+	body, _ := json.Marshal(map[string]string{
+		"kid": "ok", "secret_b64": base64.RawURLEncoding.EncodeToString([]byte("short")),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestKeyRing_Use_FlipsPrimary(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+
+	// Add a secondary.
+	newSecret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid":        "v2",
+		"secret_b64": base64.RawURLEncoding.EncodeToString(newSecret),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Use it.
+	body, _ = json.Marshal(map[string]string{"kid": "v2"})
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/use", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("use: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	kr := ptr.Load()
+	primary := kr.Primary()
+	if primary == nil || primary.KID != "v2" {
+		t.Errorf("primary after use = %+v, want kid=v2", primary)
+	}
+}
+
+func TestKeyRing_Use_UnknownKID_404(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+	body, _ := json.Marshal(map[string]string{"kid": "nonexistent"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/use", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestKeyRing_Remove_OK(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+
+	// Add a secondary first.
+	secret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid": "v2", "secret_b64": base64.RawURLEncoding.EncodeToString(secret),
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body)))
+
+	if got := len(ptr.Load().Entries); got != 2 {
+		t.Fatalf("setup: entries = %d, want 2", got)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/system/keyring/v2", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: status=%d body=%s", w.Code, w.Body.String())
+	}
+	if got := len(ptr.Load().Entries); got != 1 {
+		t.Errorf("after delete: entries = %d, want 1", got)
+	}
+}
+
+func TestKeyRing_Remove_LastEntry_409(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+	kr := ptr.Load()
+	if len(kr.Entries) != 1 {
+		t.Fatalf("setup: want 1 entry, got %d", len(kr.Entries))
+	}
+	url := "/api/v1/system/keyring/" + kr.Entries[0].KID
+	req := httptest.NewRequest(http.MethodDelete, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", w.Code)
+	}
+}
+
+func TestKeyRing_Mutations_PersistAcrossReload(t *testing.T) {
+	_, r, ptr, path := newKeyRingTestHandler(t)
+
+	// Install + use a second key.
+	secret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid": "v2", "secret_b64": base64.RawURLEncoding.EncodeToString(secret),
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body)))
+	useBody, _ := json.Marshal(map[string]string{"kid": "v2"})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/use", bytes.NewReader(useBody)))
+
+	// Reload from disk; the change should be there.
+	reloaded, _, err := crypto.LoadOrCreateKeyRing(path, "")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	prim := reloaded.Primary()
+	if prim == nil || prim.KID != "v2" {
+		t.Errorf("reloaded primary = %+v, want kid=v2", prim)
+	}
+
+	// In-memory pointer should match.
+	if got := ptr.Load().Primary().KID; got != "v2" {
+		t.Errorf("in-memory primary = %q", got)
+	}
+
+	// Verify the on-disk file mode is 0600 — secret files must not be
+	// world-readable even when GBE1 encryption isn't configured.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Errorf("file mode = %v, want 0600", st.Mode().Perm())
+	}
+}
+
+func TestKeyRing_Install_FullKeyRing_507(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+	// Seed already has 1 entry; fill to MaxKeyRingEntries.
+	for i := 0; i < crypto.MaxKeyRingEntries-1; i++ {
+		s, _ := crypto.NewSecret()
+		body, _ := json.Marshal(map[string]string{
+			"kid":        fmt.Sprintf("k%d", i),
+			"secret_b64": base64.RawURLEncoding.EncodeToString(s),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("install %d: status=%d body=%s", i, w.Code, w.Body.String())
+		}
+	}
+
+	// One more should overflow.
+	s, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid": "overflow", "secret_b64": base64.RawURLEncoding.EncodeToString(s),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInsufficientStorage {
+		t.Errorf("overflow install: status=%d, want 507", w.Code)
+	}
+}

--- a/gearbox/internal/framework/agent/client.go
+++ b/gearbox/internal/framework/agent/client.go
@@ -32,12 +32,59 @@ const (
 type Client struct {
 	baseURL    string
 	apiKey     string
+	kid        string // optional; when set, sent as X-Gearbox-Kid header
 	httpClient *http.Client
 }
+
+// HeaderKID is the request/response header name carrying the keyring
+// entry id. The agent's middleware echoes the matched kid on every
+// authenticated response (see middleware.ResponseHeaderKID); the
+// dashboard sends this kid on outbound requests so the agent + audit
+// log can correlate keys. Phase 5 (drift detection) compares the
+// request-time kid with the echoed response kid.
+const HeaderKID = "X-Gearbox-Kid"
 
 // NewClient creates a new HAProxy Agent API client.
 func NewClient(baseURL, apiKey string) *Client {
 	return NewClientWithTimeout(baseURL, apiKey, DefaultTimeout)
+}
+
+// NewClientWithKID creates a client that also identifies the keyring
+// entry it's signing with — the agent echoes back the matched kid in
+// X-Gearbox-Kid and the dashboard compares the two to detect rotation
+// drift. Empty kid is fine (legacy single-key boxes); the client just
+// won't send the header.
+func NewClientWithKID(baseURL, apiKey, kid string) *Client {
+	c := NewClient(baseURL, apiKey)
+	c.kid = kid
+	return c
+}
+
+// WithKID returns a shallow copy of c tagged with kid. Useful when a
+// short-lived client wants to be rebuilt to point at a different
+// keyring entry without re-doing TLS setup.
+func (c *Client) WithKID(kid string) *Client {
+	clone := *c
+	clone.kid = kid
+	return &clone
+}
+
+// KID returns the kid this client signs requests with, or "" if it
+// wasn't built with one. Used by the rotator and drift-detection
+// paths.
+func (c *Client) KID() string { return c.kid }
+
+// setAuthHeaders applies the standard auth + Accept headers and, when
+// the client was built with a kid, the X-Gearbox-Kid request header.
+// Callers must call this BEFORE setting Content-Type so their override
+// wins (the helper deliberately doesn't set Content-Type — varied
+// per-callsite based on whether the request has a body).
+func (c *Client) setAuthHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	if c.kid != "" {
+		req.Header.Set(HeaderKID, c.kid)
+	}
 }
 
 // NewClientWithTimeout creates a new HAProxy Agent API client with a custom timeout.
@@ -214,8 +261,7 @@ func (c *Client) doRequest(method, path string, query url.Values) ([]byte, error
 	}
 
 	// Add bearer token authentication
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -255,8 +301,7 @@ func (c *Client) doRequestLongRunning(method, path string, query url.Values) ([]
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(req)
 
 	// Use a separate client with extended timeout, sharing the same transport
 	longClient := &http.Client{
@@ -311,8 +356,7 @@ func (c *Client) doRequestWithBodyAndQuery(method, path string, reqBody interfac
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(req)
 	if reqBody != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -758,7 +802,7 @@ func (c *Client) DownloadCertificate(domain string) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	c.setAuthHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -1041,8 +1085,7 @@ func (c *Client) UpdateHAProxyConfig(req *HAProxyConfigUpdateRequest) (*HAProxyC
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	httpReq.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(httpReq)
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := c.httpClient.Do(httpReq)
@@ -1137,8 +1180,7 @@ func (c *Client) UpdateFirewallConfig(req *FirewallConfigUpdateRequest) (*Firewa
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	httpReq.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(httpReq)
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := c.httpClient.Do(httpReq)

--- a/gearbox/internal/framework/agent/keyring.go
+++ b/gearbox/internal/framework/agent/keyring.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// KeyRingMetadataEntry is the dashboard-side mirror of the agent's
+// crypto.KeyRingMetadata. Kept in this package so the dashboard
+// doesn't need to import the agent's internal crypto package.
+type KeyRingMetadataEntry struct {
+	KID         string    `json:"kid"`
+	Role        string    `json:"role"`
+	CreatedAt   time.Time `json:"created_at"`
+	Fingerprint string    `json:"fingerprint"`
+}
+
+// KeyRingResponse is the body shape of GET /api/v1/system/keyring and
+// the response to the mutation endpoints. Secrets are never present.
+type KeyRingResponse struct {
+	Version int                    `json:"version"`
+	Entries []KeyRingMetadataEntry `json:"entries"`
+}
+
+// KeyRingGet returns the agent's keyring metadata. Used by the
+// dashboard rotator to verify the post-rotation state matches its
+// expectation, and by drift detection (Phase 5).
+func (c *Client) KeyRingGet() (*KeyRingResponse, error) {
+	body, err := c.doRequest("GET", "/api/v1/system/keyring", url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse keyring response: %w", err)
+	}
+	return &resp, nil
+}
+
+// KeyRingInstall adds a new entry to the agent's keyring. Idempotent
+// when (kid, secret) match an existing entry; returns ConflictError
+// (HTTP 409) when kid clashes with a different secret.
+//
+// secret must be exactly 32 random bytes — caller's responsibility.
+func (c *Client) KeyRingInstall(kid string, secret []byte, role string) (*KeyRingResponse, error) {
+	if role == "" {
+		role = "secondary"
+	}
+	reqBody := map[string]string{
+		"kid":        kid,
+		"secret_b64": base64.RawURLEncoding.EncodeToString(secret),
+		"role":       role,
+	}
+	body, err := c.doRequestWithBody("POST", "/api/v1/system/keyring/install", reqBody)
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse install response: %w", err)
+	}
+	return &resp, nil
+}
+
+// KeyRingUse promotes the named keyring entry to primary. The previous
+// primary becomes secondary (still accepted for inbound auth).
+func (c *Client) KeyRingUse(kid string) (*KeyRingResponse, error) {
+	body, err := c.doRequestWithBody("POST", "/api/v1/system/keyring/use", map[string]string{"kid": kid})
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse use response: %w", err)
+	}
+	return &resp, nil
+}
+
+// KeyRingDelete removes the named keyring entry. Returns an APIError
+// with status 409 when called on the only remaining entry — the agent
+// refuses to brick itself.
+func (c *Client) KeyRingDelete(kid string) (*KeyRingResponse, error) {
+	body, err := c.doRequest("DELETE", "/api/v1/system/keyring/"+url.PathEscape(kid), url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse delete response: %w", err)
+	}
+	return &resp, nil
+}

--- a/gearbox/internal/framework/database/box_agent_keys.go
+++ b/gearbox/internal/framework/database/box_agent_keys.go
@@ -120,11 +120,14 @@ func (d *DB) SetBoxPrimaryKey(boxID int64, kid string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Demote current primary.
+	// Demote current primary. Use a Go-side UTC timestamp instead of
+	// SQLite's CURRENT_TIMESTAMP to avoid timezone-parsing differences
+	// between drivers (modernc.org/sqlite scans bare DATETIMEs as
+	// local, which compares wrong against a UTC time.Now() in Go).
 	if _, err := tx.Exec(`
-		UPDATE box_agent_keys SET role = 'secondary', retired_at = CURRENT_TIMESTAMP
+		UPDATE box_agent_keys SET role = 'secondary', retired_at = ?
 		WHERE box_id = ? AND role = 'primary'
-	`, boxID); err != nil {
+	`, time.Now().UTC(), boxID); err != nil {
 		return fmt.Errorf("demote primary: %w", err)
 	}
 

--- a/gearbox/internal/framework/services/agent_keyring/keygen.go
+++ b/gearbox/internal/framework/services/agent_keyring/keygen.go
@@ -1,0 +1,41 @@
+package agent_keyring
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+const (
+	// SecretLength matches the agent's crypto.SecretLength — 32 bytes
+	// / 256 bits, the AES-256 entropy floor.
+	SecretLength = 32
+
+	// KIDByteLength is the random bytes used to derive a kid. 3 bytes
+	// hex-encoded → 6-char kid, same as the agent's NewKID.
+	KIDByteLength = 3
+)
+
+// newKID returns a fresh 6-hex-char keyring entry id.
+func newKID() (string, error) {
+	b := make([]byte, KIDByteLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// newSecret returns 32 cryptographically-random bytes.
+func newSecret() ([]byte, error) {
+	b := make([]byte, SecretLength)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// base64URLNoPad mirrors the agent's wire format — base64url, no
+// padding, applied to the raw secret bytes.
+func base64URLNoPad(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/gearbox/internal/framework/services/agent_keyring/rotator.go
+++ b/gearbox/internal/framework/services/agent_keyring/rotator.go
@@ -1,0 +1,249 @@
+// Package agent_keyring orchestrates the three-phase
+// install -> use -> remove rotation flow against the agent's
+// /api/v1/system/keyring endpoints (issue #72).
+//
+// The rotator never deletes the old key until an explicit cleanup
+// step fires — that's the "overlap window" property that lets a
+// rotation survive a controller crash mid-dance. While both keys
+// coexist on the agent, the dashboard signs with the new one and the
+// agent accepts either, so an interrupted rotation degrades to "two
+// working keys, slightly noisier audit log" rather than "agent locked
+// out".
+package agent_keyring
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
+)
+
+// DefaultOverlapWindow is the time that elapses between flipping
+// primary and being eligible to remove the old key. 24h chosen to be
+// long enough to survive operator-overnight outages but short enough
+// to keep secondaries from accumulating. Configurable per-call.
+const DefaultOverlapWindow = 24 * time.Hour
+
+// Rotator coordinates the install->use->remove dance for a single box.
+// Holds no state beyond the DB + encryptor + logger; every call is
+// reentrant and safe to invoke from concurrent goroutines (DB-level
+// locking guards the transactional pieces).
+type Rotator struct {
+	db        *database.DB
+	encryptor *crypto.Encryptor
+	logger    *slog.Logger
+}
+
+// New builds a Rotator. encryptor decrypts box secrets so the rotator
+// can build an authenticated agent.Client; db carries the state.
+func New(db *database.DB, encryptor *crypto.Encryptor, logger *slog.Logger) *Rotator {
+	return &Rotator{db: db, encryptor: encryptor, logger: logger}
+}
+
+// RotationResult summarises a successful rotation.
+type RotationResult struct {
+	NewKID      string
+	OldKID      string
+	RetireAfter time.Time // when CleanupRetiredKeys would remove the old key
+}
+
+// RotateBox runs the three-phase rotation against the box's agent:
+//
+//  1. Generate a fresh (kid, secret).
+//  2. Call agent's keyring/install with role=secondary. Agent now
+//     accepts both keys.
+//  3. Insert the new entry into box_agent_keys (still secondary).
+//  4. Call agent's keyring/use { kid: new }. Agent's primary flips;
+//     both keys remain accepted.
+//  5. In a DB transaction, flip the row's role to primary and stamp
+//     retired_at on the previous primary.
+//
+// Returns the rotation result with the new and old kids and the time
+// at which the old key becomes eligible for removal (default 24h).
+//
+// Failure handling is by intent simple: if any step errors the caller
+// gets it; both old and new keys remain accepted on the agent (since
+// install is idempotent and use is idempotent), so retrying is safe.
+// The user-facing rotate button surfaces the error.
+func (r *Rotator) RotateBox(boxID int64, overlapWindow time.Duration) (*RotationResult, error) {
+	if overlapWindow <= 0 {
+		overlapWindow = DefaultOverlapWindow
+	}
+
+	box, err := r.db.GetBoxByID(boxID)
+	if err != nil {
+		return nil, fmt.Errorf("load box: %w", err)
+	}
+	if box == nil {
+		return nil, fmt.Errorf("box %d not found", boxID)
+	}
+
+	current, err := r.db.GetBoxPrimaryKey(boxID)
+	if err != nil {
+		return nil, fmt.Errorf("load current primary: %w", err)
+	}
+	if current == nil {
+		return nil, fmt.Errorf("box %d has no primary key — bootstrap a key first", boxID)
+	}
+
+	client, err := r.clientForKey(box.AgentURL, current)
+	if err != nil {
+		return nil, fmt.Errorf("build agent client: %w", err)
+	}
+
+	// Generate the new key.
+	newKID, err := newKID()
+	if err != nil {
+		return nil, fmt.Errorf("generate kid: %w", err)
+	}
+	newSecret, err := newSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate secret: %w", err)
+	}
+	r.logger.Info("rotation: starting", "box_id", boxID, "old_kid", current.KID, "new_kid", newKID)
+
+	// Step 1 — install on the agent as secondary.
+	if _, err := client.KeyRingInstall(newKID, newSecret, "secondary"); err != nil {
+		return nil, fmt.Errorf("agent install: %w", err)
+	}
+
+	// Step 2 — persist the new key on our side. The on-disk format
+	// matches the existing legacy entry: AES-256-GCM ciphertext of the
+	// 64-char hex form of the secret, so callers can decrypt uniformly.
+	encrypted, err := r.encryptor.EncryptString(hex.EncodeToString(newSecret))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt new secret: %w", err)
+	}
+	if err := r.db.InsertBoxAgentKey(&database.BoxAgentKey{
+		BoxID:           boxID,
+		KID:             newKID,
+		SecretEncrypted: encrypted,
+		Role:            "secondary",
+	}); err != nil {
+		return nil, fmt.Errorf("insert new key row: %w", err)
+	}
+
+	// Step 3 — flip primary on the agent. Both keys remain accepted.
+	if _, err := client.KeyRingUse(newKID); err != nil {
+		return nil, fmt.Errorf("agent use: %w", err)
+	}
+
+	// Step 4 — flip primary in our DB. Demoted entry gets retired_at
+	// stamped so CleanupRetiredKeys can sweep it once overlapWindow
+	// elapses.
+	if err := r.db.SetBoxPrimaryKey(boxID, newKID); err != nil {
+		return nil, fmt.Errorf("flip db primary: %w", err)
+	}
+
+	r.logger.Info("rotation: success",
+		"box_id", boxID, "old_kid", current.KID, "new_kid", newKID,
+		"retire_after", time.Now().Add(overlapWindow))
+
+	return &RotationResult{
+		NewKID:      newKID,
+		OldKID:      current.KID,
+		RetireAfter: time.Now().Add(overlapWindow),
+	}, nil
+}
+
+// CleanupRetiredKeys removes secondary keys whose retired_at is older
+// than overlapWindow. Called from the manual rotate path (immediately
+// after a rotation isn't ready to clean up; the operator clicks again
+// later, or Phase 4's scheduler does it on a tick).
+//
+// Returns the number of keys removed.
+func (r *Rotator) CleanupRetiredKeys(boxID int64, overlapWindow time.Duration) (int, error) {
+	if overlapWindow <= 0 {
+		overlapWindow = DefaultOverlapWindow
+	}
+
+	box, err := r.db.GetBoxByID(boxID)
+	if err != nil {
+		return 0, fmt.Errorf("load box: %w", err)
+	}
+	if box == nil {
+		return 0, fmt.Errorf("box %d not found", boxID)
+	}
+	primary, err := r.db.GetBoxPrimaryKey(boxID)
+	if err != nil {
+		return 0, fmt.Errorf("load primary: %w", err)
+	}
+	if primary == nil {
+		return 0, fmt.Errorf("box %d has no primary key", boxID)
+	}
+
+	all, err := r.db.GetBoxAgentKeys(boxID)
+	if err != nil {
+		return 0, fmt.Errorf("load keys: %w", err)
+	}
+
+	client, err := r.clientForKey(box.AgentURL, primary)
+	if err != nil {
+		return 0, fmt.Errorf("build agent client: %w", err)
+	}
+
+	removed := 0
+	for _, k := range all {
+		if k.Role == "primary" {
+			continue
+		}
+		if !k.RetiredAt.Valid {
+			continue
+		}
+		// time.Since uses the underlying instant, not the wall-clock zone,
+		// so this comparison is correct even when the SQLite driver
+		// scanned retired_at as a different (or "naive") timezone.
+		if time.Since(k.RetiredAt.Time) < overlapWindow {
+			continue
+		}
+
+		// Best-effort: remove from agent first, then DB. If the agent
+		// 404s, the row is stale and we can still drop our side.
+		if _, err := client.KeyRingDelete(k.KID); err != nil {
+			if !isNotFoundOrConflict(err) {
+				r.logger.Warn("cleanup: agent delete failed; leaving DB row",
+					"box_id", boxID, "kid", k.KID, "error", err)
+				continue
+			}
+		}
+		if err := r.db.DeleteBoxAgentKey(boxID, k.KID); err != nil {
+			r.logger.Warn("cleanup: db delete failed", "box_id", boxID, "kid", k.KID, "error", err)
+			continue
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// clientForKey decrypts the given key entry and builds an authenticated
+// agent.Client tagged with its kid (so X-Gearbox-Kid gets echoed back).
+func (r *Rotator) clientForKey(agentURL string, key *database.BoxAgentKey) (*agent.Client, error) {
+	hexSecret, err := r.encryptor.DecryptString(key.SecretEncrypted)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt secret: %w", err)
+	}
+	secret, err := hex.DecodeString(hexSecret)
+	if err != nil {
+		return nil, fmt.Errorf("decode secret: %w", err)
+	}
+	// Agent accepts both legacy 64-hex and prefixed gbx_<kid>_<b64>;
+	// always send the prefixed form so the audit log sees a real kid.
+	token := "gbx_" + key.KID + "_" + base64URLNoPad(secret)
+	return agent.NewClientWithKID(agentURL, token, key.KID), nil
+}
+
+// isNotFoundOrConflict is true for APIError 404 / 409 — meaning the
+// agent already doesn't have the key (404) or refused because it's the
+// only one left (409). Both are tolerable during cleanup.
+func isNotFoundOrConflict(err error) bool {
+	var apiErr *agent.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == 404 || apiErr.StatusCode == 409
+}

--- a/gearbox/internal/framework/services/agent_keyring/rotator_test.go
+++ b/gearbox/internal/framework/services/agent_keyring/rotator_test.go
@@ -1,0 +1,326 @@
+package agent_keyring
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	dashcrypto "github.com/sarg3nt/gearbox/internal/framework/services/crypto"
+)
+
+// agentMock fakes the subset of the agent's /api/v1/system/keyring/*
+// surface the rotator hits. It keeps a thread-safe in-memory keyring
+// and mimics the install/use/remove behaviour so rotator orchestration
+// can be tested without importing the agent module.
+type agentMock struct {
+	mu      sync.Mutex
+	entries []agentEntry
+}
+
+type agentEntry struct {
+	KID       string `json:"kid"`
+	SecretB64 string `json:"secret_b64,omitempty"`
+	Secret    []byte `json:"-"`
+	Role      string `json:"role"`
+}
+
+func (a *agentMock) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/system/keyring":
+			a.handleGet(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/keyring/install":
+			a.handleInstall(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/keyring/use":
+			a.handleUse(w, r)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/system/keyring/"):
+			kid := strings.TrimPrefix(r.URL.Path, "/api/v1/system/keyring/")
+			a.handleDelete(w, kid)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}
+}
+
+func (a *agentMock) handleGet(w http.ResponseWriter) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"version": 1,
+		"entries": a.entries,
+	})
+}
+
+func (a *agentMock) handleInstall(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		KID       string `json:"kid"`
+		SecretB64 string `json:"secret_b64"`
+		Role      string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	secret, err := base64.RawURLEncoding.DecodeString(body.SecretB64)
+	if err != nil || len(secret) != 32 {
+		http.Error(w, "bad secret", http.StatusBadRequest)
+		return
+	}
+	if body.Role == "" {
+		body.Role = "secondary"
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, e := range a.entries {
+		if e.KID == body.KID {
+			http.Error(w, "kid exists", http.StatusConflict)
+			return
+		}
+	}
+	a.entries = append(a.entries, agentEntry{
+		KID: body.KID, Secret: secret, SecretB64: body.SecretB64, Role: body.Role,
+	})
+	_ = json.NewEncoder(w).Encode(map[string]any{"version": 1, "entries": a.entries})
+}
+
+func (a *agentMock) handleUse(w http.ResponseWriter, r *http.Request) {
+	var body struct{ KID string }
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	found := false
+	for i := range a.entries {
+		if a.entries[i].KID == body.KID {
+			found = true
+		}
+	}
+	if !found {
+		http.Error(w, "unknown kid", http.StatusNotFound)
+		return
+	}
+	for i := range a.entries {
+		if a.entries[i].KID == body.KID {
+			a.entries[i].Role = "primary"
+		} else if a.entries[i].Role == "primary" {
+			a.entries[i].Role = "secondary"
+		}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"version": 1, "entries": a.entries})
+}
+
+func (a *agentMock) handleDelete(w http.ResponseWriter, kid string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.entries) <= 1 {
+		http.Error(w, "cannot remove last", http.StatusConflict)
+		return
+	}
+	for i := range a.entries {
+		if a.entries[i].KID == kid {
+			a.entries = append(a.entries[:i], a.entries[i+1:]...)
+			_ = json.NewEncoder(w).Encode(map[string]any{"version": 1, "entries": a.entries})
+			return
+		}
+	}
+	http.Error(w, "unknown kid", http.StatusNotFound)
+}
+
+func (a *agentMock) entryCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.entries)
+}
+
+func (a *agentMock) primaryKID() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, e := range a.entries {
+		if e.Role == "primary" {
+			return e.KID
+		}
+	}
+	return ""
+}
+
+// setupRotator wires a mock agent, a fresh DB, and a seeded box with
+// a legacy keyring entry that exists on both sides.
+func setupRotator(t *testing.T) (*Rotator, *agentMock, *database.DB, *database.BoxDB) {
+	t.Helper()
+	t.Setenv("GEARBOX_INSECURE_TLS", "true")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Mock agent — seeded with a "legacy" entry whose secret matches
+	// what we'll seed in the dashboard's DB.
+	rawSecret := make([]byte, 32)
+	for i := range rawSecret {
+		rawSecret[i] = byte(i)
+	}
+	mock := &agentMock{
+		entries: []agentEntry{{
+			KID:       "legacy",
+			Secret:    rawSecret,
+			SecretB64: base64.RawURLEncoding.EncodeToString(rawSecret),
+			Role:      "primary",
+		}},
+	}
+	srv := httptest.NewServer(mock.handler())
+	t.Cleanup(srv.Close)
+
+	// DB + encryptor.
+	dbDir := t.TempDir()
+	db, err := database.New(filepath.Join(dbDir, "gearbox.db"), logger)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	enc, err := dashcrypto.NewEncryptor("test-encryption-secret-32-bytes!")
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	box := &database.BoxDB{
+		BoxID:           "test-box",
+		Name:            "Test Box",
+		AgentURL:        srv.URL,
+		APIKeyEncrypted: []byte("unused-here"),
+		Enabled:         true,
+	}
+	if err := db.CreateBox(box); err != nil {
+		t.Fatalf("CreateBox: %v", err)
+	}
+	encryptedHex, err := enc.EncryptString(hex.EncodeToString(rawSecret))
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+	if err := db.InsertBoxAgentKey(&database.BoxAgentKey{
+		BoxID:           box.ID,
+		KID:             "legacy",
+		SecretEncrypted: encryptedHex,
+		Role:            "primary",
+	}); err != nil {
+		t.Fatalf("InsertBoxAgentKey: %v", err)
+	}
+
+	return New(db, enc, logger), mock, db, box
+}
+
+func TestRotator_HappyPath(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+
+	result, err := rotator.RotateBox(box.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+	if result.OldKID != "legacy" {
+		t.Errorf("OldKID = %q, want legacy", result.OldKID)
+	}
+	if result.NewKID == "" {
+		t.Errorf("NewKID is empty")
+	}
+
+	// Agent side: 2 entries, new is primary.
+	if got := mock.entryCount(); got != 2 {
+		t.Errorf("agent entries = %d, want 2", got)
+	}
+	if got := mock.primaryKID(); got != result.NewKID {
+		t.Errorf("agent primary kid = %q, want %q", got, result.NewKID)
+	}
+
+	// DB side: new kid is primary, legacy is secondary with retired_at.
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 2 {
+		t.Fatalf("db entries = %d, want 2", len(keys))
+	}
+	for _, k := range keys {
+		switch k.KID {
+		case result.NewKID:
+			if k.Role != "primary" {
+				t.Errorf("new kid role = %q, want primary", k.Role)
+			}
+		case "legacy":
+			if k.Role != "secondary" {
+				t.Errorf("legacy role = %q, want secondary", k.Role)
+			}
+			if !k.RetiredAt.Valid {
+				t.Errorf("legacy retired_at not set")
+			}
+		default:
+			t.Errorf("unexpected kid: %q", k.KID)
+		}
+	}
+}
+
+func TestRotator_CleanupRetiredKeys_PastOverlap(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+	if _, err := rotator.RotateBox(box.ID, 24*time.Hour); err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+
+	// Tiny overlap → anything retired more than 1ms ago is sweepable.
+	time.Sleep(10 * time.Millisecond)
+	removed, err := rotator.CleanupRetiredKeys(box.ID, 1*time.Millisecond)
+	if err != nil {
+		t.Fatalf("CleanupRetiredKeys: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+	if got := mock.entryCount(); got != 1 {
+		t.Errorf("agent entries after cleanup = %d, want 1", got)
+	}
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 1 || keys[0].KID == "legacy" {
+		t.Errorf("db keys after cleanup: %+v", keys)
+	}
+}
+
+func TestRotator_CleanupRetiredKeys_WithinOverlap(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+	if _, err := rotator.RotateBox(box.ID, 24*time.Hour); err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+
+	// Within the (generous) overlap → no cleanup.
+	removed, err := rotator.CleanupRetiredKeys(box.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CleanupRetiredKeys: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("removed = %d, want 0", removed)
+	}
+	if got := mock.entryCount(); got != 2 {
+		t.Errorf("agent entries = %d, want 2", got)
+	}
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 2 {
+		t.Errorf("db keys = %+v, want 2", keys)
+	}
+}
+
+func TestRotator_NoPrimary_Errors(t *testing.T) {
+	rotator, _, _, _ := setupRotator(t)
+	if _, err := rotator.RotateBox(9999, 24*time.Hour); err == nil {
+		t.Errorf("expected error rotating non-existent box")
+	}
+}
+
+// Silence unused-import lints when working on the file in isolation.
+var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary

Stacked on #128 (Phase 1). The active machinery for key rotation — three new agent endpoints implementing the controller-orchestrated install→use→remove three-phase dance, the dashboard-side rotator service that drives it, and the `X-Gearbox-Kid` request/response header that Phase 5 will use for drift detection.

**Agent endpoints** (all behind existing API-key auth, serialized through a handler-level mutex):

- `POST /api/v1/system/keyring/install` — body `{kid, secret_b64, role?}`. Idempotent on same (kid, secret); returns 409 on kid collision with a different secret. 507 when keyring is at MaxKeyRingEntries (4)
- `POST /api/v1/system/keyring/use` — flips named entry to primary; demotes prior primary to secondary. Both stay accepted
- `DELETE /api/v1/system/keyring/{kid}` — refuses 409 on the only remaining entry. Agent never bricks itself

**Dashboard side**

- `agent.Client` gains `NewClientWithKID(url, key, kid)` + `WithKID(kid)` + `KID()` accessor. Existing `NewClient` callers untouched. All outbound requests go through `setAuthHeaders(req)` helper that adds Bearer + (when kid set) `X-Gearbox-Kid` header
- New `KeyRingGet`/`KeyRingInstall`/`KeyRingUse`/`KeyRingDelete` methods
- New `services/agent_keyring` package with the `Rotator`:
  - `RotateBox(boxID, overlap)` runs the full sequence: decrypt current primary → install new key on agent as secondary → persist new key to DB → flip primary on agent → flip primary in DB (stamps retired_at on the old entry)
  - `CleanupRetiredKeys(boxID, overlap)` removes entries whose retired_at is older than overlap. Uses `time.Since` for cutoff comparison so SQLite-driver timezone behaviour doesn't bite

`SetBoxPrimaryKey` now stamps `retired_at` with `time.Now().UTC()` explicitly so the value round-trips correctly through the modernc.org/sqlite date parser.

## Test plan

- [ ] All 11 keyring-endpoint integration tests pass (install adds secondary, idempotent, KID collision 409, malformed secret 400, use flips primary, unknown kid 404, delete works, delete-last 409, persist-across-reload, file mode 0600, overflow 507)
- [ ] All 4 rotator integration tests pass (happy path covers full install→use→DB-flip, cleanup removes retired keys past overlap, leaves keys within overlap alone, missing-box errors)
- [ ] Existing tests in both modules still pass
- [ ] Manual smoke: rotate a key via curl against a running agent; confirm both keys accepted during overlap

## Stack

Phase 2 of 5. Base: `feature/issue-72-phase-1-keyring` (#128).

Closes part of #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)