### PR TITLE
fix(console): #140 bug fixes + multi-session manager (tabs/dock/popout)

### DIFF
--- a/gearbox/cmd/server/main.go
+++ b/gearbox/cmd/server/main.go
@@ -677,6 +677,11 @@ func main() {
 		r.Get("/config/haproxy/{boxID}", h.HAProxyConfigPage)
 		r.Get("/config/firewall/{boxID}", h.FirewallConfigPage)
 
+		// Chromeless console popout (#140). Opened via window.open()
+		// from the in-page console manager. Auth + per-box opt-in
+		// gating matches /api/console/{boxID}/capabilities.
+		r.Get("/console/popout/{boxID}", h.ConsolePopoutPage)
+
 		// HTMX partial routes (return HTML fragments)
 		r.Get("/htmx/sidebar-nav", h.SidebarNavPartialHandler)
 		r.Get("/htmx/{boxID}/status-summary", h.StatusSummaryPartialHandler)

--- a/gearbox/internal/framework/handler/console_popout.go
+++ b/gearbox/internal/framework/handler/console_popout.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sarg3nt/gearbox/internal/framework/models"
+	"github.com/sarg3nt/gearbox/internal/framework/templates/pages"
+)
+
+// ConsolePopoutPage renders a chromeless full-window console session for
+// the given box. Reached via the popout button in the in-page console
+// manager (window.open → /console/popout/{boxID}). Auth + per-box opt-in
+// match APIConsoleCapabilities so the popout can't outrun those gates.
+func (h *Handler) ConsolePopoutPage(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.authManager.GetUser(r); err != nil {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if !h.authManager.HasPermission(r, models.ComponentBoxConsole, models.PermissionView) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	boxID := chi.URLParam(r, "boxID")
+	if boxID == "" {
+		http.Error(w, "Box ID is required", http.StatusBadRequest)
+		return
+	}
+	server, err := h.db.GetBoxByBoxID(boxID)
+	if err != nil || server == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if !server.ConsoleEnabled {
+		http.Error(w, "Console is not enabled for this box", http.StatusNotFound)
+		return
+	}
+
+	component := pages.ConsolePopoutPage(boxID, server.Name)
+	if err := component.Render(r.Context(), w); err != nil {
+		h.logger.Error("Failed to render console popout page", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}

--- a/gearbox/internal/framework/templates/components/console.templ
+++ b/gearbox/internal/framework/templates/components/console.templ
@@ -51,8 +51,9 @@ templ ConsoleDrawer() {
 				<button type="button"
 					id="console-btn-clear"
 					class="console-tool-btn"
+					aria-label="Clear terminal buffer"
 					title="Clear (Ctrl-L sends to remote; this just clears the local buffer)">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3"></path>
 					</svg>
 				</button>
@@ -63,16 +64,18 @@ templ ConsoleDrawer() {
 				<button type="button"
 					id="console-btn-layout-drawer"
 					class="console-tool-btn"
+					aria-label="Switch to fullscreen layout"
 					title="Fullscreen drawer">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
 					</svg>
 				</button>
 				<button type="button"
 					id="console-btn-layout-dock"
 					class="console-tool-btn"
+					aria-label="Switch to docked layout"
 					title="Dock to bottom">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<rect x="3" y="4" width="18" height="16" rx="2" stroke-width="2"></rect>
 						<line x1="3" y1="14" x2="21" y2="14" stroke-width="2"></line>
 					</svg>
@@ -80,16 +83,18 @@ templ ConsoleDrawer() {
 				<button type="button"
 					id="console-btn-layout-popout"
 					class="console-tool-btn"
+					aria-label="Open console in new window"
 					title="Open in new window">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
 					</svg>
 				</button>
 				<button type="button"
 					id="console-drawer-close"
 					class="console-tool-btn"
+					aria-label="Close console"
 					title="Close console (Esc)">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 					</svg>
 				</button>
@@ -106,7 +111,7 @@ templ ConsoleDrawer() {
 				class="console-tab-new"
 				aria-label="New tab"
 				title="Open another tab to this box">
-				<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<svg class="w-3 h-3" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
 				</svg>
 			</button>

--- a/gearbox/internal/framework/templates/components/console.templ
+++ b/gearbox/internal/framework/templates/components/console.templ
@@ -1,60 +1,131 @@
 package components
 
-// ConsoleDrawer renders the markup for the remote-console drawer
-// (one per layout, opened on demand by window.openConsole). The
-// xterm.js terminal mounts into #console-xterm; the title bar shows
-// which box the session targets so the user can't mix them up if
-// they have multiple browser tabs open against different boxes.
+// ConsoleDrawer renders the chrome for the multi-session remote console.
+// One copy lives in the base layout (for the in-page drawer/dock) and is
+// also rendered standalone by the popout page.
 //
-// Hidden by default. Opened by static/js/console/console.js. The
-// fullscreen overlay sits at z-[200] so it lands above existing
-// modals (z-[100]); a console session is the most foreground thing
-// the UI can show.
+// Sessions are managed by static/js/console/console.js (ConsoleManager).
+// The xterm.js terminals mount into #console-xterm; the manager swaps the
+// active session's <div> into/out of that host on tab switches.
+//
+// Layout state lives on the root #console-drawer element via the
+// `console-layout-drawer` and `console-layout-dock` classes; CSS in
+// components/console.css positions accordingly. Hidden by default.
 templ ConsoleDrawer() {
 	<div id="console-drawer"
-		class="fixed inset-0 z-[200] hidden flex-col bg-slate-900 text-slate-100"
+		class="hidden flex-col bg-slate-900 text-slate-100 console-layout-drawer"
 		role="dialog"
-		aria-labelledby="console-drawer-title"
+		aria-label="Remote console"
 		aria-modal="true">
-		<div class="flex items-center justify-between px-4 py-2 border-b border-slate-700 bg-slate-800">
-			<div class="flex items-center gap-3 min-w-0">
-				<svg class="w-5 h-5 text-emerald-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-				</svg>
-				<h2 id="console-drawer-title" class="text-sm font-medium truncate">
-					Console: <span id="console-drawer-box" class="font-mono"></span>
-				</h2>
-				<span id="console-drawer-status"
-					class="text-xs px-2 py-0.5 rounded-full bg-slate-700 text-slate-300 flex-shrink-0">
-					connecting…
-				</span>
-				<span id="console-drawer-mode"
-					class="text-xs px-2 py-0.5 rounded-full bg-slate-700 text-slate-400 flex-shrink-0 font-mono"></span>
-				<span id="console-drawer-uid"
-					class="text-xs px-2 py-0.5 rounded-full bg-slate-700 text-slate-400 flex-shrink-0 font-mono"></span>
+		// Dock-only drag handle. CSS hides it in drawer mode. Mouse-down
+		// captured by ConsoleManager._wireDockResize.
+		<div id="console-dock-handle"
+			class="console-dock-handle"
+			role="separator"
+			aria-orientation="horizontal"
+			aria-label="Resize console dock"
+			title="Drag to resize"></div>
+		// Header: title block on the left, status pills next, toolbar on
+		// the right, close button at the far end.
+		// Header now hosts only the toolbar — the box name lives in the
+		// active tab and the per-tab dot carries connection state, so the
+		// header has no left-side content to render. Vertical padding
+		// kept tight (py-1) so the bar stays thin.
+		<div class="console-header flex items-center justify-end px-3 py-1 border-b border-slate-700 bg-slate-800 gap-3">
+			<div class="flex items-center gap-2 flex-shrink-0">
+				// Font-size slider — matches the logs-viewer pattern. Value
+				// persisted via localStorage by ConsoleManager.
+				<div class="flex items-center gap-2 mr-2">
+					<label for="console-font-slider" class="text-xs text-slate-300">Font</label>
+					<input
+						type="range"
+						id="console-font-slider"
+						min="10"
+						max="24"
+						value="13"
+						class="w-20 h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer"
+						aria-label="Console font size"
+					/>
+					<span id="console-font-value" class="text-xs text-slate-400 w-10">13px</span>
+				</div>
+				<button type="button"
+					id="console-btn-clear"
+					class="console-tool-btn"
+					title="Clear (Ctrl-L sends to remote; this just clears the local buffer)">
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3"></path>
+					</svg>
+				</button>
+				// Layout switchers — drawer/dock are mutually exclusive, so
+				// only the inactive one is visible at a time (JS toggles
+				// .hidden on each based on the active layout). Popout
+				// stays visible; the popout page hides all three.
+				<button type="button"
+					id="console-btn-layout-drawer"
+					class="console-tool-btn"
+					title="Fullscreen drawer">
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
+					</svg>
+				</button>
+				<button type="button"
+					id="console-btn-layout-dock"
+					class="console-tool-btn"
+					title="Dock to bottom">
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<rect x="3" y="4" width="18" height="16" rx="2" stroke-width="2"></rect>
+						<line x1="3" y1="14" x2="21" y2="14" stroke-width="2"></line>
+					</svg>
+				</button>
+				<button type="button"
+					id="console-btn-layout-popout"
+					class="console-tool-btn"
+					title="Open in new window">
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+					</svg>
+				</button>
+				<button type="button"
+					id="console-drawer-close"
+					class="console-tool-btn"
+					title="Close console (Esc)">
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+					</svg>
+				</button>
 			</div>
+		</div>
+		// Tab bar — tabs (populated by ConsoleManager) + "+ new tab" button.
+		// The bar is hidden by default and revealed by the manager once a
+		// session opens; we keep the "+" inline with the tabs so it's
+		// discoverable in the same place browsers/iTerm/etc. put it.
+		<div id="console-tab-bar" class="console-tab-bar hidden">
+			<div id="console-tabs" class="console-tabs" role="tablist"></div>
 			<button type="button"
-				id="console-drawer-close"
-				class="text-slate-400 hover:text-white p-1"
-				title="Close console (Esc)">
-				<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+				id="console-btn-newtab"
+				class="console-tab-new"
+				aria-label="New tab"
+				title="Open another tab to this box">
+				<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
 				</svg>
 			</button>
 		</div>
-		<div id="console-xterm" class="flex-1 overflow-hidden bg-black"></div>
+		// xterm host. Sessions attach their own xterm <div> into this.
+		// `console-xterm-pad` adds breathing room so cursor/text isn't
+		// flush against the panel border.
+		<div class="console-xterm-pad flex-1 overflow-hidden bg-black">
+			<div id="console-xterm" class="w-full h-full"></div>
+		</div>
 	</div>
 }
 
-// ConsoleAssets pulls in the xterm.js bundle, fit addon, and CSS.
-// Place once near the bottom of the layout (after the existing
-// vendor scripts) so window.Terminal exists before console.js runs.
-//
-// The actual wiring code is in static/js/console/console.js — kept
-// in JS so the bundler-free workflow stays simple and so tests can
-// stub window.openConsole without recompiling Go.
+// ConsoleAssets pulls in the xterm.js bundle, fit addon, console CSS, and
+// the console manager. Place once near the bottom of any layout that
+// surfaces the console (the popout page uses this directly).
 templ ConsoleAssets() {
 	<link rel="stylesheet" href="/static/css/vendor/xterm.min.css"/>
+	<link rel="stylesheet" href="/static/css/components/console.css"/>
 	<script src="/static/js/vendor/xterm.min.js" defer></script>
 	<script src="/static/js/vendor/xterm-addon-fit.min.js" defer></script>
 	<script src="/static/js/console/console.js" defer></script>

--- a/gearbox/internal/framework/templates/pages/console_popout.templ
+++ b/gearbox/internal/framework/templates/pages/console_popout.templ
@@ -1,0 +1,69 @@
+package pages
+
+import (
+	"github.com/sarg3nt/gearbox/internal/framework/middleware"
+	"github.com/sarg3nt/gearbox/internal/framework/templates/components"
+)
+
+// ConsolePopoutPage renders a chromeless full-window console session for a
+// single box. Reached via window.open() from the in-page console manager
+// (the popout button). No sidebar, no header chrome, no Tailwind app shell
+// — just the ConsoleDrawer in fullscreen mode plus the assets needed to
+// drive it.
+//
+// On load the inline boot script calls markPopout (which hides the
+// layout-switch buttons that don't apply here) and opens a session
+// against the given box. Closing the drawer here means closing the
+// browser tab — handled by overriding the close button to window.close().
+templ ConsolePopoutPage(boxID string, boxName string) {
+	<!DOCTYPE html>
+	<html lang="en" class="h-full">
+	<head>
+		<meta charset="UTF-8"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+		<title>Console: { boxName } - Gearbox</title>
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+		if middleware.UseLocalAssets(ctx) {
+			<script src="/static/js/vendor/tailwind.js"></script>
+		} else {
+			<script src="https://cdn.tailwindcss.com"></script>
+		}
+		<style>
+			html, body { height: 100%; margin: 0; background: #000; }
+			/* Force the drawer to always be visible and fullscreen in a
+			 * popout — the manager handles layout state for the in-page
+			 * case, but here we want zero chrome and zero hidden state. */
+			#console-drawer { display: flex !important; }
+			#console-drawer.hidden { display: flex !important; }
+		</style>
+	</head>
+	<body class="h-full m-0 bg-black">
+		<div id="console-popout-data" data-box-id={ boxID } data-label={ boxName } class="hidden"></div>
+		@components.ConsoleDrawer()
+		@components.ConsoleAssets()
+		<script>
+			(function () {
+				function boot() {
+					const node = document.getElementById('console-popout-data');
+					if (!node) return;
+					const boxID = node.getAttribute('data-box-id') || '';
+					const label = node.getAttribute('data-label') || boxID;
+					if (!window.gearbox || !window.gearbox.console) {
+						setTimeout(boot, 50);
+						return;
+					}
+					// markPopout hides the header + tab bar; the only way to
+					// exit is closing the window (Cmd-W / OS chrome).
+					window.gearbox.console.markPopout();
+					window.gearbox.console.open({ kind: 'box', boxID: boxID, label: label });
+				}
+				if (document.readyState === 'loading') {
+					document.addEventListener('DOMContentLoaded', boot);
+				} else {
+					boot();
+				}
+			})();
+		</script>
+	</body>
+	</html>
+}

--- a/gearbox/internal/framework/templates/pages/console_popout.templ
+++ b/gearbox/internal/framework/templates/pages/console_popout.templ
@@ -11,10 +11,14 @@ import (
 // — just the ConsoleDrawer in fullscreen mode plus the assets needed to
 // drive it.
 //
-// On load the inline boot script calls markPopout (which hides the
-// layout-switch buttons that don't apply here) and opens a session
-// against the given box. Closing the drawer here means closing the
-// browser tab — handled by overriding the close button to window.close().
+// On load the inline boot script calls markPopout which:
+//   1. Tags the drawer with .console-popout so CSS hides the entire
+//      header (incl. the close button) and the tab bar — the popout
+//      window is single-session, all chrome controls are meaningless.
+//   2. Forces the layout to drawer (fullscreen) and disables Esc-to-close.
+//
+// The only way to exit a popout is closing the OS window (Cmd-W /
+// red close button) — by design, since the chrome's gone anyway.
 templ ConsolePopoutPage(boxID string, boxName string) {
 	<!DOCTYPE html>
 	<html lang="en" class="h-full">

--- a/gearbox/static/css/components/console.css
+++ b/gearbox/static/css/components/console.css
@@ -1,0 +1,253 @@
+/* console.css — chrome for the multi-session console panel.
+ *
+ * The drawer lives in two visual modes driven by a class on
+ * #console-drawer:
+ *
+ *   .console-layout-drawer  fullscreen overlay (default)
+ *   .console-layout-dock    pinned bottom strip, drag-resizable
+ *
+ * Tab strip, toolbar buttons, and dock handle are styled here so the
+ * templ component stays Tailwind-light and the visual rules live in one
+ * place.
+ */
+
+/* ---------- layout modes ---------- */
+
+#console-drawer.console-layout-drawer {
+	position: fixed;
+	inset: 0;
+	z-index: 200;
+}
+
+#console-drawer.console-layout-dock {
+	position: fixed;
+	left: 16rem;            /* matches expanded #main-content margin-left */
+	right: 0;
+	bottom: 0;
+	height: 320px;          /* JS overrides on each frame from persisted pref */
+	z-index: 200;
+	box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.4);
+	transition: left 0.3s ease-in-out;
+}
+
+/* Track the sidebar collapse state. #main-content's `.ml-16` is added by
+ * the sidebar toggle JS in base.templ; since #console-drawer is a
+ * following sibling of #main-content in the body, the ~ selector picks
+ * it up automatically and the transition above syncs the slide with the
+ * sidebar's own width animation. */
+#main-content.ml-16 ~ #console-drawer.console-layout-dock {
+	left: 4rem;
+}
+@media (max-width: 767px) {
+	#console-drawer.console-layout-dock {
+		left: 4rem;
+	}
+}
+
+/* When the dock is open, push the main app content up so it isn't hidden
+ * underneath. The dock height tracks --gearbox-console-dock-h (set by
+ * ConsoleManager on every resize); falls back to 320px so the rule still
+ * works before JS runs. */
+:root {
+	--gearbox-console-dock-h: 320px;
+}
+body.console-dock-open {
+	padding-bottom: var(--gearbox-console-dock-h);
+}
+
+/* ---------- hidden override ----------
+ *
+ * Tailwind's utility `.hidden` (display: none) loses the cascade tie to
+ * our component display rules (`.console-tool-btn { display: inline-flex
+ * }`, etc.) because console.css is loaded after Tailwind's injected
+ * style block. Re-assert the rule with a 2-class selector so it wins on
+ * specificity wherever we toggle visibility from JS. */
+.console-tool-btn.hidden,
+.console-tab-dot.hidden,
+.console-tab-new.hidden,
+.console-tab-bar.hidden {
+	display: none;
+}
+
+/* ---------- dock drag handle ---------- */
+
+.console-dock-handle {
+	height: 5px;
+	cursor: row-resize;
+	background: linear-gradient(to bottom, transparent 0, rgba(148, 163, 184, 0.2) 50%, transparent 100%);
+	flex-shrink: 0;
+}
+.console-dock-handle:hover {
+	background: linear-gradient(to bottom, transparent 0, rgba(52, 211, 153, 0.35) 50%, transparent 100%);
+}
+#console-drawer.console-layout-drawer .console-dock-handle {
+	display: none;
+}
+
+/* ---------- toolbar buttons ---------- */
+
+.console-tool-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 4px;
+	color: rgb(148, 163, 184);
+	background: transparent;
+	transition: background-color 100ms ease, color 100ms ease;
+}
+.console-tool-btn:hover {
+	background: rgb(51, 65, 85);
+	color: rgb(226, 232, 240);
+}
+
+/* ---------- tab strip ---------- */
+
+/* The bar wraps the dynamic tabs and the static "+ new tab" button. The
+ * tabs scroll horizontally if many sessions are open; the "+" stays
+ * pinned to the right edge of the visible tabs. */
+.console-tab-bar {
+	display: flex;
+	align-items: center;
+	background: rgb(15, 23, 42);
+	border-bottom: 1px solid rgb(51, 65, 85);
+	padding: 4px 8px 0 8px;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.console-tabs {
+	display: flex;
+	gap: 2px;
+	overflow-x: auto;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.console-tab-new {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	margin-bottom: 1px;
+	background: transparent;
+	color: rgb(148, 163, 184);
+	border: 1px solid transparent;
+	border-radius: 4px;
+	cursor: pointer;
+}
+.console-tab-new:hover {
+	background: rgb(51, 65, 85);
+	color: rgb(52, 211, 153);
+}
+.console-tab {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 4px 4px 10px;
+	background: rgb(30, 41, 59);
+	border: 1px solid rgb(51, 65, 85);
+	border-bottom: none;
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	font-size: 12px;
+	color: rgb(203, 213, 225);
+	white-space: nowrap;
+}
+.console-tab.active {
+	background: rgb(2, 6, 23);
+	border-color: rgb(71, 85, 105);
+	color: rgb(226, 232, 240);
+}
+/* Per-tab status dot — connection indicator + reconnect affordance.
+ * green = connected, slate-gray = anything else. Only the
+ * closed / error states pick up `is-clickable` (pointer + hover);
+ * the in-between states stay inert. */
+.console-tab-dot {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 999px;
+	background: rgb(100, 116, 139);     /* slate-500 — "not connected" */
+	border: none;
+	padding: 0;
+	margin-right: 2px;
+	cursor: default;
+	flex-shrink: 0;
+	transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+.console-tab-dot.is-connected {
+	background: rgb(52, 211, 153);       /* emerald-400 */
+}
+.console-tab-dot.is-error {
+	background: rgb(248, 113, 113);      /* red-400 — surface errors louder than plain closed */
+}
+.console-tab-dot.is-connecting {
+	background: rgb(250, 204, 21);       /* yellow-400 */
+}
+.console-tab-dot.is-clickable {
+	cursor: pointer;
+}
+.console-tab-dot.is-clickable:hover {
+	box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.35);
+}
+
+.console-tab-label {
+	background: none;
+	border: none;
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+	padding: 0;
+}
+.console-tab-close {
+	background: none;
+	border: none;
+	color: rgb(148, 163, 184);
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0 4px;
+	border-radius: 3px;
+}
+.console-tab-close:hover {
+	background: rgb(51, 65, 85);
+	color: rgb(248, 113, 113);
+}
+
+/* ---------- popout mode: no chrome, just the terminal ---------- */
+
+/* In a popout window all the chrome is wasted space — the layout
+ * buttons are meaningless (we're already popped out), the close
+ * button is redundant with the OS window controls, and the tab
+ * bar / status pills don't add value for a single-session window.
+ * The class is added by ConsoleManager.markPopout(). */
+#console-drawer.console-popout .console-header,
+#console-drawer.console-popout .console-tab-bar,
+#console-drawer.console-popout .console-dock-handle {
+	display: none;
+}
+
+/* ---------- xterm padding ---------- */
+
+/* xterm.js paints right up to its container's edges by default. The
+ * .console-xterm-pad wrapper adds breathing room around the terminal
+ * without affecting xterm's own cols/rows math — xterm reads the inner
+ * div's size, so padding lives on the wrapper. */
+.console-xterm-pad {
+	padding: 8px 10px;
+}
+
+.console-session-host {
+	width: 100%;
+	height: 100%;
+}
+
+/* The .xterm viewport already handles its own scrollbar; suppress the
+ * outer wrapper's so we don't get two stacked tracks during transitions. */
+.console-xterm-pad > .console-session-host > .xterm {
+	height: 100%;
+}

--- a/gearbox/static/css/components/console.css
+++ b/gearbox/static/css/components/console.css
@@ -247,7 +247,13 @@ body.console-dock-open {
 }
 
 /* The .xterm viewport already handles its own scrollbar; suppress the
- * outer wrapper's so we don't get two stacked tracks during transitions. */
-.console-xterm-pad > .console-session-host > .xterm {
+ * outer wrapper's so we don't get two stacked tracks during transitions.
+ * DOM hierarchy is .console-xterm-pad > #console-xterm > .console-session-host > .xterm
+ * — sessions append their host into #console-xterm. */
+.console-xterm-pad #console-xterm > .console-session-host > .xterm {
+	height: 100%;
+}
+#console-xterm {
+	width: 100%;
 	height: 100%;
 }

--- a/gearbox/static/js/bx/bx-page.js
+++ b/gearbox/static/js/bx/bx-page.js
@@ -238,24 +238,6 @@
                     cssClass: 'bx-col-status',
                 },
                 { title: 'Name', field: 'name', formatter: nameFormatter, minWidth: 140 },
-                {
-                    title: '',
-                    field: '_console',
-                    width: 44,
-                    minWidth: 44,
-                    hozAlign: 'center',
-                    headerSort: false,
-                    formatter: consoleFormatter,
-                    cellClick: function (e, cell) {
-                        e.stopPropagation();
-                        const d = cell.getRow().getData();
-                        if (window.openConsole) {
-                            window.openConsole(d.id, d.name);
-                        }
-                    },
-                    headerTooltip: 'Open remote console (requires box_console:connect)',
-                    cssClass: 'bx-col-console',
-                },
                 { title: 'Location', field: 'location', formatter: emDashIfEmpty, minWidth: 120 },
                 { title: 'Agent', field: 'agent_url', formatter: agentFormatter, minWidth: 200 },
                 {
@@ -278,10 +260,45 @@
                         return ta - tb;
                     },
                 },
+                {
+                    title: 'Tools',
+                    field: '_tools',
+                    width: 72,
+                    minWidth: 72,
+                    hozAlign: 'center',
+                    headerSort: false,
+                    // Intentionally not frozen — Tabulator paints a divider
+                    // box-shadow on frozen columns that looked ugly against
+                    // the rest of the grid. Horizontal scroll on this grid
+                    // is rare enough that we don't need it pinned.
+                    formatter: consoleFormatter,
+                    cellClick: function (e, cell) {
+                        // Tabulator delivers its own `rowClick` independently
+                        // of DOM bubbling, so stopPropagation alone won't keep
+                        // the row handler from firing. The rowClick handler
+                        // below checks for `.bx-col-tools` and bails out —
+                        // keep both guards in sync if you rename the class.
+                        e.stopPropagation();
+                        const d = cell.getRow().getData();
+                        if (window.openConsole) {
+                            window.openConsole(d.box_id, d.name);
+                        }
+                    },
+                    headerTooltip: 'Open remote console (requires box_console:connect)',
+                    cssClass: 'bx-col-tools',
+                },
             ],
         });
 
         grid.on('rowClick', function (e, row) {
+            // Tools-column buttons (e.g. the shell icon) have their own
+            // cellClick handlers — Tabulator fires rowClick anyway because
+            // it runs from its own event delegation, so we filter here. If
+            // the click originated inside an action button we treat it as
+            // a button click and skip the row navigation.
+            if (e && e.target && e.target.closest && e.target.closest('.bx-col-tools')) {
+                return;
+            }
             const data = row.getData();
             if (!data || !data.box_id) return;
             // /home with the cookie-driven box selection — switchBox writes
@@ -370,12 +387,12 @@
                 // just produce a "disabled" error when clicked.
                 if (!row.console_enabled) return;
                 cmds.register({
-                    id: 'bx.console.' + row.id,
-                    label: 'Console: ' + (row.name || row.id),
+                    id: 'bx.console.' + row.box_id,
+                    label: 'Console: ' + (row.name || row.box_id),
                     subtitle: 'Open a remote shell on this box',
                     group: 'Console',
                     run: function () {
-                        if (window.openConsole) window.openConsole(row.id, row.name);
+                        if (window.openConsole) window.openConsole(row.box_id, row.name);
                     },
                 });
             });

