### PR TITLE
feat(rotation): keyring phases 2–5 — recovery PR for orphaned stack

### DIFF
--- a/gearbox-agent/cmd/gearbox-agent/main.go
+++ b/gearbox-agent/cmd/gearbox-agent/main.go
@@ -542,7 +542,7 @@ func main() {
 	// backoff layered on top — see 2026-05 audit P1-7).
 	rateLimiter := middleware.DefaultRateLimiter(logger)
 	authBackoff := middleware.DefaultBackoffTracker(logger)
-	keyRingHandler := api.NewKeyRingHandler(server.KeyRing(), logger)
+	keyRingHandler := api.NewKeyRingHandler(server.KeyRing(), cfg.KeyRingPath, logger)
 	pluginRouter := server.Router().Group(func(r chi.Router) {
 		r.Use(middleware.RateLimitMiddleware(rateLimiter))
 		r.Use(middleware.APIKeyAuth(server.KeyRing(), logger, authBackoff))

--- a/gearbox-agent/internal/api/keyring.go
+++ b/gearbox-agent/internal/api/keyring.go
@@ -1,42 +1,58 @@
 package api
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
+	"sync"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/sarg3nt/gearbox-agent/internal/framework/crypto"
 )
 
-// KeyRingHandler exposes the agent's keyring metadata over the HTTP API.
-// Phase 1 ships only the read endpoint; Phase 2 adds install/use/remove
-// for the controller-driven three-phase rotation flow (issue #72).
+// KeyRingHandler exposes the agent's keyring metadata and rotation
+// endpoints over the HTTP API. The mutation endpoints (install/use/
+// remove) drive the controller-orchestrated three-phase rotation from
+// issue #72; the metadata endpoint is read-only.
 type KeyRingHandler struct {
 	keyring *crypto.KeyRingPointer
+	path    string
 	logger  *slog.Logger
+
+	// mu serializes mutation handlers — keyring writes are tmpfile+
+	// rename atomic on disk, but two concurrent installs racing would
+	// still let the second one's read-modify-write step lose the
+	// first one's changes.
+	mu sync.Mutex
 }
 
-// NewKeyRingHandler wires a handler around the agent's keyring pointer.
-func NewKeyRingHandler(keyring *crypto.KeyRingPointer, logger *slog.Logger) *KeyRingHandler {
-	return &KeyRingHandler{keyring: keyring, logger: logger}
+// NewKeyRingHandler wires a handler around the agent's keyring pointer
+// and the disk path the keyring is persisted to.
+func NewKeyRingHandler(keyring *crypto.KeyRingPointer, path string, logger *slog.Logger) *KeyRingHandler {
+	return &KeyRingHandler{keyring: keyring, path: path, logger: logger}
 }
 
 // RegisterRoutes mounts the keyring endpoints on r. The caller is
 // responsible for putting r behind the API-key auth middleware.
 func (h *KeyRingHandler) RegisterRoutes(r chi.Router) {
 	r.Get("/api/v1/system/keyring", h.handleGet)
+	r.Post("/api/v1/system/keyring/install", h.handleInstall)
+	r.Post("/api/v1/system/keyring/use", h.handleUse)
+	r.Delete("/api/v1/system/keyring/{kid}", h.handleRemove)
 }
 
-// keyRingResponse is what the API returns. Never includes secret bytes.
+// keyRingResponse is what GET returns. Never includes secret bytes.
 type keyRingResponse struct {
-	Version int                       `json:"version"`
-	Entries []crypto.KeyRingMetadata  `json:"entries"`
+	Version int                      `json:"version"`
+	Entries []crypto.KeyRingMetadata `json:"entries"`
 }
 
-// handleGet returns the keyring metadata — kids, roles, creation times,
-// and short fingerprints — but never the actual secrets.
+// handleGet returns keyring metadata — kids, roles, creation times,
+// fingerprints. Secrets are never exposed.
 //
 //	@Summary		Get agent keyring metadata
 //	@Description	Returns the currently-installed API keys' metadata. Secrets are NEVER exposed. The fingerprint is the first 8 hex chars of sha256(secret); useful to verify the dashboard has the same secret without round-tripping the secret itself.
@@ -61,8 +77,251 @@ func (h *KeyRingHandler) handleGet(w http.ResponseWriter, _ *http.Request) {
 		Version: kr.Version,
 		Entries: kr.Snapshot(),
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		h.logger.Error("encode keyring response failed", "error", err)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// installRequest is the install endpoint's body. Secret is base64url-
+// encoded raw bytes (the same encoding used in the on-wire token).
+type installRequest struct {
+	KID      string `json:"kid"`
+	SecretB64 string `json:"secret_b64"`
+	Role     string `json:"role"` // optional; defaults to "secondary"
+}
+
+// handleInstall adds a new entry to the keyring. Idempotent: re-
+// installing the same (kid, secret) pair is a no-op and returns 200.
+// Installing a different secret under an existing kid returns 409.
+//
+//	@Summary		Install a new keyring entry
+//	@Description	Adds a new accepted API key to the agent's keyring. New entries default to role=secondary; the controller calls /use to flip primary after confirming installation.
+//	@Tags			system
+//	@Security		BearerAuth
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		installRequest	true	"new key"
+//	@Success		200		{object}	keyRingResponse
+//	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		401		{string}	string	"Unauthorized"
+//	@Failure		409		{string}	string	"Conflict"
+//	@Failure		507		{string}	string	"Keyring full"
+//	@Router			/api/v1/system/keyring/install [post]
+func (h *KeyRingHandler) handleInstall(w http.ResponseWriter, r *http.Request) {
+	var req installRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
+	req.KID = strings.TrimSpace(req.KID)
+	if req.KID == "" || req.SecretB64 == "" {
+		writeError(w, http.StatusBadRequest, "kid and secret_b64 are required")
+		return
+	}
+	secret, err := base64.RawURLEncoding.DecodeString(req.SecretB64)
+	if err != nil || len(secret) != crypto.SecretLength {
+		writeError(w, http.StatusBadRequest, "secret_b64 must be base64url-encoded 32 random bytes")
+		return
+	}
+	role := req.Role
+	if role == "" {
+		role = "secondary"
+	}
+	if role != "primary" && role != "secondary" {
+		writeError(w, http.StatusBadRequest, "role must be 'primary' or 'secondary'")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	current := h.keyring.Load()
+	next := current.Clone()
+
+	// Idempotency: same (kid, secret) → 200 with current state. Same
+	// kid + different secret → 409. The controller treats both as
+	// "already done" but the 409 surfaces a state divergence to logs.
+	if existing := findEntry(current, req.KID); existing != nil {
+		if constantTimeEq(existing.Secret, secret) {
+			writeJSON(w, http.StatusOK, keyRingResponse{
+				Version: current.Version,
+				Entries: current.Snapshot(),
+			})
+			return
+		}
+		writeError(w, http.StatusConflict, "kid already exists with a different secret")
+		return
+	}
+
+	entry := crypto.KeyRingEntry{
+		KID:    req.KID,
+		Secret: secret,
+		Role:   role,
+	}
+	if err := next.Add(entry); err != nil {
+		if errors.Is(err, crypto.ErrKeyRingFull) {
+			writeError(w, http.StatusInsufficientStorage, "keyring at maximum capacity")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "add entry: "+err.Error())
+		return
+	}
+
+	if err := crypto.SaveKeyRing(h.path, next); err != nil {
+		h.logger.Error("save keyring", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist keyring")
+		return
+	}
+	h.keyring.Store(next)
+	h.logger.Info("keyring: installed entry", "kid", req.KID, "role", role)
+
+	writeJSON(w, http.StatusOK, keyRingResponse{
+		Version: next.Version,
+		Entries: next.Snapshot(),
+	})
+}
+
+// useRequest is the use endpoint's body.
+type useRequest struct {
+	KID string `json:"kid"`
+}
+
+// handleUse flips the named entry to role=primary and demotes the
+// existing primary to secondary. Both stay accepted; the agent doesn't
+// distinguish primary vs secondary for inbound auth purposes, but the
+// /keyring metadata response and the kid echoed in `X-Gearbox-Kid` let
+// the controller drive the overlap window correctly.
+//
+//	@Summary		Promote a keyring entry to primary
+//	@Description	Flips the named keyring entry's role to "primary" and demotes the prior primary to "secondary". Both keys remain valid for inbound auth.
+//	@Tags			system
+//	@Security		BearerAuth
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		useRequest	true	"target kid"
+//	@Success		200		{object}	keyRingResponse
+//	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		401		{string}	string	"Unauthorized"
+//	@Failure		404		{string}	string	"Unknown kid"
+//	@Router			/api/v1/system/keyring/use [post]
+func (h *KeyRingHandler) handleUse(w http.ResponseWriter, r *http.Request) {
+	var req useRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.KID = strings.TrimSpace(req.KID)
+	if req.KID == "" {
+		writeError(w, http.StatusBadRequest, "kid is required")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	next := h.keyring.Load().Clone()
+	if err := next.SetPrimary(req.KID); err != nil {
+		if errors.Is(err, crypto.ErrUnknownKID) {
+			writeError(w, http.StatusNotFound, "unknown kid")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "set primary: "+err.Error())
+		return
+	}
+
+	if err := crypto.SaveKeyRing(h.path, next); err != nil {
+		h.logger.Error("save keyring", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist keyring")
+		return
+	}
+	h.keyring.Store(next)
+	h.logger.Info("keyring: promoted to primary", "kid", req.KID)
+
+	writeJSON(w, http.StatusOK, keyRingResponse{
+		Version: next.Version,
+		Entries: next.Snapshot(),
+	})
+}
+
+// handleRemove deletes the named entry. Refuses to remove the only
+// remaining entry — an operator error otherwise bricks the box.
+//
+//	@Summary		Remove a keyring entry
+//	@Description	Deletes the named keyring entry. Refuses to remove the only remaining entry; the agent always retains at least one accepted key.
+//	@Tags			system
+//	@Security		BearerAuth
+//	@Param			kid	path	string	true	"key id"
+//	@Success		200	{object}	keyRingResponse
+//	@Failure		401	{string}	string	"Unauthorized"
+//	@Failure		404	{string}	string	"Unknown kid"
+//	@Failure		409	{string}	string	"Cannot remove last key"
+//	@Router			/api/v1/system/keyring/{kid} [delete]
+func (h *KeyRingHandler) handleRemove(w http.ResponseWriter, r *http.Request) {
+	kid := strings.TrimSpace(chi.URLParam(r, "kid"))
+	if kid == "" {
+		writeError(w, http.StatusBadRequest, "kid is required")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	next := h.keyring.Load().Clone()
+	if err := next.Remove(kid); err != nil {
+		switch {
+		case errors.Is(err, crypto.ErrUnknownKID):
+			writeError(w, http.StatusNotFound, "unknown kid")
+		case errors.Is(err, crypto.ErrCannotRemoveLast):
+			writeError(w, http.StatusConflict, "cannot remove the only remaining key")
+		default:
+			writeError(w, http.StatusInternalServerError, "remove: "+err.Error())
+		}
+		return
+	}
+
+	if err := crypto.SaveKeyRing(h.path, next); err != nil {
+		h.logger.Error("save keyring", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist keyring")
+		return
+	}
+	h.keyring.Store(next)
+	h.logger.Info("keyring: removed entry", "kid", kid)
+
+	writeJSON(w, http.StatusOK, keyRingResponse{
+		Version: next.Version,
+		Entries: next.Snapshot(),
+	})
+}
+
+// findEntry returns the entry with the given kid, or nil. Reads only
+// — does not lock; caller already holds the handler mutex.
+func findEntry(kr *crypto.KeyRing, kid string) *crypto.KeyRingEntry {
+	for i := range kr.Entries {
+		if kr.Entries[i].KID == kid {
+			return &kr.Entries[i]
+		}
+	}
+	return nil
+}
+
+// constantTimeEq compares two byte slices in constant time. Used by
+// the install-idempotency check so reinstalling under an existing kid
+// doesn't leak timing about the existing secret.
+func constantTimeEq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := range a {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
 }

--- a/gearbox-agent/internal/api/keyring_test.go
+++ b/gearbox-agent/internal/api/keyring_test.go
@@ -1,0 +1,317 @@
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sarg3nt/gearbox-agent/internal/framework/crypto"
+)
+
+func newKeyRingTestHandler(t *testing.T) (*KeyRingHandler, *chi.Mux, *crypto.KeyRingPointer, string) {
+	t.Helper()
+	t.Setenv("GEARBOX_AGENT_ENCRYPTION_KEY", "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+
+	// Seed with one entry so tests can start from a sane baseline.
+	kid, _ := crypto.NewKID()
+	secret, _ := crypto.NewSecret()
+	kr := &crypto.KeyRing{Version: 1, Entries: []crypto.KeyRingEntry{{
+		KID:       kid,
+		Secret:    secret,
+		SecretHex: hex.EncodeToString(secret),
+		Role:      "primary",
+		CreatedAt: time.Now().UTC(),
+	}}}
+	if err := crypto.SaveKeyRing(path, kr); err != nil {
+		t.Fatalf("SaveKeyRing: %v", err)
+	}
+
+	ptr := crypto.NewKeyRingPointer(kr)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := NewKeyRingHandler(ptr, path, logger)
+
+	r := chi.NewRouter()
+	h.RegisterRoutes(r)
+	return h, r, ptr, path
+}
+
+func TestKeyRing_Get_ReturnsMetadataNoSecrets(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/keyring", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !bytes.Contains(w.Body.Bytes(), []byte("entries")) {
+		t.Errorf("missing entries field: %s", body)
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("\"secret\"")) {
+		t.Errorf("response leaked secret field: %s", body)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("\"fingerprint\"")) {
+		t.Errorf("missing fingerprint field: %s", body)
+	}
+}
+
+func TestKeyRing_Install_AddsSecondary(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+
+	newSecret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid":        "abc123",
+		"secret_b64": base64.RawURLEncoding.EncodeToString(newSecret),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	kr := ptr.Load()
+	if len(kr.Entries) != 2 {
+		t.Fatalf("expected 2 entries after install, got %d", len(kr.Entries))
+	}
+	// Find the new one.
+	found := false
+	for _, e := range kr.Entries {
+		if e.KID == "abc123" {
+			if e.Role != "secondary" {
+				t.Errorf("new entry role = %q, want secondary", e.Role)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("new kid not in keyring: %+v", kr.Entries)
+	}
+}
+
+func TestKeyRing_Install_Idempotent(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+
+	newSecret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid":        "abc123",
+		"secret_b64": base64.RawURLEncoding.EncodeToString(newSecret),
+	})
+
+	// First install.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first install: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Same kid + same secret → 200, no-op.
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("second install (idempotent): status=%d, want 200", w.Code)
+	}
+}
+
+func TestKeyRing_Install_KIDClashDifferentSecret_409(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+
+	secretA, _ := crypto.NewSecret()
+	bodyA, _ := json.Marshal(map[string]string{
+		"kid": "shared", "secret_b64": base64.RawURLEncoding.EncodeToString(secretA),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(bodyA))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("install A: %d", w.Code)
+	}
+
+	secretB, _ := crypto.NewSecret()
+	bodyB, _ := json.Marshal(map[string]string{
+		"kid": "shared", "secret_b64": base64.RawURLEncoding.EncodeToString(secretB),
+	})
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(bodyB))
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("install B (collision): status=%d, want 409", w.Code)
+	}
+}
+
+func TestKeyRing_Install_BadSecretLength(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+	body, _ := json.Marshal(map[string]string{
+		"kid": "ok", "secret_b64": base64.RawURLEncoding.EncodeToString([]byte("short")),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestKeyRing_Use_FlipsPrimary(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+
+	// Add a secondary.
+	newSecret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid":        "v2",
+		"secret_b64": base64.RawURLEncoding.EncodeToString(newSecret),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Use it.
+	body, _ = json.Marshal(map[string]string{"kid": "v2"})
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/use", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("use: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	kr := ptr.Load()
+	primary := kr.Primary()
+	if primary == nil || primary.KID != "v2" {
+		t.Errorf("primary after use = %+v, want kid=v2", primary)
+	}
+}
+
+func TestKeyRing_Use_UnknownKID_404(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+	body, _ := json.Marshal(map[string]string{"kid": "nonexistent"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/use", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestKeyRing_Remove_OK(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+
+	// Add a secondary first.
+	secret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid": "v2", "secret_b64": base64.RawURLEncoding.EncodeToString(secret),
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body)))
+
+	if got := len(ptr.Load().Entries); got != 2 {
+		t.Fatalf("setup: entries = %d, want 2", got)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/system/keyring/v2", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: status=%d body=%s", w.Code, w.Body.String())
+	}
+	if got := len(ptr.Load().Entries); got != 1 {
+		t.Errorf("after delete: entries = %d, want 1", got)
+	}
+}
+
+func TestKeyRing_Remove_LastEntry_409(t *testing.T) {
+	_, r, ptr, _ := newKeyRingTestHandler(t)
+	kr := ptr.Load()
+	if len(kr.Entries) != 1 {
+		t.Fatalf("setup: want 1 entry, got %d", len(kr.Entries))
+	}
+	url := "/api/v1/system/keyring/" + kr.Entries[0].KID
+	req := httptest.NewRequest(http.MethodDelete, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", w.Code)
+	}
+}
+
+func TestKeyRing_Mutations_PersistAcrossReload(t *testing.T) {
+	_, r, ptr, path := newKeyRingTestHandler(t)
+
+	// Install + use a second key.
+	secret, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid": "v2", "secret_b64": base64.RawURLEncoding.EncodeToString(secret),
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body)))
+	useBody, _ := json.Marshal(map[string]string{"kid": "v2"})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/use", bytes.NewReader(useBody)))
+
+	// Reload from disk; the change should be there.
+	reloaded, _, err := crypto.LoadOrCreateKeyRing(path, "")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	prim := reloaded.Primary()
+	if prim == nil || prim.KID != "v2" {
+		t.Errorf("reloaded primary = %+v, want kid=v2", prim)
+	}
+
+	// In-memory pointer should match.
+	if got := ptr.Load().Primary().KID; got != "v2" {
+		t.Errorf("in-memory primary = %q", got)
+	}
+
+	// Verify the on-disk file mode is 0600 — secret files must not be
+	// world-readable even when GBE1 encryption isn't configured.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Errorf("file mode = %v, want 0600", st.Mode().Perm())
+	}
+}
+
+func TestKeyRing_Install_FullKeyRing_507(t *testing.T) {
+	_, r, _, _ := newKeyRingTestHandler(t)
+	// Seed already has 1 entry; fill to MaxKeyRingEntries.
+	for i := 0; i < crypto.MaxKeyRingEntries-1; i++ {
+		s, _ := crypto.NewSecret()
+		body, _ := json.Marshal(map[string]string{
+			"kid":        fmt.Sprintf("k%d", i),
+			"secret_b64": base64.RawURLEncoding.EncodeToString(s),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("install %d: status=%d body=%s", i, w.Code, w.Body.String())
+		}
+	}
+
+	// One more should overflow.
+	s, _ := crypto.NewSecret()
+	body, _ := json.Marshal(map[string]string{
+		"kid": "overflow", "secret_b64": base64.RawURLEncoding.EncodeToString(s),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/keyring/install", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInsufficientStorage {
+		t.Errorf("overflow install: status=%d, want 507", w.Code)
+	}
+}

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -616,6 +616,8 @@ func main() {
 			r.Post("/boxes/{id}/edit", h.HAProxyBoxUpdatePost)
 			r.Post("/boxes/{id}/delete", h.HAProxyBoxDeletePost)
 			r.Post("/boxes/{id}/toggle", h.HAProxyBoxTogglePost)
+			r.Post("/boxes/{id}/rotate-key", h.HAProxyBoxRotateKeyPost)
+			r.Post("/boxes/rotate-key-all", h.HAProxyBoxesRotateKeyAllPost)
 			r.Post("/boxes/test", h.HAProxyBoxTestConnectionPost)
 			r.Get("/boxes/{id}/logs", h.HAProxyBoxLogSettingsPage)
 			r.Post("/boxes/{id}/logs", h.HAProxyBoxLogSettingsPost)

--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	gbmiddleware "github.com/sarg3nt/gearbox/internal/framework/middleware"
 	"github.com/sarg3nt/gearbox/internal/framework/models"
 	"github.com/sarg3nt/gearbox/internal/framework/services"
+	"github.com/sarg3nt/gearbox/internal/framework/services/agent_keyring"
 	"github.com/sarg3nt/gearbox/internal/framework/services/alerts"
 	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
 	"github.com/sarg3nt/gearbox/internal/framework/services/email"
@@ -343,6 +344,24 @@ func main() {
 	alertEvaluator := alerts.NewEvaluator(db, registry, eventHub, logger)
 	alertEvaluator.Start(30 * time.Second) // Evaluate alerts every 30 seconds
 	logger.Info("alert evaluator initialized")
+
+	// Initialize retired-key cleaner. Each manual or scheduled rotation
+	// leaves the demoted key in box_agent_keys with retired_at stamped
+	// but role=secondary so the overlap window can preserve recovery.
+	// The cleaner walks every box every CleanerInterval and removes
+	// keys whose retired_at + overlap window has passed — both on the
+	// agent and in the DB. See issue #72 Phase 4.
+	keyringCleaner := agent_keyring.NewCleaner(
+		agent_keyring.New(db, encryptor, logger),
+		db,
+		agent_keyring.DefaultOverlapWindow,
+		agent_keyring.CleanerInterval,
+		logger,
+	)
+	keyringCleanerCtx, cancelKeyringCleaner := context.WithCancel(context.Background())
+	defer cancelKeyringCleaner()
+	go keyringCleaner.Run(keyringCleanerCtx)
+	logger.Info("retired-key cleaner initialized")
 
 	// Initialize WebSocket manager for Agent connections
 	wsManager := collector.NewWebSocketManager(eventHub, registry, logger)

--- a/gearbox/internal/framework/agent/client.go
+++ b/gearbox/internal/framework/agent/client.go
@@ -32,12 +32,59 @@ const (
 type Client struct {
 	baseURL    string
 	apiKey     string
+	kid        string // optional; when set, sent as X-Gearbox-Kid header
 	httpClient *http.Client
 }
+
+// HeaderKID is the request/response header name carrying the keyring
+// entry id. The agent's middleware echoes the matched kid on every
+// authenticated response (see middleware.ResponseHeaderKID); the
+// dashboard sends this kid on outbound requests so the agent + audit
+// log can correlate keys. Phase 5 (drift detection) compares the
+// request-time kid with the echoed response kid.
+const HeaderKID = "X-Gearbox-Kid"
 
 // NewClient creates a new HAProxy Agent API client.
 func NewClient(baseURL, apiKey string) *Client {
 	return NewClientWithTimeout(baseURL, apiKey, DefaultTimeout)
+}
+
+// NewClientWithKID creates a client that also identifies the keyring
+// entry it's signing with — the agent echoes back the matched kid in
+// X-Gearbox-Kid and the dashboard compares the two to detect rotation
+// drift. Empty kid is fine (legacy single-key boxes); the client just
+// won't send the header.
+func NewClientWithKID(baseURL, apiKey, kid string) *Client {
+	c := NewClient(baseURL, apiKey)
+	c.kid = kid
+	return c
+}
+
+// WithKID returns a shallow copy of c tagged with kid. Useful when a
+// short-lived client wants to be rebuilt to point at a different
+// keyring entry without re-doing TLS setup.
+func (c *Client) WithKID(kid string) *Client {
+	clone := *c
+	clone.kid = kid
+	return &clone
+}
+
+// KID returns the kid this client signs requests with, or "" if it
+// wasn't built with one. Used by the rotator and drift-detection
+// paths.
+func (c *Client) KID() string { return c.kid }
+
+// setAuthHeaders applies the standard auth + Accept headers and, when
+// the client was built with a kid, the X-Gearbox-Kid request header.
+// Callers must call this BEFORE setting Content-Type so their override
+// wins (the helper deliberately doesn't set Content-Type — varied
+// per-callsite based on whether the request has a body).
+func (c *Client) setAuthHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	if c.kid != "" {
+		req.Header.Set(HeaderKID, c.kid)
+	}
 }
 
 // NewClientWithTimeout creates a new HAProxy Agent API client with a custom timeout.
@@ -214,8 +261,7 @@ func (c *Client) doRequest(method, path string, query url.Values) ([]byte, error
 	}
 
 	// Add bearer token authentication
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -255,8 +301,7 @@ func (c *Client) doRequestLongRunning(method, path string, query url.Values) ([]
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(req)
 
 	// Use a separate client with extended timeout, sharing the same transport
 	longClient := &http.Client{
@@ -311,8 +356,7 @@ func (c *Client) doRequestWithBodyAndQuery(method, path string, reqBody interfac
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(req)
 	if reqBody != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -758,7 +802,7 @@ func (c *Client) DownloadCertificate(domain string) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	c.setAuthHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -1041,8 +1085,7 @@ func (c *Client) UpdateHAProxyConfig(req *HAProxyConfigUpdateRequest) (*HAProxyC
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	httpReq.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(httpReq)
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := c.httpClient.Do(httpReq)
@@ -1137,8 +1180,7 @@ func (c *Client) UpdateFirewallConfig(req *FirewallConfigUpdateRequest) (*Firewa
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	httpReq.Header.Set("Accept", "application/json")
+	c.setAuthHeaders(httpReq)
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := c.httpClient.Do(httpReq)

--- a/gearbox/internal/framework/agent/client.go
+++ b/gearbox/internal/framework/agent/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -33,6 +34,7 @@ type Client struct {
 	baseURL    string
 	apiKey     string
 	kid        string // optional; when set, sent as X-Gearbox-Kid header
+	onDrift    DriftHandler
 	httpClient *http.Client
 }
 
@@ -40,9 +42,34 @@ type Client struct {
 // entry id. The agent's middleware echoes the matched kid on every
 // authenticated response (see middleware.ResponseHeaderKID); the
 // dashboard sends this kid on outbound requests so the agent + audit
-// log can correlate keys. Phase 5 (drift detection) compares the
+// log can correlate keys. Drift detection (Phase 5) compares the
 // request-time kid with the echoed response kid.
 const HeaderKID = "X-Gearbox-Kid"
+
+// DriftHandler is invoked when the agent's echoed kid differs from
+// the kid the client sent. Implementations typically log + surface a
+// "rotation drift" banner; the default is to do nothing (set via
+// SetDriftHandler).
+//
+// expected = what the client sent on the request
+// actual   = what the agent echoed back on the response
+//
+// The handler is called on the request goroutine; cheap operations
+// only (logging is fine, network calls are not).
+type DriftHandler func(expected, actual string)
+
+// LogDriftHandler returns a DriftHandler that emits a structured
+// warn-level log line — the lowest-friction wiring for a long-lived
+// agent.Client. The "box_id" tag lets the operator filter the journal
+// to a single box.
+func LogDriftHandler(logger *slog.Logger, boxID int64) DriftHandler {
+	return func(expected, actual string) {
+		logger.Warn("rotation drift: agent matched a different kid than expected",
+			"box_id", boxID,
+			"expected_kid", expected,
+			"actual_kid", actual)
+	}
+}
 
 // NewClient creates a new HAProxy Agent API client.
 func NewClient(baseURL, apiKey string) *Client {
@@ -73,6 +100,29 @@ func (c *Client) WithKID(kid string) *Client {
 // wasn't built with one. Used by the rotator and drift-detection
 // paths.
 func (c *Client) KID() string { return c.kid }
+
+// SetDriftHandler installs a callback invoked when the agent's
+// echoed X-Gearbox-Kid response header differs from the kid the
+// client sent. Nil disables drift detection (the default).
+//
+// Use this on long-lived Client instances cached per box; the rotator
+// builds short-lived clients per call and wouldn't benefit from
+// installing a handler.
+func (c *Client) SetDriftHandler(h DriftHandler) { c.onDrift = h }
+
+// checkDrift inspects resp's X-Gearbox-Kid header against the kid the
+// client sent. Called from each doRequest* path on success. No-op when
+// the client has no kid or no handler is installed.
+func (c *Client) checkDrift(resp *http.Response) {
+	if resp == nil || c.kid == "" || c.onDrift == nil {
+		return
+	}
+	actual := resp.Header.Get(HeaderKID)
+	if actual == "" || actual == c.kid {
+		return
+	}
+	c.onDrift(c.kid, actual)
+}
 
 // setAuthHeaders applies the standard auth + Accept headers and, when
 // the client was built with a kid, the X-Gearbox-Kid request header.
@@ -135,14 +185,37 @@ func NewClientWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client
 		},
 	}
 
-	return &Client{
+	c := &Client{
 		baseURL: baseURL,
 		apiKey:  apiKey,
-		httpClient: &http.Client{
-			Timeout:   timeout,
-			Transport: transport,
-		},
 	}
+	c.httpClient = &http.Client{
+		Timeout: timeout,
+		// Wrap the base transport so every response is inspected for the
+		// X-Gearbox-Kid header against c.kid. The transport reads c.kid
+		// and c.onDrift at RoundTrip time, so SetDriftHandler is reflected
+		// immediately without rebuilding the client.
+		Transport: &kidObservingTransport{base: transport, c: c},
+	}
+	return c
+}
+
+// kidObservingTransport wraps an http.RoundTripper and invokes the
+// owning Client's checkDrift on every successful response. Implements
+// the drift-detection half of Phase 5 (issue #72) — the dashboard
+// learns immediately when an agent's matched kid disagrees with the
+// kid the dashboard sent, signalling a partial rotation.
+type kidObservingTransport struct {
+	base http.RoundTripper
+	c    *Client
+}
+
+func (t *kidObservingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err == nil {
+		t.c.checkDrift(resp)
+	}
+	return resp, err
 }
 
 // BuildTLSConfig is the exported alias for createTLSConfig — used by

--- a/gearbox/internal/framework/agent/client_drift_test.go
+++ b/gearbox/internal/framework/agent/client_drift_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDriftHandler_FiresOnKIDMismatch(t *testing.T) {
+	// Mock agent that always echoes a hard-coded kid in the response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderKID, "actual-kid")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithKID(srv.URL, "ignored", "expected-kid")
+	var fired atomic.Bool
+	var seenExpected, seenActual string
+	c.SetDriftHandler(func(expected, actual string) {
+		fired.Store(true)
+		seenExpected, seenActual = expected, actual
+	})
+
+	if _, err := c.doRequest("GET", "/anything", url.Values{}); err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	if !fired.Load() {
+		t.Errorf("drift handler not invoked")
+	}
+	if seenExpected != "expected-kid" || seenActual != "actual-kid" {
+		t.Errorf("drift handler args: expected=%q actual=%q", seenExpected, seenActual)
+	}
+}
+
+func TestDriftHandler_DoesNotFireOnMatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderKID, "matched")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithKID(srv.URL, "ignored", "matched")
+	var fired atomic.Bool
+	c.SetDriftHandler(func(_, _ string) { fired.Store(true) })
+
+	if _, err := c.doRequest("GET", "/anything", url.Values{}); err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	if fired.Load() {
+		t.Errorf("drift handler incorrectly invoked on matching kid")
+	}
+}
+
+func TestDriftHandler_DoesNotFireWhenAgentDoesNotEchoKID(t *testing.T) {
+	// Older agents won't set X-Gearbox-Kid. The drift handler should
+	// stay silent rather than flagging every response as "drift".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithKID(srv.URL, "ignored", "expected-kid")
+	var fired atomic.Bool
+	c.SetDriftHandler(func(_, _ string) { fired.Store(true) })
+
+	if _, err := c.doRequest("GET", "/anything", url.Values{}); err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	if fired.Load() {
+		t.Errorf("drift handler incorrectly invoked when agent sent no kid header")
+	}
+}
+
+func TestDriftHandler_DoesNotFireWhenClientHasNoKID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderKID, "something")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "ignored") // no kid
+	var fired atomic.Bool
+	c.SetDriftHandler(func(_, _ string) { fired.Store(true) })
+
+	if _, err := c.doRequest("GET", "/anything", url.Values{}); err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	if fired.Load() {
+		t.Errorf("drift handler invoked when client has no kid; should no-op")
+	}
+}

--- a/gearbox/internal/framework/agent/client_test.go
+++ b/gearbox/internal/framework/agent/client_test.go
@@ -579,7 +579,11 @@ func TestClientTimeout(t *testing.T) {
 		t.Fatal("expected timeout error")
 	}
 
-	if !strings.Contains(err.Error(), "context deadline exceeded") && !strings.Contains(err.Error(), "timeout") {
+	// The error message format varies by Go version + timing: sometimes
+	// "context deadline exceeded", sometimes "Client.Timeout exceeded
+	// while awaiting headers" (capital T). Match either by lower-casing.
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "context deadline exceeded") && !strings.Contains(msg, "timeout") {
 		t.Errorf("expected timeout error, got %v", err)
 	}
 }

--- a/gearbox/internal/framework/agent/keyring.go
+++ b/gearbox/internal/framework/agent/keyring.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// KeyRingMetadataEntry is the dashboard-side mirror of the agent's
+// crypto.KeyRingMetadata. Kept in this package so the dashboard
+// doesn't need to import the agent's internal crypto package.
+type KeyRingMetadataEntry struct {
+	KID         string    `json:"kid"`
+	Role        string    `json:"role"`
+	CreatedAt   time.Time `json:"created_at"`
+	Fingerprint string    `json:"fingerprint"`
+}
+
+// KeyRingResponse is the body shape of GET /api/v1/system/keyring and
+// the response to the mutation endpoints. Secrets are never present.
+type KeyRingResponse struct {
+	Version int                    `json:"version"`
+	Entries []KeyRingMetadataEntry `json:"entries"`
+}
+
+// KeyRingGet returns the agent's keyring metadata. Used by the
+// dashboard rotator to verify the post-rotation state matches its
+// expectation, and by drift detection (Phase 5).
+func (c *Client) KeyRingGet() (*KeyRingResponse, error) {
+	body, err := c.doRequest("GET", "/api/v1/system/keyring", url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse keyring response: %w", err)
+	}
+	return &resp, nil
+}
+
+// KeyRingInstall adds a new entry to the agent's keyring. Idempotent
+// when (kid, secret) match an existing entry; returns ConflictError
+// (HTTP 409) when kid clashes with a different secret.
+//
+// secret must be exactly 32 random bytes — caller's responsibility.
+func (c *Client) KeyRingInstall(kid string, secret []byte, role string) (*KeyRingResponse, error) {
+	if role == "" {
+		role = "secondary"
+	}
+	reqBody := map[string]string{
+		"kid":        kid,
+		"secret_b64": base64.RawURLEncoding.EncodeToString(secret),
+		"role":       role,
+	}
+	body, err := c.doRequestWithBody("POST", "/api/v1/system/keyring/install", reqBody)
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse install response: %w", err)
+	}
+	return &resp, nil
+}
+
+// KeyRingUse promotes the named keyring entry to primary. The previous
+// primary becomes secondary (still accepted for inbound auth).
+func (c *Client) KeyRingUse(kid string) (*KeyRingResponse, error) {
+	body, err := c.doRequestWithBody("POST", "/api/v1/system/keyring/use", map[string]string{"kid": kid})
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse use response: %w", err)
+	}
+	return &resp, nil
+}
+
+// KeyRingDelete removes the named keyring entry. Returns an APIError
+// with status 409 when called on the only remaining entry — the agent
+// refuses to brick itself.
+func (c *Client) KeyRingDelete(kid string) (*KeyRingResponse, error) {
+	body, err := c.doRequest("DELETE", "/api/v1/system/keyring/"+url.PathEscape(kid), url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	var resp KeyRingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse delete response: %w", err)
+	}
+	return &resp, nil
+}

--- a/gearbox/internal/framework/database/box_agent_keys.go
+++ b/gearbox/internal/framework/database/box_agent_keys.go
@@ -120,11 +120,14 @@ func (d *DB) SetBoxPrimaryKey(boxID int64, kid string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Demote current primary.
+	// Demote current primary. Use a Go-side UTC timestamp instead of
+	// SQLite's CURRENT_TIMESTAMP to avoid timezone-parsing differences
+	// between drivers (modernc.org/sqlite scans bare DATETIMEs as
+	// local, which compares wrong against a UTC time.Now() in Go).
 	if _, err := tx.Exec(`
-		UPDATE box_agent_keys SET role = 'secondary', retired_at = CURRENT_TIMESTAMP
+		UPDATE box_agent_keys SET role = 'secondary', retired_at = ?
 		WHERE box_id = ? AND role = 'primary'
-	`, boxID); err != nil {
+	`, time.Now().UTC(), boxID); err != nil {
 		return fmt.Errorf("demote primary: %w", err)
 	}
 

--- a/gearbox/internal/framework/handler/haproxy_rotate_key.go
+++ b/gearbox/internal/framework/handler/haproxy_rotate_key.go
@@ -1,0 +1,123 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sarg3nt/gearbox/internal/framework/services/agent_keyring"
+)
+
+// HAProxyBoxRotateKeyPost rotates the API key for a single box via the
+// install -> use -> mark-retired three-phase dance. The old key stays
+// accepted on the agent until the overlap window elapses; an explicit
+// cleanup step (manual or scheduled) removes it after that.
+//
+// Wired at POST /settings/boxes/{id}/rotate-key. Body is empty; the
+// only input is the box id from the path.
+//
+// Response: 200 with {"success":true, "new_kid":..., "old_kid":...,
+// "retire_after": "..."} or 4xx/5xx with {"success":false, "message":
+// ...}.
+func (h *Handler) HAProxyBoxRotateKeyPost(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeRotateError(w, http.StatusBadRequest, "invalid box id")
+		return
+	}
+
+	encryptor, err := h.getEncryptor()
+	if err != nil {
+		h.logger.Error("rotate-key: getEncryptor", "error", err)
+		writeRotateError(w, http.StatusInternalServerError, "encryption unavailable")
+		return
+	}
+
+	rotator := agent_keyring.New(h.db, encryptor, h.logger)
+
+	result, err := rotator.RotateBox(id, agent_keyring.DefaultOverlapWindow)
+	if err != nil {
+		h.logger.Warn("rotate-key: failed", "box_id", id, "error", err)
+		writeRotateError(w, http.StatusBadGateway, "rotation failed: "+err.Error())
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"success":      true,
+		"new_kid":      result.NewKID,
+		"old_kid":      result.OldKID,
+		"retire_after": result.RetireAfter,
+	})
+}
+
+// HAProxyBoxesRotateKeyAllPost rotates every enabled box sequentially
+// with a small stagger between rotations (avoids hammering the
+// agents). Reports per-box outcomes; the operator sees which boxes
+// succeeded and which failed and can act on each.
+//
+// Wired at POST /settings/boxes/rotate-key-all. Body is empty.
+func (h *Handler) HAProxyBoxesRotateKeyAllPost(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	encryptor, err := h.getEncryptor()
+	if err != nil {
+		h.logger.Error("rotate-all: getEncryptor", "error", err)
+		writeRotateError(w, http.StatusInternalServerError, "encryption unavailable")
+		return
+	}
+
+	boxes, err := h.db.GetEnabledBoxes()
+	if err != nil {
+		h.logger.Error("rotate-all: list boxes", "error", err)
+		writeRotateError(w, http.StatusInternalServerError, "failed to list boxes")
+		return
+	}
+
+	rotator := agent_keyring.New(h.db, encryptor, h.logger)
+
+	type boxResult struct {
+		BoxID   int64  `json:"box_id"`
+		Name    string `json:"name"`
+		Success bool   `json:"success"`
+		NewKID  string `json:"new_kid,omitempty"`
+		OldKID  string `json:"old_kid,omitempty"`
+		Error   string `json:"error,omitempty"`
+	}
+	results := make([]boxResult, 0, len(boxes))
+	successCount := 0
+	for _, box := range boxes {
+		out := boxResult{BoxID: box.ID, Name: box.Name}
+		rr, rerr := rotator.RotateBox(box.ID, agent_keyring.DefaultOverlapWindow)
+		if rerr != nil {
+			out.Success = false
+			out.Error = rerr.Error()
+			h.logger.Warn("rotate-all: box failed", "box_id", box.ID, "name", box.Name, "error", rerr)
+		} else {
+			out.Success = true
+			out.NewKID = rr.NewKID
+			out.OldKID = rr.OldKID
+			successCount++
+		}
+		results = append(results, out)
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"success":  successCount == len(boxes),
+		"rotated":  successCount,
+		"total":    len(boxes),
+		"results":  results,
+	})
+}
+
+func writeRotateError(w http.ResponseWriter, status int, msg string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"success": false,
+		"message": msg,
+	})
+}

--- a/gearbox/internal/framework/services/agent_keyring/cleaner.go
+++ b/gearbox/internal/framework/services/agent_keyring/cleaner.go
@@ -1,0 +1,111 @@
+package agent_keyring
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+)
+
+// CleanerInterval is the cadence at which RetiredKeyCleaner walks the
+// fleet looking for keys whose retired_at + overlap window has passed.
+// One hour is a sensible default: short enough that a 24-hour overlap
+// rotation cleans up within a few hours of its target, long enough that
+// the sweep is cheap (one DB query per box, one DELETE per agent).
+const CleanerInterval = 1 * time.Hour
+
+// RetiredKeyCleaner is a background service that periodically walks
+// every box and asks the Rotator to remove any keys whose retired_at
+// is older than the overlap window. The Phase 3 manual-rotate buttons
+// stamp retired_at but don't remove the old key — the cleaner does, so
+// retired keys don't linger forever after a rotation.
+//
+// Phase 4 in the original plan also covered auto-rotation on a
+// schedule; that needs a new global-settings surface in the dashboard
+// (the dashboard doesn't have one yet for app-level config) and is
+// intentionally deferred to a follow-up. The cleaner is the smaller
+// piece that's genuinely needed regardless of whether auto-rotation
+// is enabled.
+type RetiredKeyCleaner struct {
+	rotator       *Rotator
+	db            *database.DB
+	overlapWindow time.Duration
+	interval      time.Duration
+	logger        *slog.Logger
+}
+
+// NewCleaner builds a cleaner around an existing rotator. Pass
+// overlapWindow=0 to use DefaultOverlapWindow; interval=0 → CleanerInterval.
+func NewCleaner(rotator *Rotator, db *database.DB, overlapWindow, interval time.Duration, logger *slog.Logger) *RetiredKeyCleaner {
+	if overlapWindow <= 0 {
+		overlapWindow = DefaultOverlapWindow
+	}
+	if interval <= 0 {
+		interval = CleanerInterval
+	}
+	return &RetiredKeyCleaner{
+		rotator:       rotator,
+		db:            db,
+		overlapWindow: overlapWindow,
+		interval:      interval,
+		logger:        logger,
+	}
+}
+
+// Run blocks until ctx is cancelled. Sweeps once immediately on start
+// so a freshly-deployed dashboard catches up on any retired keys left
+// over from manual rotations done while the previous instance was
+// down, then ticks every interval.
+//
+// Errors are logged but not propagated — one bad box shouldn't break
+// the fleet sweep, and we don't want to spam fatal errors at startup
+// for a transient agent outage.
+func (c *RetiredKeyCleaner) Run(ctx context.Context) {
+	c.logger.Info("retired-key cleaner started",
+		"interval", c.interval,
+		"overlap_window", c.overlapWindow)
+
+	c.sweepOnce(ctx)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("retired-key cleaner stopped")
+			return
+		case <-ticker.C:
+			c.sweepOnce(ctx)
+		}
+	}
+}
+
+func (c *RetiredKeyCleaner) sweepOnce(ctx context.Context) {
+	boxes, err := c.db.GetEnabledBoxes()
+	if err != nil {
+		c.logger.Warn("cleaner: failed to list boxes", "error", err)
+		return
+	}
+
+	total := 0
+	for _, box := range boxes {
+		if ctx.Err() != nil {
+			return
+		}
+		removed, err := c.rotator.CleanupRetiredKeys(box.ID, c.overlapWindow)
+		if err != nil {
+			c.logger.Warn("cleaner: box sweep failed",
+				"box_id", box.ID, "name", box.Name, "error", err)
+			continue
+		}
+		if removed > 0 {
+			c.logger.Info("cleaner: swept retired keys",
+				"box_id", box.ID, "name", box.Name, "removed", removed)
+			total += removed
+		}
+	}
+	if total > 0 {
+		c.logger.Info("cleaner: sweep complete", "total_removed", total)
+	}
+}

--- a/gearbox/internal/framework/services/agent_keyring/cleaner_test.go
+++ b/gearbox/internal/framework/services/agent_keyring/cleaner_test.go
@@ -1,0 +1,67 @@
+package agent_keyring
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCleaner_RemovesRetiredKeyOnTick(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+	if _, err := rotator.RotateBox(box.ID, 24*time.Hour); err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+	if mock.entryCount() != 2 {
+		t.Fatalf("post-rotation agent entries = %d, want 2", mock.entryCount())
+	}
+
+	// Tiny overlap + tiny interval so the cleaner sweeps quickly and
+	// considers the just-retired legacy entry eligible.
+	cleaner := NewCleaner(rotator, db, 1*time.Millisecond, 20*time.Millisecond, rotator.logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		cleaner.Run(ctx)
+		close(done)
+	}()
+
+	// Give it time for the immediate-on-start sweep to fire.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := mock.entryCount(); got != 1 {
+		t.Errorf("agent entries after cleaner sweep = %d, want 1", got)
+	}
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 1 {
+		t.Errorf("db keys after cleaner sweep = %d, want 1", len(keys))
+	}
+}
+
+func TestCleaner_NoopWhenNothingRetired(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+	// No rotation = no retired keys. Cleaner sweep should leave the
+	// single legacy primary alone.
+
+	cleaner := NewCleaner(rotator, db, 1*time.Millisecond, 1*time.Hour, rotator.logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		cleaner.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := mock.entryCount(); got != 1 {
+		t.Errorf("mock entries = %d, want 1", got)
+	}
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 1 {
+		t.Errorf("db keys = %d, want 1", len(keys))
+	}
+}

--- a/gearbox/internal/framework/services/agent_keyring/keygen.go
+++ b/gearbox/internal/framework/services/agent_keyring/keygen.go
@@ -1,0 +1,41 @@
+package agent_keyring
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+const (
+	// SecretLength matches the agent's crypto.SecretLength — 32 bytes
+	// / 256 bits, the AES-256 entropy floor.
+	SecretLength = 32
+
+	// KIDByteLength is the random bytes used to derive a kid. 3 bytes
+	// hex-encoded → 6-char kid, same as the agent's NewKID.
+	KIDByteLength = 3
+)
+
+// newKID returns a fresh 6-hex-char keyring entry id.
+func newKID() (string, error) {
+	b := make([]byte, KIDByteLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// newSecret returns 32 cryptographically-random bytes.
+func newSecret() ([]byte, error) {
+	b := make([]byte, SecretLength)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// base64URLNoPad mirrors the agent's wire format — base64url, no
+// padding, applied to the raw secret bytes.
+func base64URLNoPad(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/gearbox/internal/framework/services/agent_keyring/rotator.go
+++ b/gearbox/internal/framework/services/agent_keyring/rotator.go
@@ -1,0 +1,249 @@
+// Package agent_keyring orchestrates the three-phase
+// install -> use -> remove rotation flow against the agent's
+// /api/v1/system/keyring endpoints (issue #72).
+//
+// The rotator never deletes the old key until an explicit cleanup
+// step fires — that's the "overlap window" property that lets a
+// rotation survive a controller crash mid-dance. While both keys
+// coexist on the agent, the dashboard signs with the new one and the
+// agent accepts either, so an interrupted rotation degrades to "two
+// working keys, slightly noisier audit log" rather than "agent locked
+// out".
+package agent_keyring
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/agent"
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	"github.com/sarg3nt/gearbox/internal/framework/services/crypto"
+)
+
+// DefaultOverlapWindow is the time that elapses between flipping
+// primary and being eligible to remove the old key. 24h chosen to be
+// long enough to survive operator-overnight outages but short enough
+// to keep secondaries from accumulating. Configurable per-call.
+const DefaultOverlapWindow = 24 * time.Hour
+
+// Rotator coordinates the install->use->remove dance for a single box.
+// Holds no state beyond the DB + encryptor + logger; every call is
+// reentrant and safe to invoke from concurrent goroutines (DB-level
+// locking guards the transactional pieces).
+type Rotator struct {
+	db        *database.DB
+	encryptor *crypto.Encryptor
+	logger    *slog.Logger
+}
+
+// New builds a Rotator. encryptor decrypts box secrets so the rotator
+// can build an authenticated agent.Client; db carries the state.
+func New(db *database.DB, encryptor *crypto.Encryptor, logger *slog.Logger) *Rotator {
+	return &Rotator{db: db, encryptor: encryptor, logger: logger}
+}
+
+// RotationResult summarises a successful rotation.
+type RotationResult struct {
+	NewKID      string
+	OldKID      string
+	RetireAfter time.Time // when CleanupRetiredKeys would remove the old key
+}
+
+// RotateBox runs the three-phase rotation against the box's agent:
+//
+//  1. Generate a fresh (kid, secret).
+//  2. Call agent's keyring/install with role=secondary. Agent now
+//     accepts both keys.
+//  3. Insert the new entry into box_agent_keys (still secondary).
+//  4. Call agent's keyring/use { kid: new }. Agent's primary flips;
+//     both keys remain accepted.
+//  5. In a DB transaction, flip the row's role to primary and stamp
+//     retired_at on the previous primary.
+//
+// Returns the rotation result with the new and old kids and the time
+// at which the old key becomes eligible for removal (default 24h).
+//
+// Failure handling is by intent simple: if any step errors the caller
+// gets it; both old and new keys remain accepted on the agent (since
+// install is idempotent and use is idempotent), so retrying is safe.
+// The user-facing rotate button surfaces the error.
+func (r *Rotator) RotateBox(boxID int64, overlapWindow time.Duration) (*RotationResult, error) {
+	if overlapWindow <= 0 {
+		overlapWindow = DefaultOverlapWindow
+	}
+
+	box, err := r.db.GetBoxByID(boxID)
+	if err != nil {
+		return nil, fmt.Errorf("load box: %w", err)
+	}
+	if box == nil {
+		return nil, fmt.Errorf("box %d not found", boxID)
+	}
+
+	current, err := r.db.GetBoxPrimaryKey(boxID)
+	if err != nil {
+		return nil, fmt.Errorf("load current primary: %w", err)
+	}
+	if current == nil {
+		return nil, fmt.Errorf("box %d has no primary key — bootstrap a key first", boxID)
+	}
+
+	client, err := r.clientForKey(box.AgentURL, current)
+	if err != nil {
+		return nil, fmt.Errorf("build agent client: %w", err)
+	}
+
+	// Generate the new key.
+	newKID, err := newKID()
+	if err != nil {
+		return nil, fmt.Errorf("generate kid: %w", err)
+	}
+	newSecret, err := newSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate secret: %w", err)
+	}
+	r.logger.Info("rotation: starting", "box_id", boxID, "old_kid", current.KID, "new_kid", newKID)
+
+	// Step 1 — install on the agent as secondary.
+	if _, err := client.KeyRingInstall(newKID, newSecret, "secondary"); err != nil {
+		return nil, fmt.Errorf("agent install: %w", err)
+	}
+
+	// Step 2 — persist the new key on our side. The on-disk format
+	// matches the existing legacy entry: AES-256-GCM ciphertext of the
+	// 64-char hex form of the secret, so callers can decrypt uniformly.
+	encrypted, err := r.encryptor.EncryptString(hex.EncodeToString(newSecret))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt new secret: %w", err)
+	}
+	if err := r.db.InsertBoxAgentKey(&database.BoxAgentKey{
+		BoxID:           boxID,
+		KID:             newKID,
+		SecretEncrypted: encrypted,
+		Role:            "secondary",
+	}); err != nil {
+		return nil, fmt.Errorf("insert new key row: %w", err)
+	}
+
+	// Step 3 — flip primary on the agent. Both keys remain accepted.
+	if _, err := client.KeyRingUse(newKID); err != nil {
+		return nil, fmt.Errorf("agent use: %w", err)
+	}
+
+	// Step 4 — flip primary in our DB. Demoted entry gets retired_at
+	// stamped so CleanupRetiredKeys can sweep it once overlapWindow
+	// elapses.
+	if err := r.db.SetBoxPrimaryKey(boxID, newKID); err != nil {
+		return nil, fmt.Errorf("flip db primary: %w", err)
+	}
+
+	r.logger.Info("rotation: success",
+		"box_id", boxID, "old_kid", current.KID, "new_kid", newKID,
+		"retire_after", time.Now().Add(overlapWindow))
+
+	return &RotationResult{
+		NewKID:      newKID,
+		OldKID:      current.KID,
+		RetireAfter: time.Now().Add(overlapWindow),
+	}, nil
+}
+
+// CleanupRetiredKeys removes secondary keys whose retired_at is older
+// than overlapWindow. Called from the manual rotate path (immediately
+// after a rotation isn't ready to clean up; the operator clicks again
+// later, or Phase 4's scheduler does it on a tick).
+//
+// Returns the number of keys removed.
+func (r *Rotator) CleanupRetiredKeys(boxID int64, overlapWindow time.Duration) (int, error) {
+	if overlapWindow <= 0 {
+		overlapWindow = DefaultOverlapWindow
+	}
+
+	box, err := r.db.GetBoxByID(boxID)
+	if err != nil {
+		return 0, fmt.Errorf("load box: %w", err)
+	}
+	if box == nil {
+		return 0, fmt.Errorf("box %d not found", boxID)
+	}
+	primary, err := r.db.GetBoxPrimaryKey(boxID)
+	if err != nil {
+		return 0, fmt.Errorf("load primary: %w", err)
+	}
+	if primary == nil {
+		return 0, fmt.Errorf("box %d has no primary key", boxID)
+	}
+
+	all, err := r.db.GetBoxAgentKeys(boxID)
+	if err != nil {
+		return 0, fmt.Errorf("load keys: %w", err)
+	}
+
+	client, err := r.clientForKey(box.AgentURL, primary)
+	if err != nil {
+		return 0, fmt.Errorf("build agent client: %w", err)
+	}
+
+	removed := 0
+	for _, k := range all {
+		if k.Role == "primary" {
+			continue
+		}
+		if !k.RetiredAt.Valid {
+			continue
+		}
+		// time.Since uses the underlying instant, not the wall-clock zone,
+		// so this comparison is correct even when the SQLite driver
+		// scanned retired_at as a different (or "naive") timezone.
+		if time.Since(k.RetiredAt.Time) < overlapWindow {
+			continue
+		}
+
+		// Best-effort: remove from agent first, then DB. If the agent
+		// 404s, the row is stale and we can still drop our side.
+		if _, err := client.KeyRingDelete(k.KID); err != nil {
+			if !isNotFoundOrConflict(err) {
+				r.logger.Warn("cleanup: agent delete failed; leaving DB row",
+					"box_id", boxID, "kid", k.KID, "error", err)
+				continue
+			}
+		}
+		if err := r.db.DeleteBoxAgentKey(boxID, k.KID); err != nil {
+			r.logger.Warn("cleanup: db delete failed", "box_id", boxID, "kid", k.KID, "error", err)
+			continue
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// clientForKey decrypts the given key entry and builds an authenticated
+// agent.Client tagged with its kid (so X-Gearbox-Kid gets echoed back).
+func (r *Rotator) clientForKey(agentURL string, key *database.BoxAgentKey) (*agent.Client, error) {
+	hexSecret, err := r.encryptor.DecryptString(key.SecretEncrypted)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt secret: %w", err)
+	}
+	secret, err := hex.DecodeString(hexSecret)
+	if err != nil {
+		return nil, fmt.Errorf("decode secret: %w", err)
+	}
+	// Agent accepts both legacy 64-hex and prefixed gbx_<kid>_<b64>;
+	// always send the prefixed form so the audit log sees a real kid.
+	token := "gbx_" + key.KID + "_" + base64URLNoPad(secret)
+	return agent.NewClientWithKID(agentURL, token, key.KID), nil
+}
+
+// isNotFoundOrConflict is true for APIError 404 / 409 — meaning the
+// agent already doesn't have the key (404) or refused because it's the
+// only one left (409). Both are tolerable during cleanup.
+func isNotFoundOrConflict(err error) bool {
+	var apiErr *agent.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == 404 || apiErr.StatusCode == 409
+}

--- a/gearbox/internal/framework/services/agent_keyring/rotator_test.go
+++ b/gearbox/internal/framework/services/agent_keyring/rotator_test.go
@@ -1,0 +1,326 @@
+package agent_keyring
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sarg3nt/gearbox/internal/framework/database"
+	dashcrypto "github.com/sarg3nt/gearbox/internal/framework/services/crypto"
+)
+
+// agentMock fakes the subset of the agent's /api/v1/system/keyring/*
+// surface the rotator hits. It keeps a thread-safe in-memory keyring
+// and mimics the install/use/remove behaviour so rotator orchestration
+// can be tested without importing the agent module.
+type agentMock struct {
+	mu      sync.Mutex
+	entries []agentEntry
+}
+
+type agentEntry struct {
+	KID       string `json:"kid"`
+	SecretB64 string `json:"secret_b64,omitempty"`
+	Secret    []byte `json:"-"`
+	Role      string `json:"role"`
+}
+
+func (a *agentMock) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/system/keyring":
+			a.handleGet(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/keyring/install":
+			a.handleInstall(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/keyring/use":
+			a.handleUse(w, r)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/system/keyring/"):
+			kid := strings.TrimPrefix(r.URL.Path, "/api/v1/system/keyring/")
+			a.handleDelete(w, kid)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}
+}
+
+func (a *agentMock) handleGet(w http.ResponseWriter) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"version": 1,
+		"entries": a.entries,
+	})
+}
+
+func (a *agentMock) handleInstall(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		KID       string `json:"kid"`
+		SecretB64 string `json:"secret_b64"`
+		Role      string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	secret, err := base64.RawURLEncoding.DecodeString(body.SecretB64)
+	if err != nil || len(secret) != 32 {
+		http.Error(w, "bad secret", http.StatusBadRequest)
+		return
+	}
+	if body.Role == "" {
+		body.Role = "secondary"
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, e := range a.entries {
+		if e.KID == body.KID {
+			http.Error(w, "kid exists", http.StatusConflict)
+			return
+		}
+	}
+	a.entries = append(a.entries, agentEntry{
+		KID: body.KID, Secret: secret, SecretB64: body.SecretB64, Role: body.Role,
+	})
+	_ = json.NewEncoder(w).Encode(map[string]any{"version": 1, "entries": a.entries})
+}
+
+func (a *agentMock) handleUse(w http.ResponseWriter, r *http.Request) {
+	var body struct{ KID string }
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	found := false
+	for i := range a.entries {
+		if a.entries[i].KID == body.KID {
+			found = true
+		}
+	}
+	if !found {
+		http.Error(w, "unknown kid", http.StatusNotFound)
+		return
+	}
+	for i := range a.entries {
+		if a.entries[i].KID == body.KID {
+			a.entries[i].Role = "primary"
+		} else if a.entries[i].Role == "primary" {
+			a.entries[i].Role = "secondary"
+		}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"version": 1, "entries": a.entries})
+}
+
+func (a *agentMock) handleDelete(w http.ResponseWriter, kid string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.entries) <= 1 {
+		http.Error(w, "cannot remove last", http.StatusConflict)
+		return
+	}
+	for i := range a.entries {
+		if a.entries[i].KID == kid {
+			a.entries = append(a.entries[:i], a.entries[i+1:]...)
+			_ = json.NewEncoder(w).Encode(map[string]any{"version": 1, "entries": a.entries})
+			return
+		}
+	}
+	http.Error(w, "unknown kid", http.StatusNotFound)
+}
+
+func (a *agentMock) entryCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.entries)
+}
+
+func (a *agentMock) primaryKID() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, e := range a.entries {
+		if e.Role == "primary" {
+			return e.KID
+		}
+	}
+	return ""
+}
+
+// setupRotator wires a mock agent, a fresh DB, and a seeded box with
+// a legacy keyring entry that exists on both sides.
+func setupRotator(t *testing.T) (*Rotator, *agentMock, *database.DB, *database.BoxDB) {
+	t.Helper()
+	t.Setenv("GEARBOX_INSECURE_TLS", "true")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Mock agent — seeded with a "legacy" entry whose secret matches
+	// what we'll seed in the dashboard's DB.
+	rawSecret := make([]byte, 32)
+	for i := range rawSecret {
+		rawSecret[i] = byte(i)
+	}
+	mock := &agentMock{
+		entries: []agentEntry{{
+			KID:       "legacy",
+			Secret:    rawSecret,
+			SecretB64: base64.RawURLEncoding.EncodeToString(rawSecret),
+			Role:      "primary",
+		}},
+	}
+	srv := httptest.NewServer(mock.handler())
+	t.Cleanup(srv.Close)
+
+	// DB + encryptor.
+	dbDir := t.TempDir()
+	db, err := database.New(filepath.Join(dbDir, "gearbox.db"), logger)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	enc, err := dashcrypto.NewEncryptor("test-encryption-secret-32-bytes!")
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	box := &database.BoxDB{
+		BoxID:           "test-box",
+		Name:            "Test Box",
+		AgentURL:        srv.URL,
+		APIKeyEncrypted: []byte("unused-here"),
+		Enabled:         true,
+	}
+	if err := db.CreateBox(box); err != nil {
+		t.Fatalf("CreateBox: %v", err)
+	}
+	encryptedHex, err := enc.EncryptString(hex.EncodeToString(rawSecret))
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+	if err := db.InsertBoxAgentKey(&database.BoxAgentKey{
+		BoxID:           box.ID,
+		KID:             "legacy",
+		SecretEncrypted: encryptedHex,
+		Role:            "primary",
+	}); err != nil {
+		t.Fatalf("InsertBoxAgentKey: %v", err)
+	}
+
+	return New(db, enc, logger), mock, db, box
+}
+
+func TestRotator_HappyPath(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+
+	result, err := rotator.RotateBox(box.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+	if result.OldKID != "legacy" {
+		t.Errorf("OldKID = %q, want legacy", result.OldKID)
+	}
+	if result.NewKID == "" {
+		t.Errorf("NewKID is empty")
+	}
+
+	// Agent side: 2 entries, new is primary.
+	if got := mock.entryCount(); got != 2 {
+		t.Errorf("agent entries = %d, want 2", got)
+	}
+	if got := mock.primaryKID(); got != result.NewKID {
+		t.Errorf("agent primary kid = %q, want %q", got, result.NewKID)
+	}
+
+	// DB side: new kid is primary, legacy is secondary with retired_at.
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 2 {
+		t.Fatalf("db entries = %d, want 2", len(keys))
+	}
+	for _, k := range keys {
+		switch k.KID {
+		case result.NewKID:
+			if k.Role != "primary" {
+				t.Errorf("new kid role = %q, want primary", k.Role)
+			}
+		case "legacy":
+			if k.Role != "secondary" {
+				t.Errorf("legacy role = %q, want secondary", k.Role)
+			}
+			if !k.RetiredAt.Valid {
+				t.Errorf("legacy retired_at not set")
+			}
+		default:
+			t.Errorf("unexpected kid: %q", k.KID)
+		}
+	}
+}
+
+func TestRotator_CleanupRetiredKeys_PastOverlap(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+	if _, err := rotator.RotateBox(box.ID, 24*time.Hour); err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+
+	// Tiny overlap → anything retired more than 1ms ago is sweepable.
+	time.Sleep(10 * time.Millisecond)
+	removed, err := rotator.CleanupRetiredKeys(box.ID, 1*time.Millisecond)
+	if err != nil {
+		t.Fatalf("CleanupRetiredKeys: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+	if got := mock.entryCount(); got != 1 {
+		t.Errorf("agent entries after cleanup = %d, want 1", got)
+	}
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 1 || keys[0].KID == "legacy" {
+		t.Errorf("db keys after cleanup: %+v", keys)
+	}
+}
+
+func TestRotator_CleanupRetiredKeys_WithinOverlap(t *testing.T) {
+	rotator, mock, db, box := setupRotator(t)
+	if _, err := rotator.RotateBox(box.ID, 24*time.Hour); err != nil {
+		t.Fatalf("RotateBox: %v", err)
+	}
+
+	// Within the (generous) overlap → no cleanup.
+	removed, err := rotator.CleanupRetiredKeys(box.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CleanupRetiredKeys: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("removed = %d, want 0", removed)
+	}
+	if got := mock.entryCount(); got != 2 {
+		t.Errorf("agent entries = %d, want 2", got)
+	}
+	keys, _ := db.GetBoxAgentKeys(box.ID)
+	if len(keys) != 2 {
+		t.Errorf("db keys = %+v, want 2", keys)
+	}
+}
+
+func TestRotator_NoPrimary_Errors(t *testing.T) {
+	rotator, _, _, _ := setupRotator(t)
+	if _, err := rotator.RotateBox(9999, 24*time.Hour); err == nil {
+		t.Errorf("expected error rotating non-existent box")
+	}
+}
+
+// Silence unused-import lints when working on the file in isolation.
+var _ = fmt.Sprintf

--- a/gearbox/internal/framework/templates/pages/haproxy_settings.templ
+++ b/gearbox/internal/framework/templates/pages/haproxy_settings.templ
@@ -30,6 +30,19 @@ templ HAProxyBoxesPageContent(user *models.User, servers []*database.BoxDB) {
 				</p>
 			</div>
 			<div class="flex items-center space-x-3">
+				if len(servers) > 0 {
+					<button
+						type="button"
+						onclick="rotateAllKeys(this)"
+						class="inline-flex items-center px-4 py-2 border border-amber-300 dark:border-amber-700 text-sm font-medium rounded-md text-amber-700 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/40"
+					>
+						<svg id="rotate-all-spinner" class="hidden animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+						Rotate All Keys
+					</button>
+				}
 				<a
 					href="/settings/boxes/new"
 					class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
@@ -318,6 +331,55 @@ templ HAProxyBoxesPageContent(user *models.User, servers []*database.BoxDB) {
 					closeDeleteModal();
 				}
 			});
+
+			async function rotateAllKeys(buttonEl) {
+				const confirmed = await showConfirmDialog({
+					title: 'Rotate keys for every enabled box?',
+					message: 'A new API key will be generated and installed on each agent. The old keys stay accepted for 24 hours so partial rotations are recoverable. Boxes that fail rotation are reported individually; others succeed independently.',
+					confirmText: 'Rotate All Keys',
+					type: 'warning',
+				});
+				if (!confirmed) return;
+
+				const spinner = document.getElementById('rotate-all-spinner');
+				spinner.classList.remove('hidden');
+				buttonEl.disabled = true;
+				try {
+					const resp = await fetch('/settings/boxes/rotate-key-all', {
+						method: 'POST',
+						headers: { 'Accept': 'application/json' },
+					});
+					const data = await resp.json();
+					if (resp.ok) {
+						const failures = (data.results || []).filter(r => !r.success);
+						if (failures.length === 0) {
+							window.showToast('Rotated ' + data.rotated + ' of ' + data.total + ' boxes.', 'success');
+						} else {
+							const msg = failures.map(r => r.name + ' (id=' + r.box_id + '): ' + r.error).join('\n');
+							await showAlertDialog({
+								title: 'Some rotations failed',
+								message: 'Succeeded: ' + data.rotated + ' / ' + data.total + '\n\nFailed:\n' + msg,
+								type: 'error',
+							});
+						}
+					} else {
+						await showAlertDialog({
+							title: 'Rotation failed',
+							message: (data && data.message) || 'Unknown server error.',
+							type: 'error',
+						});
+					}
+				} catch (err) {
+					await showAlertDialog({
+						title: 'Rotation failed',
+						message: err.message || String(err),
+						type: 'error',
+					});
+				} finally {
+					spinner.classList.add('hidden');
+					buttonEl.disabled = false;
+				}
+			}
 		</script>
 }
 
@@ -578,6 +640,30 @@ templ haProxyBoxForm(user *models.User, server *database.BoxDB, isEdit bool, err
 							<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Leave blank to keep existing API key</p>
 						}
 					</div>
+					if isEdit && server != nil {
+						<div class="pt-2 border-t border-gray-200 dark:border-gray-700">
+							<div class="flex items-start justify-between gap-4">
+								<div>
+									<h3 class="text-sm font-medium text-gray-900 dark:text-white">Rotate API key</h3>
+									<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+										Generates a fresh key, installs it on the agent, and demotes the current key to secondary. The old key keeps working for 24 hours so a partial rotation can be recovered from without bricking the box.
+									</p>
+								</div>
+								<button
+									type="button"
+									data-box-id={ fmt.Sprintf("%d", server.ID) }
+									onclick="rotateApiKey(this)"
+									class="shrink-0 inline-flex items-center px-4 py-2 border border-amber-300 dark:border-amber-700 text-sm font-medium rounded-md text-amber-700 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/40 whitespace-nowrap"
+								>
+									<svg id="rotate-spinner" class="hidden animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+										<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+										<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+									</svg>
+									Rotate Key
+								</button>
+							</div>
+						</div>
+					}
 				</div>
 			</div>
 			<!-- Form Actions -->
@@ -718,6 +804,46 @@ templ haProxyBoxForm(user *models.User, server *database.BoxDB, isEdit bool, err
 				closeApiKeyModal();
 			}
 		});
+
+		async function rotateApiKey(buttonEl) {
+			const boxID = buttonEl.dataset.boxId;
+			const confirmed = await showConfirmDialog({
+				title: 'Rotate this box\'s API key?',
+				message: 'A new key will be generated and installed on the agent. The old key stays accepted on the agent for 24 hours so a partial rotation can be recovered. After 24 hours the old key is removed automatically on the next cleanup run.',
+				confirmText: 'Rotate Key',
+				type: 'warning',
+			});
+			if (!confirmed) return;
+
+			const spinner = document.getElementById('rotate-spinner');
+			spinner.classList.remove('hidden');
+			buttonEl.disabled = true;
+			try {
+				const resp = await fetch('/settings/boxes/' + encodeURIComponent(boxID) + '/rotate-key', {
+					method: 'POST',
+					headers: { 'Accept': 'application/json' },
+				});
+				const data = await resp.json();
+				if (resp.ok && data.success) {
+					window.showToast('Rotation complete. New kid: ' + data.new_kid + '. Old kid (' + data.old_kid + ') retires after ' + new Date(data.retire_after).toLocaleString() + '.', 'success');
+				} else {
+					await showAlertDialog({
+						title: 'Rotation failed',
+						message: data.message || 'Unknown error during rotation.',
+						type: 'error',
+					});
+				}
+			} catch (err) {
+				await showAlertDialog({
+					title: 'Rotation failed',
+					message: err.message || String(err),
+					type: 'error',
+				});
+			} finally {
+				spinner.classList.add('hidden');
+				buttonEl.disabled = false;
+			}
+		}
 
 		async function testConnection() {
 			const spinner = document.getElementById('test-spinner');


### PR DESCRIPTION
## Summary

Recovery PR for the keyring rotation work that got tangled by the cascade-merge order this morning. PRs #129, #130, #131, #132 were stacked on each other; when I attempted to merge them after #128 landed, only #130 and #132 "merged" — but they merged into their **stacked base branches** (`feature/issue-72-phase-2-rotation-endpoints` and `feature/issue-72-phase-4-cleanup-scheduler`), not into `main`. #129 and #131 got closed without merging during the cascade.

This PR cherry-picks the four phase commits onto a fresh branch off current `main` so the content lands in one squash. Net effect is equivalent to the original PR #129 + #130 + #131 + #132 merging in order:

- Phase 2 — install/use/remove endpoints + rotator service (originally #129)
- Phase 3 — manual rotate UI + handlers (originally #130)
- Phase 4 — retired-key cleaner (originally #131)
- Phase 5 — drift detection in agent.Client (originally #132)

Tracks issue #72.

## Test plan

- [x] `go build ./...` clean in both `gearbox/` and `gearbox-agent/`
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` passes in both modules — `agent_keyring` package's `cleaner_test.go` and `rotator_test.go` pass; agent's `crypto` keyring tests pass; gearbox-agent's `keyring_test.go` for the install/use/remove endpoints passes
- [ ] On a deployment, exercise the rotate UI and confirm new keys install, current key swaps, retired keys age out per the cleaner schedule

## Why not just reopen #129–#132?

GitHub returns `Could not open the pull request` when the head branch's commits no longer diff cleanly against any open base — the stacked bases (`feature/issue-72-phase-1-keyring`, etc.) were deleted as part of the cascade merges, and the head branches now contain a mix of original + auto-merge commits that don't cleanly rebase. A fresh PR is the cheapest recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)