### PR TITLE
feat(logs): consume access-log Resources for source picker

### DIFF
--- a/gearbox/internal/framework/agent/capabilities_cache.go
+++ b/gearbox/internal/framework/agent/capabilities_cache.go
@@ -49,6 +49,28 @@ func (b *BoxCapabilities) Entry(gearName string) (CapabilityEntry, bool) {
 	return e, ok
 }
 
+// Resource returns the named structured resource published by the gear,
+// if both the gear and the resource key are present. Issue #112 Phase 2.
+//
+// The agent publishes resources as `map[string]any` so each gear can
+// pick its own shape; the dashboard reads each gear's known keys
+// explicitly. Typical use is the Logs page reading
+// caps.Resource("access-log", "log_sources") to populate its source
+// dropdown without inferring sources from gear-availability flags.
+//
+// The third return distinguishes "the gear isn't surfaced" (false)
+// from "the gear is surfaced but didn't publish this resource" (also
+// false). Callers that need to fail-open on the older-agent case
+// should pair this with caps.Has(gearName).
+func (b *BoxCapabilities) Resource(gearName, resourceKey string) (any, bool) {
+	entry, ok := b.Entry(gearName)
+	if !ok {
+		return nil, false
+	}
+	v, ok := entry.Resources[resourceKey]
+	return v, ok
+}
+
 // CapabilitiesCache memoises agent capability fetches per (box, agent
 // URL) pair. Dashboard pages call into this on every render that needs
 // to decide what to surface; without the cache, that's one synchronous

--- a/gearbox/internal/framework/agent/models.go
+++ b/gearbox/internal/framework/agent/models.go
@@ -943,6 +943,18 @@ type CapabilityEntry struct {
 	Status       string            `json:"status"`
 	Reason       string            `json:"reason,omitempty"`
 	Capabilities map[string]string `json:"capabilities,omitempty"`
+
+	// Resources carries structured, gear-specific data the agent
+	// advertises beyond what fits in the flat Capabilities map. The
+	// dashboard reads each gear's known keys explicitly — e.g. the
+	// access-log gear publishes `log_sources` as a slice of
+	// {name, display_name, path} maps that the Logs page renders in
+	// its source picker. See issue #112 Phase 2.
+	//
+	// Decoded as map[string]any so the dashboard can do per-gear
+	// JSON decoding into typed shapes without forcing every gear's
+	// resource schema into a shared Go struct.
+	Resources map[string]any `json:"resources,omitempty"`
 }
 
 // CapabilitiesResponse mirrors the agent's CapabilitiesResponse.

--- a/gearbox/internal/framework/handler/api_logs.go
+++ b/gearbox/internal/framework/handler/api_logs.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
 	apperrors "github.com/sarg3nt/gearbox/internal/framework/errors"
 	"github.com/sarg3nt/gearbox/internal/framework/models"
 )