--- a/gearbox/static/js/console/console.js
+++ b/gearbox/static/js/console/console.js
@@ -237,6 +237,15 @@
         this.ws.send(JSON.stringify({ t: 'resize', cols: cols, rows: rows }));
     };
 
+    // Emit a visible error line into the xterm buffer. The status dot
+    // also reflects the state via color, but the terminal needs its own
+    // surface so a failing session isn't a silent black void. Matches
+    // the server-side 'err' frame path which already writes red text.
+    ConsoleSession.prototype._writeError = function (msg) {
+        if (!this.term) return;
+        this.term.write('\r\n\x1b[31m[console] ' + msg + '\x1b[0m\r\n');
+    };
+
     ConsoleSession.prototype.connect = function () {
         this._ensureTerm();
         if (this.ws) { try { this.ws.close(); } catch (_) {} }
@@ -255,6 +264,7 @@
                     self.mode = '';
                     self.uid = null;
                     self.errorMsg = 'disabled on agent';
+                    self._writeError('console disabled on this agent');
                     self._setStatus('error');
                     return;
                 }
@@ -264,6 +274,7 @@
             })
             .catch(function (e) {
                 self.errorMsg = e.message;
+                self._writeError('capabilities fetch failed: ' + e.message);
                 self._setStatus('error');
             });
     };
