### PR TITLE
fix(ci): remove accidental .claude/skills submodule gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ gearbox-agent/.env
 *.local.json
 .mcp.json
 
+# Claude Code per-developer state (commands/ and settings.local.json.example
+# are intentionally tracked; everything else is local-only)
+.claude/skills/
+.claude/worktrees/
+
 # Development
 .DS_Store
 *.swp


### PR DESCRIPTION
## Summary

- Commit [`015fd5e`](https://github.com/sarg3nt/gearbox/commit/015fd5e8f04ffe6aa2cd7ce6039cb1a8601e9ed4) (CSS layout fix) accidentally added `.claude/skills` to the tree as a submodule gitlink (mode `160000`) without a corresponding `.gitmodules` entry.
- This has been breaking [actions/checkout](https://github.com/actions/checkout) on every workflow that runs on `main`. The submodule-cleanup step in checkout v4/v6 hard-fails with `fatal: No url found for submodule path '.claude/skills' in .gitmodules`.
- Symptom on the workflows tab: **OpenSSF Scorecard has failed on every push and on the scheduled Sunday run since 2026-05-11** (~30 consecutive failures). Gitleaks and Trivy emit the same warning during their checkouts.
- Fix: drop the gitlink from the index and add `.claude/skills/` + `.claude/worktrees/` to `.gitignore` so per-developer agent state can't slip back into the tree. The intentionally-tracked `.claude/commands/` slash commands and `.claude/settings.local.json.example` are unaffected.

Example failing run: <https://github.com/sarg3nt/gearbox/actions/runs/25999377392>

## Test plan

- [ ] Scorecard run on this PR's push to `main` (after merge) succeeds end-to-end.
- [ ] No "fatal: No url found for submodule path" warnings in Trivy / Gitleaks checkouts after merge.
- [ ] `git ls-tree HEAD .claude/` no longer shows a `160000 commit` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)