@@ -111,24 +112,30 @@ func (h *Handler) APILogSourcesHandler(w http.ResponseWriter, r *http.Request) {
 // entries for a box, derived from the agent's probe table. Used when
 // the operator hasn't saved explicit log-source settings.
 //
-// Heuristic:
-//   - `haproxy` is offered when EITHER access-log OR logs gear is
-//     available. access-log streams the HAProxy access log directly;
-//     logs streams it via journalctl/file when journalctl is present.
-//   - `system` is offered only when the `logs` gear is available, since
-//     system journal access requires journalctl/tail.
+// Resolution chain (issue #112 Phase 2):
 //
-// Fail-open posture (matches filterGearsByAgentCapabilities):
-//   - Capabilities unreachable (agent down, no API key) → legacy pair.
-//   - Agent didn't surface BOTH gears (older agent that pre-dates
-//     access-log/logs probing) → legacy pair. We distinguish "the
-//     agent didn't tell us about this gear" (caps.Has == false) from
-//     "the agent said this gear is unavailable" (caps.Has == true,
-//     IsAvailable == false) so a forward-compatibility gap doesn't
-//     silently strip the source list.
-//   - Agent surfaced both gears and reported both unavailable → empty
-//     list. This is the only case the JS renders an empty dropdown
-//     and skips the immediate fetch — better than 5xx storming.
+//  1. **Structured resources**: when the access-log gear publishes
+//     `log_sources` in its agent-side Resources map (one entry per
+//     discovered web-server access log, with name + display_name +
+//     path), the dashboard surfaces that list verbatim. The agent is
+//     the single source of truth for which sources exist and what
+//     they're called.
+//  2. **Capability heuristic** (legacy fallback for pre-Phase-2
+//     agents): if the agent doesn't publish a `log_sources` resource,
+//     derive defaults from gear availability flags:
+//       - `haproxy` is offered when EITHER access-log OR logs gear is
+//         available
+//       - `system` is offered only when the `logs` gear is available
+//  3. **Fail-open** to the legacy `[haproxy, system]` pair when
+//     capabilities are unreachable (agent down, no API key) OR the
+//     agent doesn't surface either gear at all (older agent). Per
+//     the #116 fix we distinguish caps.Has() == false ("the agent
+//     doesn't know about this gear yet") from
+//     caps.IsAvailable() == false ("the agent says it's unavailable")
+//     so a forward-compat gap doesn't silently strip the dropdown.
+//  4. **Empty list**: only when the agent explicitly reports both
+//     gears unavailable. The JS renders an empty dropdown instead
+//     of 5xx-storming fetches.
 func (h *Handler) defaultLogSourcesForBox(boxID string) []map[string]string {
 	legacy := []map[string]string{
 		{"name": "haproxy", "display_name": "HAProxy"},
@@ -137,6 +144,11 @@ func (h *Handler) defaultLogSourcesForBox(boxID string) []map[string]string {
 	caps, ok := h.getBoxCapabilities(boxID)
 	if !ok {
 		return legacy
+	}
+
+	// Phase 2 preferred path: agent advertises its log sources directly.
+	if sources, ok := logSourcesFromResources(caps); ok {
+		return sources
 	}
 
 	knowsAccessLog := caps.Has("access-log")
@@ -161,4 +173,70 @@ func (h *Handler) defaultLogSourcesForBox(boxID string) []map[string]string {
 	// unavailable. JS renders an empty dropdown rather than 5xx-storming
 	// fetches for sources the agent can't serve.
 	return out
+}
+
+// logSourcesFromResources extracts the access-log gear's `log_sources`
+// resource (issue #112 Phase 2) and reshapes it into the dropdown
+// envelope the Logs page expects: `[{name, display_name}, …]`. The
+// `path` the agent publishes is intentionally dropped at this layer
+// because the dashboard doesn't expose log paths to the browser.
+//
+// Returns (nil, false) when:
+//   - the access-log gear isn't surfaced by the agent;
+//   - the `log_sources` key is missing from its Resources map;
+//   - the resource isn't shaped as the expected JSON array of objects.
+//
+// Returning false in those cases lets defaultLogSourcesForBox fall
+// through to the older capability heuristic instead of producing an
+// empty dropdown.
+//
+// JSON-decoding note: encoding/json decodes a JSON array as []any
+// where each member object is map[string]any. We also tolerate the
+// Go-typed []map[string]string shape so tests can build the
+// CapabilitiesResponse with concrete types without coercing through
+// json.Marshal/Unmarshal.
+func logSourcesFromResources(caps *agent.BoxCapabilities) ([]map[string]string, bool) {
+	raw, ok := caps.Resource("access-log", "log_sources")
+	if !ok {
+		return nil, false
+	}
+
+	var entries []map[string]string
+	switch v := raw.(type) {
+	case []any:
+		entries = make([]map[string]string, 0, len(v))
+		for _, item := range v {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := obj["name"].(string)
+			display, _ := obj["display_name"].(string)
+			if name == "" || display == "" {
+				continue
+			}
+			entries = append(entries, map[string]string{
+				"name":         name,
+				"display_name": display,
+			})
+		}
+	case []map[string]string:
+		entries = make([]map[string]string, 0, len(v))
+		for _, item := range v {
+			if item["name"] == "" || item["display_name"] == "" {
+				continue
+			}
+			entries = append(entries, map[string]string{
+				"name":         item["name"],
+				"display_name": item["display_name"],
+			})
+		}
+	default:
+		return nil, false
+	}
+
+	if len(entries) == 0 {
+		return nil, false
+	}
+	return entries, true
 }

--- a/gearbox/internal/framework/handler/api_logs_resources_test.go
+++ b/gearbox/internal/framework/handler/api_logs_resources_test.go
@@ -1,0 +1,132 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+)
+
+func boxCaps(entries map[string]agent.CapabilityEntry) *agent.BoxCapabilities {
+	return &agent.BoxCapabilities{
+		Response: &agent.CapabilitiesResponse{Gears: entries},
+	}
+}
+
+// TestLogSourcesFromResources_PreferredShape: when the access-log gear
+// publishes `log_sources` in the Resources map, the dropdown is built
+// directly from it. Issue #112 Phase 2 — the dashboard stops inferring
+// sources from gear-availability flags.
+func TestLogSourcesFromResources_PreferredShape(t *testing.T) {
+	caps := boxCaps(map[string]agent.CapabilityEntry{
+		"access-log": {
+			Status: "available",
+			Resources: map[string]any{
+				// Use the JSON-decoded shape to exercise the production path.
+				"log_sources": []any{
+					map[string]any{"name": "haproxy", "display_name": "HAProxy", "path": "/var/log/haproxy.log"},
+					map[string]any{"name": "nginx", "display_name": "nginx", "path": "/var/log/nginx/access.log"},
+				},
+			},
+		},
+	})
+
+	got, ok := logSourcesFromResources(caps)
+	if !ok {
+		t.Fatalf("logSourcesFromResources returned false; expected to consume the resource")
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(got), got)
+	}
+	if got[0]["name"] != "haproxy" || got[0]["display_name"] != "HAProxy" {
+		t.Errorf("first entry = %+v, want haproxy/HAProxy", got[0])
+	}
+	if _, hasPath := got[0]["path"]; hasPath {
+		t.Errorf("path field leaked through to dropdown shape: %+v", got[0])
+	}
+}
+
+// TestLogSourcesFromResources_GoTypedShape exercises the tolerated
+// alternate input shape — when tests or in-process callers construct
+// the resource as a Go-typed []map[string]string, the helper accepts
+// it without forcing a JSON round-trip.
+func TestLogSourcesFromResources_GoTypedShape(t *testing.T) {
+	caps := boxCaps(map[string]agent.CapabilityEntry{
+		"access-log": {
+			Status: "available",
+			Resources: map[string]any{
+				"log_sources": []map[string]string{
+					{"name": "caddy", "display_name": "Caddy", "path": "/var/log/caddy/access.log"},
+				},
+			},
+		},
+	})
+	got, ok := logSourcesFromResources(caps)
+	if !ok || len(got) != 1 || got[0]["name"] != "caddy" {
+		t.Fatalf("logSourcesFromResources for Go-typed shape = (%+v, %v), want one caddy entry", got, ok)
+	}
+}
+
+// TestLogSourcesFromResources_AccessLogGearMissing: an older agent
+// that doesn't surface the access-log gear at all yields (nil, false)
+// so the caller falls through to the capability heuristic instead of
+// returning an empty dropdown.
+func TestLogSourcesFromResources_AccessLogGearMissing(t *testing.T) {
+	caps := boxCaps(map[string]agent.CapabilityEntry{
+		"host":    {Status: "available"},
+		"metrics": {Status: "available"},
+	})
+	if got, ok := logSourcesFromResources(caps); ok {
+		t.Errorf("logSourcesFromResources for missing access-log = (%+v, true), want (nil, false)", got)
+	}
+}
+
+// TestLogSourcesFromResources_ResourceKeyMissing: the access-log gear
+// is surfaced but pre-Phase-2 — Resources map is nil or doesn't carry
+// log_sources. Caller falls through to the heuristic.
+func TestLogSourcesFromResources_ResourceKeyMissing(t *testing.T) {
+	caps := boxCaps(map[string]agent.CapabilityEntry{
+		"access-log": {
+			Status: "available",
+			Capabilities: map[string]string{
+				"nginx_log": "/var/log/nginx/access.log",
+			},
+		},
+	})
+	if got, ok := logSourcesFromResources(caps); ok {
+		t.Errorf("logSourcesFromResources for missing log_sources key = (%+v, true), want (nil, false)", got)
+	}
+}
+
+// TestLogSourcesFromResources_RejectsBadShape: a malformed payload
+// (string where an array was expected, or array of strings instead of
+// objects) yields (nil, false). Defensive — guards against future agent
+// changes producing the wrong shape.
+func TestLogSourcesFromResources_RejectsBadShape(t *testing.T) {
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"string instead of array", "haproxy,nginx"},
+		{"array of strings", []any{"haproxy", "nginx"}},
+		{"array of objects missing display_name", []any{
+			map[string]any{"name": "haproxy"},
+		}},
+		{"array of objects missing name", []any{
+			map[string]any{"display_name": "HAProxy"},
+		}},
+		{"empty array", []any{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			caps := boxCaps(map[string]agent.CapabilityEntry{
+				"access-log": {
+					Status:    "available",
+					Resources: map[string]any{"log_sources": c.val},
+				},
+			})
+			if got, ok := logSourcesFromResources(caps); ok {
+				t.Errorf("malformed %q accepted = (%+v, true), want (nil, false)", c.name, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Dashboard companion to agent PR #135. Teaches the Logs source picker to read the access-log gear's structured `log_sources` resource (issue #112 Phase 2) rather than inferring sources from gear-availability flags.

- `agent.CapabilityEntry` mirrors the new `resources` JSON field as `map[string]any`.
- `BoxCapabilities.Resource(gearName, key)` — small helper for typed resource lookup.
- `defaultLogSourcesForBox` resolution chain is now:
  1. Operator's saved per-box log-source settings (DB)
  2. Agent's structured `log_sources` resource (Phase 2)
  3. Capability heuristic (pre-Phase-2 fallback)
  4. Legacy `[haproxy, system]` (agent unreachable / forward-compat)
- The `path` field the agent publishes is dropped at this layer — dashboard doesn't expose log paths to the browser.

Phase 2 of #112. **Stacked on #116**; pairs with agent PR #135. Merge order: #116 → #135 → this PR.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -count=1 ./internal/framework/handler/... ./internal/framework/agent/...` clean
- [x] Nine new tests covering: JSON-decoded shape (production path), Go-typed shape (in-process tests), missing access-log gear, missing resource key, five malformed-payload variants
- [ ] After agent PR #135 deploys to mjolnir: visit `/logs?server=mjolnir` and confirm the dropdown is populated from the agent's published `log_sources`, not the legacy hardcoded pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)