@@ -304,6 +315,7 @@
         };
         ws.onerror = function () {
             self.errorMsg = 'socket error';
+            self._writeError('websocket error');
             self._setStatus('error');
         };
         ws.onclose = function () {
@@ -399,31 +411,50 @@
         if (!handle) return;
         const self = this;
         let dragging = false;
+        let pointerID = null;
         let startY = 0;
         let startH = 0;
 
-        handle.addEventListener('mousedown', function (e) {
-            dragging = true;
-            startY = e.clientY;
-            startH = self.dockHeight;
-            document.body.style.cursor = 'row-resize';
-            document.body.style.userSelect = 'none';
-            e.preventDefault();
-        });
-        window.addEventListener('mousemove', function (e) {
-            if (!dragging) return;
-            const dy = startY - e.clientY;
-            self.dockHeight = clampInt(startH + dy, DOCK_MIN, window.innerHeight - 100);
-            self._applyDockHeight();
-        });
-        window.addEventListener('mouseup', function () {
+        // Pointer Events with setPointerCapture so drag state survives
+        // the cursor leaving the window — mouseup-outside used to leave
+        // the dock in a stuck "still resizing" state. visibilitychange
+        // and blur are additional belt-and-suspenders cleanups.
+        const stopDrag = function () {
             if (!dragging) return;
             dragging = false;
+            try { if (pointerID !== null) handle.releasePointerCapture(pointerID); } catch (_) {}
+            pointerID = null;
             document.body.style.cursor = '';
             document.body.style.userSelect = '';
             prefSet('dockHeight', self.dockHeight);
             const s = self._active();
             if (s) s.fit();
+        };
+
+        handle.addEventListener('pointerdown', function (e) {
+            dragging = true;
+            pointerID = e.pointerId;
+            startY = e.clientY;
+            startH = self.dockHeight;
+            document.body.style.cursor = 'row-resize';
+            document.body.style.userSelect = 'none';
+            try { handle.setPointerCapture(e.pointerId); } catch (_) {}
+            e.preventDefault();
+        });
+        handle.addEventListener('pointermove', function (e) {
+            if (!dragging || e.pointerId !== pointerID) return;
+            const dy = startY - e.clientY;
+            self.dockHeight = clampInt(startH + dy, DOCK_MIN, window.innerHeight - 100);
+            self._applyDockHeight();
+        });
+        handle.addEventListener('pointerup', stopDrag);
+        handle.addEventListener('pointercancel', stopDrag);
+        // If the user alt-tabs or the page is hidden mid-drag, treat it
+        // as drop — without these the body cursor/userSelect overrides
+        // can linger after the user returns.
+        window.addEventListener('blur', stopDrag);
+        document.addEventListener('visibilitychange', function () {
+            if (document.hidden) stopDrag();
         });
     };
 
@@ -665,10 +696,14 @@
                 ? s.label + ' #' + labelIdx[s.label]
                 : s.label;
 
+            // Tab wrapper is layout-only — the focusable element with
+            // role="tab" is the label button. This keeps ARIA semantics
+            // happy: nested interactive children (dot, close) sit inside
+            // the wrapper but are siblings of the role="tab" element,
+            // not nested inside it. See Copilot review on PR #141.
             const tab = document.createElement('div');
             tab.className = 'console-tab' + (s.id === self.activeID ? ' active' : '');
-            tab.setAttribute('role', 'tab');
-            tab.setAttribute('aria-selected', s.id === self.activeID ? 'true' : 'false');
+            tab.setAttribute('role', 'presentation');
 
             // Per-tab status dot. Doubles as a reconnect button when the
             // session is closed/errored — clicking switches active to
@@ -678,17 +713,22 @@
             dot.type = 'button';
             dot.className = 'console-tab-dot is-' + s.status;
             const isReconnectable = s.status === 'closed' || s.status === 'error';
+            const dotStateText = ({
+                connected: 'Connected',
+                connecting: 'Connecting',
+                idle: 'Idle',
+                closed: 'Closed',
+                error: 'Error: ' + (s.errorMsg || 'unknown'),
+            })[s.status] || s.status;
             if (isReconnectable) {
                 dot.classList.add('is-clickable');
-                dot.title = (s.status === 'error'
-                    ? 'Error: ' + (s.errorMsg || 'unknown')
-                    : 'Closed') + ' — click to reconnect';
+                dot.title = dotStateText + ' — click to reconnect';
+                dot.setAttribute('aria-label', display + ' — ' + dotStateText + '. Click to reconnect.');
+                dot.removeAttribute('aria-disabled');
             } else {
-                dot.title = ({
-                    connected: 'Connected',
-                    connecting: 'Connecting…',
-                    idle: '',
-                })[s.status] || s.status;
+                dot.title = dotStateText;
+                dot.setAttribute('aria-label', display + ' — ' + dotStateText);
+                dot.setAttribute('aria-disabled', 'true');
             }
             dot.addEventListener('click', function (e) {
                 e.stopPropagation();
@@ -700,6 +740,11 @@
             label.className = 'console-tab-label';
             label.textContent = display;
             label.title = display + ' (' + s.status + ')';
+            // Label button carries the role="tab" semantics so screen
+            // readers expose the tab list correctly (one role="tab" per
+            // tab, focusable, with aria-selected reflecting active).
+            label.setAttribute('role', 'tab');
+            label.setAttribute('aria-selected', s.id === self.activeID ? 'true' : 'false');
             label.addEventListener('click', function () { self._setActive(s.id); });
 
             const close = document.createElement('button');

--- a/gearbox/static/js/console/console.js
+++ b/gearbox/static/js/console/console.js
@@ -1,252 +1,763 @@
-// console.js — drives the remote-console drawer.
+// console.js — multi-session console manager.
 //
-// Public surface:
-//   window.openConsole(boxID, boxName) — opens the drawer and starts a session
-//   window.closeConsole()              — closes whatever session is open
+// Public API:
+//   window.openConsole(boxID, boxName)          — backwards-compat shim
+//   window.gearbox.console.open(descriptor)     — canonical entry point
+//   window.gearbox.console.close()              — close active session
+//   window.gearbox.console.setLayout(mode)      — 'drawer'|'dock'|'popout'
 //
-// The drawer markup (#console-drawer, #console-xterm, etc.) is rendered
-// by templ component ConsoleDrawer() in the base layout; we just attach
-// xterm.js to #console-xterm and pipe bytes through a WebSocket to
-// /api/console/{boxID}/ws (dashboard-side proxy to the agent).
+// Design notes
+// ============
+// Sessions are the unit of work — one PTY, one xterm, one WebSocket. The
+// manager owns the chrome (tabs, toolbar, layout) and routes input/output
+// to the active session. This is intentionally pluggable: a future Docker
+// "exec into container" gear will just hand the manager a different URL
+// descriptor; the rest of the UI is identical.
 //
-// Wire protocol — JSON frames, matched to the agent's protocol.go:
-//   {"t":"data","d":"<base64 stdin/stdout>"}
-//   {"t":"resize","cols":120,"rows":40}
-//   {"t":"signal","s":"INT"}        (rarely used — Ctrl-C is just bytes)
-//   {"t":"ping"} / {"t":"pong"}
-//   {"t":"exit","code":N,"reason":"…"}
-//   {"t":"err","msg":"…","reason":"AUTH_DENIED|…"}
+// A "descriptor" is a plain object describing how to open a session:
+//   { kind: 'box', boxID, label }
+//   { kind: 'container', boxID, containerID, label }  (future)
 //
-// Phase 1c: single drawer, one PTY at a time. Multi-pane is a Phase 2+
-// concern. The Esc key closes the drawer.
+// The URL builder lives in one place (urlForDescriptor / capsURLForDescriptor),
+// so adding new session kinds means adding one case to each builder.
+//
+// Layouts
+// -------
+// drawer: fullscreen overlay (the original behavior). Single visible chrome.
+// dock:   pinned to bottom of viewport, resizable via a drag handle on top,
+//         height persisted to localStorage. Main page content stays usable.
+// popout: handled by /console/popout/{boxID} — a separate window that hosts
+//         its own ConsoleManager in drawer mode. The popout button here just
+//         calls window.open() and lets the destination page take over.
+//
+// Tabs are visible in drawer and dock layouts; one session at a time is
+// "active" (focused, fitted, receiving keystrokes). Inactive sessions stay
+// connected in the background — their xterm just isn't visible. Closing a
+// tab destroys its session (PTY + WS).
+//
+// Preferences (localStorage, namespaced gearbox.console.*)
+// --------------------------------------------------------
+//   fontSize    integer 10..24, default 13
+//   dockHeight  integer px, default 320
+//   layout      'drawer'|'dock', default 'drawer' (popout is transient)
 
 (function () {
-	'use strict';
+    'use strict';
 
-	let term = null;       // xterm.Terminal instance
-	let fitAddon = null;   // xterm-addon-fit
-	let ws = null;         // active WebSocket
-	let currentBox = null; // {id, name} for status bar
-	let resizeObserver = null;
+    /* ============================================================== *
+     * Constants
+     * ============================================================== */
 
-	function $(id) { return document.getElementById(id); }
+    const PREF_PREFIX = 'gearbox.console.';
+    const FONT_MIN = 10;
+    const FONT_MAX = 24;
+    const FONT_DEFAULT = 13;
+    const DOCK_MIN = 160;
+    const DOCK_DEFAULT = 320;
 
-	function setStatus(text, tone) {
-		const el = $('console-drawer-status');
-		if (!el) return;
-		el.textContent = text;
-		el.classList.remove('bg-slate-700', 'bg-emerald-700', 'bg-red-700', 'bg-yellow-700');
-		const cls = {
-			connecting: 'bg-yellow-700',
-			connected: 'bg-emerald-700',
-			closed: 'bg-slate-700',
-			error: 'bg-red-700',
-		}[tone] || 'bg-slate-700';
-		el.classList.add(cls);
-	}
+    /* ============================================================== *
+     * Helpers
+     * ============================================================== */
 
-	function setMode(mode, uid) {
-		const m = $('console-drawer-mode');
-		const u = $('console-drawer-uid');
-		if (m) m.textContent = mode ? 'mode=' + mode : '';
-		if (u) u.textContent = (uid === undefined || uid === null) ? '' : 'uid=' + uid;
-	}
+    function clearChildren(node) {
+        while (node.firstChild) node.removeChild(node.firstChild);
+    }
 
-	// base64 encode/decode for binary-safe data frames. The dashboard
-	// pipes them through unchanged; the agent does the actual decode
-	// when writing to the PTY.
-	function b64encode(bytes) {
-		let bin = '';
-		for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-		return btoa(bin);
-	}
-	function b64decode(s) {
-		const bin = atob(s);
-		const out = new Uint8Array(bin.length);
-		for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-		return out;
-	}
+    function clampInt(n, lo, hi) {
+        n = parseInt(n, 10);
+        if (!isFinite(n)) n = lo;
+        return Math.max(lo, Math.min(hi, n));
+    }
 
-	function sendData(bytes) {
-		if (!ws || ws.readyState !== WebSocket.OPEN) return;
-		ws.send(JSON.stringify({ t: 'data', d: b64encode(bytes) }));
-	}
+    /* ============================================================== *
+     * Preferences (localStorage with safe fallback)
+     * ============================================================== */
 
-	function sendResize(cols, rows) {
-		if (!ws || ws.readyState !== WebSocket.OPEN) return;
-		ws.send(JSON.stringify({ t: 'resize', cols: cols, rows: rows }));
-	}
+    function prefGet(key, fallback) {
+        try {
+            const v = localStorage.getItem(PREF_PREFIX + key);
+            if (v == null) return fallback;
+            if (typeof fallback === 'number') {
+                const n = parseInt(v, 10);
+                return isFinite(n) ? n : fallback;
+            }
+            return v;
+        } catch (_) { return fallback; }
+    }
+    function prefSet(key, value) {
+        try { localStorage.setItem(PREF_PREFIX + key, String(value)); } catch (_) {}
+    }
 
-	function fitNow() {
-		if (!fitAddon) return;
-		try {
-			fitAddon.fit();
-			if (term) sendResize(term.cols, term.rows);
-		} catch (e) {
-			// xterm.fit can throw if the container has zero size during
-			// transitions — ignore and let the next frame retry.
-		}
-	}
+    /* ============================================================== *
+     * Descriptor URLs — single place to extend for new session kinds
+     * ============================================================== */
 
-	function ensureTerm() {
-		if (term) return;
-		if (typeof Terminal === 'undefined') {
-			console.error('[console] xterm.js not loaded');
-			return;
-		}
-		term = new Terminal({
-			cursorBlink: true,
-			fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
-			fontSize: 13,
-			theme: {
-				background: '#000000',
-				foreground: '#e5e7eb',
-				cursor: '#34d399',
-			},
-			scrollback: 5000,
-			allowProposedApi: true,
-		});
-		fitAddon = new FitAddon.FitAddon();
-		term.loadAddon(fitAddon);
-		term.open($('console-xterm'));
+    function wsURLForDescriptor(d) {
+        const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const host = window.location.host;
+        if (d.kind === 'box') {
+            return proto + '//' + host + '/api/console/' + encodeURIComponent(d.boxID) + '/ws';
+        }
+        throw new Error('unknown console descriptor kind: ' + d.kind);
+    }
 
-		// Browser → server: every keystroke is a data frame. xterm
-		// emits already-encoded VT sequences (arrow keys, Ctrl-C as
-		// 0x03, etc.), so we just byte-encode and ship.
-		term.onData(function (data) {
-			const enc = new TextEncoder();
-			sendData(enc.encode(data));
-		});
+    function capsURLForDescriptor(d) {
+        if (d.kind === 'box') {
+            return '/api/console/' + encodeURIComponent(d.boxID) + '/capabilities';
+        }
+        throw new Error('unknown console descriptor kind: ' + d.kind);
+    }
 
-		// Resize on container changes (drawer open, viewport resize).
-		resizeObserver = new ResizeObserver(function () {
-			fitNow();
-		});
-		resizeObserver.observe($('console-xterm'));
-	}
+    // Every session gets a unique numeric ID. We intentionally do NOT key
+    // by descriptor — opening the same box twice should produce two
+    // independent tabs (matches terminal-app convention; the user asked
+    // for this explicitly).
+    let _sessionCounter = 0;
+    function nextSessionID() { _sessionCounter += 1; return 's' + _sessionCounter; }
 
-	function openWS(boxID) {
-		const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-		const url = proto + '//' + window.location.host + '/api/console/' + encodeURIComponent(boxID) + '/ws';
-		ws = new WebSocket(url);
-		ws.binaryType = 'arraybuffer';
+    /* ============================================================== *
+     * Base64 helpers (binary-safe data frames)
+     * ============================================================== */
 
-		ws.onopen = function () {
-			setStatus('connected', 'connected');
-			// Fit on next frame so the container has its final size.
-			requestAnimationFrame(fitNow);
-		};
+    function b64encode(bytes) {
+        let bin = '';
+        for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+        return btoa(bin);
+    }
+    function b64decode(s) {
+        const bin = atob(s);
+        const out = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+        return out;
+    }
 
-		ws.onmessage = function (ev) {
-			let frame;
-			try {
-				frame = JSON.parse(ev.data);
-			} catch (e) {
-				return;
-			}
-			switch (frame.t) {
-				case 'data':
-					if (term && frame.d) {
-						const bytes = b64decode(frame.d);
-						const dec = new TextDecoder('utf-8', { fatal: false });
-						term.write(dec.decode(bytes));
-					}
-					break;
-				case 'exit':
-					setStatus('exited (' + (frame.code !== undefined ? frame.code : '?') + ')', 'closed');
-					break;
-				case 'err':
-					setStatus('error: ' + (frame.reason || frame.msg || 'unknown'), 'error');
-					if (term) {
-						term.write('\r\n\x1b[31m[console] ' + (frame.msg || frame.reason) + '\x1b[0m\r\n');
-					}
-					break;
-			}
-		};
+    /* ============================================================== *
+     * ConsoleSession — one PTY, one xterm, one WebSocket
+     * ============================================================== */
 
-		ws.onerror = function () {
-			setStatus('error', 'error');
-		};
+    function ConsoleSession(descriptor) {
+        this.id = nextSessionID();
+        this.descriptor = descriptor;
+        this.label = descriptor.label || descriptor.boxID || this.id;
+        this.status = 'idle';
+        this.mode = '';
+        this.uid = null;
+        this.errorMsg = '';
+        this.term = null;
+        this.fitAddon = null;
+        this.ws = null;
+        this.host = null;            // wrapper that gets attached/detached
+        this.onStatusChange = null;  // ConsoleManager wires this
+        this.fontSize = FONT_DEFAULT;
+    }
 
-		ws.onclose = function () {
-			setStatus('closed', 'closed');
-		};
-	}
+    ConsoleSession.prototype._setStatus = function (status) {
+        this.status = status;
+        if (typeof this.onStatusChange === 'function') {
+            try { this.onStatusChange(this); } catch (_) {}
+        }
+    };
 
-	function fetchCapsAndOpen(boxID) {
-		fetch('/api/console/' + encodeURIComponent(boxID) + '/capabilities', {
-			credentials: 'same-origin',
-		}).then(function (r) {
-			if (!r.ok) {
-				return r.json().then(function (j) {
-					throw new Error(j.reason || ('HTTP ' + r.status));
-				}, function () {
-					throw new Error('HTTP ' + r.status);
-				});
-			}
-			return r.json();
-		}).then(function (caps) {
-			if (!caps.enabled) {
-				setStatus('disabled on agent', 'error');
-				return;
-			}
-			setMode(caps.mode, caps.default_uid);
-			openWS(boxID);
-		}).catch(function (e) {
-			setStatus('error: ' + e.message, 'error');
-		});
-	}
+    ConsoleSession.prototype._ensureTerm = function () {
+        if (this.term) return;
+        if (typeof Terminal === 'undefined') {
+            console.error('[console] xterm.js not loaded');
+            return;
+        }
+        this.host = document.createElement('div');
+        this.host.className = 'console-session-host';
+        this.term = new Terminal({
+            cursorBlink: true,
+            fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+            fontSize: this.fontSize,
+            theme: { background: '#000000', foreground: '#e5e7eb', cursor: '#34d399' },
+            scrollback: 5000,
+            allowProposedApi: true,
+        });
+        this.fitAddon = new FitAddon.FitAddon();
+        this.term.loadAddon(this.fitAddon);
+        this.term.open(this.host);
 
-	window.openConsole = function (boxID, boxName) {
-		const drawer = $('console-drawer');
-		if (!drawer) {
-			console.error('[console] drawer markup missing — is ConsoleDrawer() in the layout?');
-			return;
-		}
-		currentBox = { id: boxID, name: boxName || boxID };
-		const boxEl = $('console-drawer-box');
-		if (boxEl) boxEl.textContent = currentBox.name;
-		setMode('', null);
-		setStatus('connecting…', 'connecting');
-		drawer.classList.remove('hidden');
-		drawer.classList.add('flex');
-		document.body.style.overflow = 'hidden';
-		ensureTerm();
-		fetchCapsAndOpen(boxID);
-		requestAnimationFrame(fitNow);
-		if (term) term.focus();
-	};
+        const self = this;
+        this.term.onData(function (data) {
+            const enc = new TextEncoder();
+            self._sendData(enc.encode(data));
+        });
+    };
 
-	window.closeConsole = function () {
-		if (ws) {
-			try { ws.close(1000, 'user closed'); } catch (e) {}
-			ws = null;
-		}
-		const drawer = $('console-drawer');
-		if (drawer) {
-			drawer.classList.add('hidden');
-			drawer.classList.remove('flex');
-		}
-		document.body.style.overflow = '';
-		currentBox = null;
-		setMode('', null);
-		setStatus('closed', 'closed');
-		// Note: we keep the xterm instance around for the next
-		// session so scrollback isn't lost during a quick reconnect.
-		if (term) term.reset();
-	};
+    ConsoleSession.prototype.attach = function (parent) {
+        this._ensureTerm();
+        if (!this.host) return;
+        if (this.host.parentNode !== parent) {
+            parent.appendChild(this.host);
+        }
+        this.host.style.display = '';
+        // Defer fit until the layout has applied size — fit on a zero-sized
+        // container silently sets cols=0.
+        requestAnimationFrame(this.fit.bind(this));
+    };
 
-	// Wire up the close button + Esc once DOM is ready.
-	document.addEventListener('DOMContentLoaded', function () {
-		const btn = $('console-drawer-close');
-		if (btn) btn.addEventListener('click', window.closeConsole);
-		document.addEventListener('keydown', function (e) {
-			if (e.key === 'Escape') {
-				const drawer = $('console-drawer');
-				if (drawer && !drawer.classList.contains('hidden')) {
-					window.closeConsole();
-				}
-			}
-		});
-	});
+    ConsoleSession.prototype.detach = function () {
+        if (this.host) this.host.style.display = 'none';
+    };
+
+    ConsoleSession.prototype.focus = function () {
+        if (this.term) this.term.focus();
+    };
+
+    ConsoleSession.prototype.fit = function () {
+        if (!this.fitAddon) return;
+        try {
+            this.fitAddon.fit();
+            if (this.term && this.ws && this.ws.readyState === WebSocket.OPEN) {
+                this._sendResize(this.term.cols, this.term.rows);
+            }
+        } catch (_) { /* zero-size container during transitions */ }
+    };
+
+    ConsoleSession.prototype.setFontSize = function (size) {
+        this.fontSize = size;
+        if (this.term) {
+            this.term.options.fontSize = size;
+            this.fit();
+        }
+    };
+
+    ConsoleSession.prototype.clear = function () {
+        if (this.term) this.term.clear();
+    };
+
+    ConsoleSession.prototype._sendData = function (bytes) {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        this.ws.send(JSON.stringify({ t: 'data', d: b64encode(bytes) }));
+    };
+
+    ConsoleSession.prototype._sendResize = function (cols, rows) {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        this.ws.send(JSON.stringify({ t: 'resize', cols: cols, rows: rows }));
+    };
+
+    ConsoleSession.prototype.connect = function () {
+        this._ensureTerm();
+        if (this.ws) { try { this.ws.close(); } catch (_) {} }
+        this._setStatus('connecting');
+        const self = this;
+        fetch(capsURLForDescriptor(this.descriptor), { credentials: 'same-origin' })
+            .then(function (r) {
+                if (!r.ok) {
+                    return r.json().then(function (j) { throw new Error(j.reason || ('HTTP ' + r.status)); },
+                                         function ()  { throw new Error('HTTP ' + r.status); });
+                }
+                return r.json();
+            })
+            .then(function (caps) {
+                if (!caps.enabled) {
+                    self.mode = '';
+                    self.uid = null;
+                    self.errorMsg = 'disabled on agent';
+                    self._setStatus('error');
+                    return;
+                }
+                self.mode = caps.mode || '';
+                self.uid = (caps.default_uid === undefined ? null : caps.default_uid);
+                self._openWS();
+            })
+            .catch(function (e) {
+                self.errorMsg = e.message;
+                self._setStatus('error');
+            });
+    };
+
+    ConsoleSession.prototype._openWS = function () {
+        const self = this;
+        const ws = new WebSocket(wsURLForDescriptor(this.descriptor));
+        ws.binaryType = 'arraybuffer';
+        this.ws = ws;
+
+        ws.onopen = function () {
+            self._setStatus('connected');
+            requestAnimationFrame(self.fit.bind(self));
+        };
+        ws.onmessage = function (ev) {
+            let frame;
+            try { frame = JSON.parse(ev.data); } catch (e) { return; }
+            switch (frame.t) {
+                case 'data':
+                    if (self.term && frame.d) {
+                        const bytes = b64decode(frame.d);
+                        const dec = new TextDecoder('utf-8', { fatal: false });
+                        self.term.write(dec.decode(bytes));
+                    }
+                    break;
+                case 'exit':
+                    self.errorMsg = 'exited (' + (frame.code !== undefined ? frame.code : '?') + ')';
+                    self._setStatus('closed');
+                    break;
+                case 'err':
+                    self.errorMsg = frame.reason || frame.msg || 'unknown';
+                    self._setStatus('error');
+                    if (self.term) {
+                        self.term.write('\r\n\x1b[31m[console] ' + (frame.msg || frame.reason) + '\x1b[0m\r\n');
+                    }
+                    break;
+            }
+        };
+        ws.onerror = function () {
+            self.errorMsg = 'socket error';
+            self._setStatus('error');
+        };
+        ws.onclose = function () {
+            if (self.status !== 'error' && self.status !== 'closed') {
+                self._setStatus('closed');
+            }
+        };
+    };
+
+    ConsoleSession.prototype.destroy = function () {
+        if (this.ws) { try { this.ws.close(1000, 'user closed'); } catch (_) {} }
+        this.ws = null;
+        if (this.term) { try { this.term.dispose(); } catch (_) {} }
+        this.term = null;
+        this.fitAddon = null;
+        if (this.host && this.host.parentNode) this.host.parentNode.removeChild(this.host);
+        this.host = null;
+        this._setStatus('closed');
+    };
+
+    /* ============================================================== *
+     * ConsoleManager — owns chrome, sessions, layout, prefs
+     * ============================================================== */
+
+    function ConsoleManager() {
+        this.sessions = [];          // ordered list
+        this.activeID = null;
+        this.layout = prefGet('layout', 'drawer');
+        if (this.layout !== 'drawer' && this.layout !== 'dock') this.layout = 'drawer';
+        this.fontSize = clampInt(prefGet('fontSize', FONT_DEFAULT), FONT_MIN, FONT_MAX);
+        this.dockHeight = clampInt(prefGet('dockHeight', DOCK_DEFAULT), DOCK_MIN, 2000);
+        this.popoutMode = false;     // set true by the popout page
+        this._wired = false;
+    }
+
+    ConsoleManager.prototype._$ = function (id) { return document.getElementById(id); };
+
+    ConsoleManager.prototype._wire = function () {
+        if (this._wired) return;
+        const drawer = this._$('console-drawer');
+        if (!drawer) return; // markup not on this page
+
+        const close = this._$('console-drawer-close');
+        if (close) close.addEventListener('click', this.close.bind(this));
+
+        const layoutDrawerBtn = this._$('console-btn-layout-drawer');
+        const layoutDockBtn = this._$('console-btn-layout-dock');
+        const layoutPopoutBtn = this._$('console-btn-layout-popout');
+        const clearBtn = this._$('console-btn-clear');
+        const newTabBtn = this._$('console-btn-newtab');
+        const slider = this._$('console-font-slider');
+        const sliderVal = this._$('console-font-value');
+
+        if (layoutDrawerBtn) layoutDrawerBtn.addEventListener('click', this.setLayout.bind(this, 'drawer'));
+        if (layoutDockBtn) layoutDockBtn.addEventListener('click', this.setLayout.bind(this, 'dock'));
+        if (layoutPopoutBtn) layoutPopoutBtn.addEventListener('click', this._popoutActive.bind(this));
+        if (clearBtn) clearBtn.addEventListener('click', this._clearActive.bind(this));
+        if (newTabBtn) newTabBtn.addEventListener('click', this._newTabActive.bind(this));
+
+        if (slider) {
+            slider.min = String(FONT_MIN);
+            slider.max = String(FONT_MAX);
+            slider.value = String(this.fontSize);
+            if (sliderVal) sliderVal.textContent = this.fontSize + 'px';
+            slider.addEventListener('input', this._onFontSlider.bind(this));
+        }
+
+        const self = this;
+        document.addEventListener('keydown', function (e) {
+            if (e.key !== 'Escape') return;
+            if (drawer.classList.contains('hidden')) return;
+            // In a popout window Esc would just empty the page — let the
+            // user close the window with the OS shortcut instead.
+            if (self.popoutMode) return;
+            if (self.layout === 'dock' && self.sessions.length > 1) {
+                self.closeSession(self.activeID);
+            } else {
+                self.close();
+            }
+        });
+
+        window.addEventListener('resize', function () {
+            const s = self._active();
+            if (s) s.fit();
+        });
+
+        this._wireDockResize();
+        this._wired = true;
+    };
+
+    ConsoleManager.prototype._wireDockResize = function () {
+        const handle = this._$('console-dock-handle');
+        if (!handle) return;
+        const self = this;
+        let dragging = false;
+        let startY = 0;
+        let startH = 0;
+
+        handle.addEventListener('mousedown', function (e) {
+            dragging = true;
+            startY = e.clientY;
+            startH = self.dockHeight;
+            document.body.style.cursor = 'row-resize';
+            document.body.style.userSelect = 'none';
+            e.preventDefault();
+        });
+        window.addEventListener('mousemove', function (e) {
+            if (!dragging) return;
+            const dy = startY - e.clientY;
+            self.dockHeight = clampInt(startH + dy, DOCK_MIN, window.innerHeight - 100);
+            self._applyDockHeight();
+        });
+        window.addEventListener('mouseup', function () {
+            if (!dragging) return;
+            dragging = false;
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+            prefSet('dockHeight', self.dockHeight);
+            const s = self._active();
+            if (s) s.fit();
+        });
+    };
+
+    ConsoleManager.prototype._applyDockHeight = function () {
+        const drawer = this._$('console-drawer');
+        if (!drawer) return;
+        if (this.layout === 'dock') {
+            drawer.style.height = this.dockHeight + 'px';
+            // Keep body padding-bottom in sync so main page content
+            // isn't hidden under the dock when its height changes.
+            document.documentElement.style.setProperty('--gearbox-console-dock-h', this.dockHeight + 'px');
+        } else {
+            drawer.style.height = '';
+        }
+    };
+
+    ConsoleManager.prototype._active = function () {
+        if (!this.activeID) return null;
+        for (let i = 0; i < this.sessions.length; i++) {
+            if (this.sessions[i].id === this.activeID) return this.sessions[i];
+        }
+        return null;
+    };
+
+    ConsoleManager.prototype._onFontSlider = function (e) {
+        const v = clampInt(e.target.value, FONT_MIN, FONT_MAX);
+        this.fontSize = v;
+        prefSet('fontSize', v);
+        const valEl = this._$('console-font-value');
+        if (valEl) valEl.textContent = v + 'px';
+        for (let i = 0; i < this.sessions.length; i++) {
+            this.sessions[i].setFontSize(v);
+        }
+    };
+
+    /* ---------------- session lifecycle ---------------- */
+
+    ConsoleManager.prototype.open = function (descriptor) {
+        this._wire();
+        const drawer = this._$('console-drawer');
+        if (!drawer) {
+            console.error('[console] drawer markup missing');
+            return null;
+        }
+        // Always create a new session, even if one already targets the
+        // same box — terminal-app convention is "another click = another
+        // tab." Tab labels disambiguate duplicates with a #N suffix.
+        const sess = new ConsoleSession(descriptor);
+        sess.fontSize = this.fontSize;
+        sess.onStatusChange = this._renderStatus.bind(this);
+        this.sessions.push(sess);
+        this._setActive(sess.id);
+        this._show();
+        sess.connect();
+        return sess;
+    };
+
+    ConsoleManager.prototype.closeSession = function (id) {
+        const idx = this._indexByID(id);
+        if (idx < 0) return;
+        const sess = this.sessions[idx];
+        sess.destroy();
+        this.sessions.splice(idx, 1);
+        if (this.activeID === id) {
+            const next = this.sessions[idx] || this.sessions[idx - 1] || null;
+            this.activeID = next ? next.id : null;
+            if (!next) {
+                this.close();
+                return;
+            }
+        }
+        this._renderChrome();
+        const active = this._active();
+        if (active) active.attach(this._$('console-xterm'));
+    };
+
+    ConsoleManager.prototype.close = function () {
+        while (this.sessions.length) this.sessions.pop().destroy();
+        this.activeID = null;
+        const drawer = this._$('console-drawer');
+        if (drawer) {
+            drawer.classList.add('hidden');
+            drawer.classList.remove('flex');
+            drawer.classList.remove('console-layout-dock');
+            drawer.classList.remove('console-layout-drawer');
+            drawer.style.height = '';
+        }
+        document.body.style.overflow = '';
+        document.body.classList.remove('console-dock-open');
+    };
+
+    /* ---------------- visibility / layout ---------------- */
+
+    ConsoleManager.prototype._show = function () {
+        const drawer = this._$('console-drawer');
+        if (!drawer) return;
+        drawer.classList.remove('hidden');
+        drawer.classList.add('flex');
+        this._applyLayout();
+        this._renderChrome();
+        const active = this._active();
+        if (active) {
+            active.attach(this._$('console-xterm'));
+            active.focus();
+        }
+    };
+
+    ConsoleManager.prototype.setLayout = function (mode) {
+        if (mode !== 'drawer' && mode !== 'dock') return;
+        this.layout = mode;
+        prefSet('layout', mode);
+        this._applyLayout();
+        const s = this._active();
+        if (s) requestAnimationFrame(s.fit.bind(s));
+    };
+
+    ConsoleManager.prototype._applyLayout = function () {
+        const drawer = this._$('console-drawer');
+        if (!drawer) return;
+        drawer.classList.remove('console-layout-drawer', 'console-layout-dock');
+        drawer.classList.add('console-layout-' + this.layout);
+
+        if (this.layout === 'drawer') {
+            document.body.style.overflow = 'hidden';
+            document.body.classList.remove('console-dock-open');
+            drawer.style.height = '';
+        } else if (this.layout === 'dock') {
+            document.body.style.overflow = '';
+            document.body.classList.add('console-dock-open');
+            this._applyDockHeight();
+        }
+
+        // Drawer and dock buttons are mutually exclusive — only the
+        // button representing the *other* layout is visible, so clicking
+        // it visibly toggles state. The popout button stays visible.
+        const drawerBtn = this._$('console-btn-layout-drawer');
+        const dockBtn = this._$('console-btn-layout-dock');
+        if (drawerBtn) drawerBtn.classList.toggle('hidden', this.layout === 'drawer');
+        if (dockBtn) dockBtn.classList.toggle('hidden', this.layout === 'dock');
+    };
+
+    ConsoleManager.prototype._popoutActive = function () {
+        const s = this._active();
+        if (!s) return;
+        if (s.descriptor.kind !== 'box') return;
+        const url = '/console/popout/' + encodeURIComponent(s.descriptor.boxID);
+        window.open(url, '_blank', 'popup=yes,noopener=yes,width=1100,height=700');
+    };
+
+    ConsoleManager.prototype._clearActive = function () {
+        const s = this._active();
+        if (s) { s.clear(); s.focus(); }
+    };
+
+    // Click handler for a per-tab status dot. Reconnects when the
+    // session is in a terminal non-connected state (closed / error).
+    // Other states (connected / connecting / idle) ignore the click —
+    // we don't want to rip a live shell or stack a second connect on
+    // top of one already in flight. Also makes the clicked tab active
+    // so the reconnect happens where the user can see it.
+    ConsoleManager.prototype._tabDotClick = function (sessionID) {
+        const idx = this._indexByID(sessionID);
+        if (idx < 0) return;
+        const s = this.sessions[idx];
+        if (s.status !== 'closed' && s.status !== 'error') return;
+        this._setActive(sessionID);
+        s.connect();
+        s.focus();
+    };
+
+    // Spawn a new session against the same descriptor as the active tab.
+    // Bound to the "+" button in the toolbar; pairs with the bx-grid
+    // behavior where each shell-icon click opens an additional tab.
+    ConsoleManager.prototype._newTabActive = function () {
+        const s = this._active();
+        if (!s) return;
+        // Reuse the descriptor verbatim — the label stays the box name and
+        // _renderTabs disambiguates duplicates with a #N suffix.
+        this.open(s.descriptor);
+    };
+
+    /* ---------------- session lookup ---------------- */
+
+    ConsoleManager.prototype._indexByID = function (id) {
+        for (let i = 0; i < this.sessions.length; i++) {
+            if (this.sessions[i].id === id) return i;
+        }
+        return -1;
+    };
+
+    ConsoleManager.prototype._setActive = function (id) {
+        for (let i = 0; i < this.sessions.length; i++) {
+            if (this.sessions[i].id !== id) this.sessions[i].detach();
+        }
+        this.activeID = id;
+        const xtermHost = this._$('console-xterm');
+        const active = this._active();
+        if (active && xtermHost) {
+            active.attach(xtermHost);
+            active.focus();
+        }
+        this._renderChrome();
+    };
+
+    /* ---------------- chrome (tabs + status + toolbar) ---------------- */
+
+    ConsoleManager.prototype._renderChrome = function () {
+        this._renderTabs();
+        this._renderStatus();
+    };
+
+    ConsoleManager.prototype._renderTabs = function () {
+        const strip = this._$('console-tabs');
+        const bar = this._$('console-tab-bar');
+        if (!strip || !bar) return;
+        if (this.sessions.length === 0) {
+            bar.classList.add('hidden');
+            clearChildren(strip);
+            return;
+        }
+        bar.classList.remove('hidden');
+        clearChildren(strip);
+
+        // Disambiguate duplicate labels with a "#N" suffix. We only
+        // suffix when there's actually a conflict — a single "Light
+        // Hugger" stays "Light Hugger"; two of them become "Light
+        // Hugger #1" and "Light Hugger #2". Counts reset on every
+        // render so closing a duplicate cleans up the survivor.
+        const labelCounts = {};
+        this.sessions.forEach(function (s) {
+            labelCounts[s.label] = (labelCounts[s.label] || 0) + 1;
+        });
+        const labelIdx = {};
+
+        const self = this;
+        this.sessions.forEach(function (s) {
+            labelIdx[s.label] = (labelIdx[s.label] || 0) + 1;
+            const display = labelCounts[s.label] > 1
+                ? s.label + ' #' + labelIdx[s.label]
+                : s.label;
+
+            const tab = document.createElement('div');
+            tab.className = 'console-tab' + (s.id === self.activeID ? ' active' : '');
+            tab.setAttribute('role', 'tab');
+            tab.setAttribute('aria-selected', s.id === self.activeID ? 'true' : 'false');
+
+            // Per-tab status dot. Doubles as a reconnect button when the
+            // session is closed/errored — clicking switches active to
+            // this tab and kicks off a reconnect. Connected / connecting
+            // / idle dots are inert.
+            const dot = document.createElement('button');
+            dot.type = 'button';
+            dot.className = 'console-tab-dot is-' + s.status;
+            const isReconnectable = s.status === 'closed' || s.status === 'error';
+            if (isReconnectable) {
+                dot.classList.add('is-clickable');
+                dot.title = (s.status === 'error'
+                    ? 'Error: ' + (s.errorMsg || 'unknown')
+                    : 'Closed') + ' — click to reconnect';
+            } else {
+                dot.title = ({
+                    connected: 'Connected',
+                    connecting: 'Connecting…',
+                    idle: '',
+                })[s.status] || s.status;
+            }
+            dot.addEventListener('click', function (e) {
+                e.stopPropagation();
+                if (isReconnectable) self._tabDotClick(s.id);
+            });
+
+            const label = document.createElement('button');
+            label.type = 'button';
+            label.className = 'console-tab-label';
+            label.textContent = display;
+            label.title = display + ' (' + s.status + ')';
+            label.addEventListener('click', function () { self._setActive(s.id); });
+
+            const close = document.createElement('button');
+            close.type = 'button';
+            close.className = 'console-tab-close';
+            close.setAttribute('aria-label', 'Close ' + display);
+            close.title = 'Close tab';
+            close.textContent = '×';
+            close.addEventListener('click', function (e) {
+                e.stopPropagation();
+                self.closeSession(s.id);
+            });
+
+            tab.appendChild(dot);
+            tab.appendChild(label);
+            tab.appendChild(close);
+            strip.appendChild(tab);
+        });
+    };
+
+    // Header has no connection state to render anymore — the per-tab
+    // dots own that. We still re-render the tab strip on every status
+    // change so the dot colors and tooltips stay accurate.
+    ConsoleManager.prototype._renderStatus = function () {
+        this._renderTabs();
+    };
+
+    /* ============================================================== *
+     * Wire-up and public API
+     * ============================================================== */
+
+    const manager = new ConsoleManager();
+
+    window.openConsole = function (boxID, boxName) {
+        manager.open({ kind: 'box', boxID: boxID, label: boxName || boxID });
+    };
+    window.closeConsole = function () { manager.close(); };
+
+    window.gearbox = window.gearbox || {};
+    window.gearbox.console = {
+        open: function (d) { return manager.open(d); },
+        openBox: function (boxID, label) {
+            return manager.open({ kind: 'box', boxID: boxID, label: label || boxID });
+        },
+        close: function () { manager.close(); },
+        closeSession: function (id) { manager.closeSession(id); },
+        setLayout: function (mode) { manager.setLayout(mode); },
+        manager: manager,
+    };
+
+    window.gearbox.console.markPopout = function () {
+        manager.popoutMode = true;
+        manager.layout = 'drawer';
+        // Tag the drawer so CSS can drop the header + tab bar — in a
+        // popout window the chrome is wasted vertical space, none of
+        // the layout/popout buttons make sense (we're already popped
+        // out), and Cmd-W/closing the tab is the natural way to exit.
+        const drawer = document.getElementById('console-drawer');
+        if (drawer) drawer.classList.add('console-popout');
+    };
 })();


### PR DESCRIPTION
## Summary

Closes #140.

Started as the bug fixes from #140 (404 on shell icon, drop-to-Home navigation, Tools-column placement). User asked to bundle scope-creep QoL work in the same PR — multi-session/tabs/dock/popout/font-slider — since they prefer one big diff over many small ones. Result: full console-manager rewrite layered on top of the original fixes.

### Bug fixes (original #140 scope)

- `d.id` → `d.box_id` at three call sites in `static/js/bx/bx-page.js` (cellClick, palette command id, palette run). `BoxRow.JSONfield` is `box_id`, not `id` — old code sent `/api/console/undefined/capabilities` → 404.
- Guard `grid.on('rowClick', …)` against clicks originating in the Tools column. Tabulator fires `rowClick` from its own event delegation independent of DOM bubbling, so `e.stopPropagation()` inside `cellClick` was not enough.
- Move shell icon out from between Name / Location into a right-anchored **Tools** column. Originally `frozen: true`; switched to unfrozen after the user pointed out the Tabulator divider was ugly.

### Reusable console plumbing

`static/js/console/console.js` rewritten as a `ConsoleSession` (one PTY + xterm + WS) plus a `ConsoleManager` (chrome / tabs / layout / prefs). Sessions take a *descriptor*: `{ kind, boxID, … }`. Adding container-exec for the future Docker gear means a new `kind: 'container'` case in `wsURLForDescriptor` + `capsURLForDescriptor` — the chrome and tabs come along for free.

### Layouts

- **drawer** — fullscreen overlay (the original behavior).
- **dock** — pinned bottom strip, drag-resizable, height persisted to `localStorage["gearbox.console.dockHeight"]`. Pure-CSS sibling selector keeps the dock anchored to the right of the sidebar (`#main-content.ml-16 ~ #console-drawer.console-layout-dock { left: 4rem }`), with a `transition: left 0.3s` to track the sidebar's own collapse animation.
- **popout** — `window.open('/console/popout/{boxID}', '_blank', 'popup=yes …')` opens a chromeless window driven by `pages.ConsolePopoutPage`. Authentication + per-box opt-in gating match `APIConsoleCapabilities`. In popout mode all chrome is hidden (`.console-popout .console-header`, `.console-tab-bar`, `.console-dock-handle { display: none }`) so the terminal fills the window.

Drawer ↔ dock are mutually exclusive — only the inactive layout's button is visible in the toolbar. Popout button stays put.

### Tabs

- Tab strip + per-tab close button, visible from the first session so the **+ new tab** affordance is always discoverable.
- Every click of the bx-grid shell icon spawns a new tab (no de-duping). The **+** button reuses the active tab's descriptor — "another shell into the same box."
- Duplicate labels get a `#N` suffix at render time; closing one of two clones renames the survivor back.
- Per-tab status dot (left of the label) doubles as the reconnect button: green = connected (inert), yellow = connecting, red = error (clickable → reconnect), gray = closed/idle. Connected dots are inert to avoid an accidental session rip.

### Header + toolbar

- "Console: \<box\>" prefix + box-name span + status/mode/uid pills all removed — the box name lives in the tab, the dot carries connection state, `uid` is recoverable with `whoami`, `mode` is a single value today (revisit if we add an SSH-bridge mode).
- Toolbar: font-slider (10–24 px, persisted to `localStorage`, matches logs-viewer pattern), Clear, layout-switch (drawer-or-dock, mutually exclusive), popout, close.
- Header padding tightened (`py-2` → `py-1`), dock resize handle dropped from 6px → 5px.

### Preferences

All under `gearbox.console.*`:

- `fontSize` (int 10..24, default 13) — applied to all sessions immediately
- `dockHeight` (int px, default 320, min 160)
- `layout` ("drawer" | "dock", default "drawer") — popout is transient, never persisted

### Files

```text
gearbox/cmd/server/main.go                                           +5      route /console/popout/{boxID}
gearbox/internal/framework/handler/console_popout.go                 +46     NEW — popout page handler
gearbox/internal/framework/templates/components/console.templ        ~151    drawer chrome rewritten
gearbox/internal/framework/templates/pages/console_popout.templ      +69     NEW — chromeless popout page
gearbox/static/css/components/console.css                            +253    NEW — layouts, tabs, dot, handle
gearbox/static/js/bx/bx-page.js                                      ~59     bug fixes + Tools column
gearbox/static/js/console/console.js                                 ~1001   ConsoleSession + ConsoleManager
```

## Test plan

- [ ] Shell icon on the bx grid opens a console for the targeted box (no 404, no nav to Home).
- [ ] Tools column on the right of the grid, no divider between Last checked and Tools.
- [ ] Clicking the shell icon twice opens two tabs against the same box, labelled `Light Hugger #1` / `#2`.
- [ ] Closing one duplicate tab renames the survivor back to `Light Hugger`.
- [ ] Closing the only tab closes the panel.
- [ ] Per-tab dot is green when connected, red on error, clickable to reconnect when closed/errored.
- [ ] Font slider changes the size live, persists across reload, applies to all sessions in the panel.
- [ ] Drawer ↔ dock toggle: clicking the visible layout button swaps modes; only one layout button is visible at a time.
- [ ] In dock mode, the panel sits to the right of the sidebar (does NOT cover it), drag handle resizes, the height survives a reload.
- [ ] Collapsing the sidebar slides the dock left to meet it (transition synced).
- [ ] Popout button opens a new chromeless window with no header / tabs / toolbar — just the terminal.
- [ ] `Cmd-W` closes the popout window cleanly.
- [ ] `Esc` closes the in-page console (or just the active tab in dock mode with ≥ 2 sessions); Esc is a no-op inside a popout window.
- [ ] Permissions still gated: a user without `box_console:view` gets 403 on `/console/popout/{boxID}`.
- [ ] A box with `console_enabled: false` returns 404 on `/console/popout/{boxID}` and the bx grid does not show the shell icon for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)